### PR TITLE
Build ose-powervs-machine-controllers only on ppc64le

### DIFF
--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -1,3 +1,5 @@
+arches:
+- ppc64le
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
This container is relevant only to a ppc64le-specific cloud.

/cc @thiagoallesio
