### PR TITLE
images: Use the 2.9 Ansible rpms for metering.

### DIFF
--- a/images/ose-metering-ansible-operator.yml
+++ b/images/ose-metering-ansible-operator.yml
@@ -13,7 +13,7 @@ enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
 - rhel-server-ose-rpms
-- rhel-7-server-ansible-2.8-rpms
+- rhel-7-server-ansible-2.9-rpms
 from:
   builder:
   - member: ose-metering-helm


### PR DESCRIPTION
We use the ansible-operator as a base image for the metering-ansible-operator, which uses the 2.9 rpms: https://github.com/openshift/ocp-build-data/blob/openshift-4.6/images/openshift-enterprise-ansible-operator.yml#L17