### PR TITLE
Remove dangling rhel-8-fast-datapath-beta-rpms

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -244,17 +244,6 @@ repos:
       optional: true
     reposync:
       enabled: false
-  rhel-8-fast-datapath-beta-rpms:
-    conf:
-      baseurl:
-        ppc64le: http://download-node-02.eng.bos.redhat.com/brewroot/repos/fast-datapath-rhel-8-build/latest/ppc64le
-        s390x: http://download-node-02.eng.bos.redhat.com/brewroot/repos/fast-datapath-rhel-8-build/latest/s390x
-        x86_64: http://download-node-02.eng.bos.redhat.com/brewroot/repos/fast-datapath-rhel-8-build/latest/x86_64
-    content_set:
-      default: rhel-8-for-x86_64-fast-datapath-beta-rpms
-      ppc64le: rhel-8-for-ppc64le-fast-datapath-beta-rpms
-      s390x: rhel-8-for-s390x-fast-datapath-beta-rpms
-      optional: true
   openstack-16-for-rhel-8-rpms:
     conf:
       baseurl:


### PR DESCRIPTION
After https://github.com/openshift/ocp-build-data/pull/508, there is no consumer of this repository. Removing.