### PR TITLE
Disable disappeared jenkins images

### DIFF
--- a/images/jenkins-slave-maven-rhel7.yml
+++ b/images/jenkins-slave-maven-rhel7.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - x86_64
 content:

--- a/images/jenkins-slave-nodejs-rhel7.yml
+++ b/images/jenkins-slave-nodejs-rhel7.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - x86_64
 content:


### PR DESCRIPTION
The paths `slave-maven` and `slave-nodejs` have disappeared from the upstream branch. Reflecting that change in the build definition.