### PR TITLE
Disable images

### DIFF
--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: build/Dockerfile.openshift


### PR DESCRIPTION
Two 4.12 branches turn out to not be created. Reopened
https://issues.redhat.com/browse/CLOUDBLD-10175. Disabling these
non-payload images for now.