### PR TITLE
[4.12] use mainline RHEL repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -299,10 +299,11 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/baseos/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/baseos/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/baseos/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/baseos/os/
+        # NOTE: re-peg to 9.0 when 9.1 GA is pending
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el9
@@ -319,10 +320,11 @@ repos:
   rhel-9-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/appstream/os/
+        # NOTE: re-peg to 9.0 when 9.1 GA is pending
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el9


### PR DESCRIPTION
Per [slack](https://coreos.slack.com/archives/CB95J6R4N/p1657130672594489?thread_ts=1657006519.906429&cid=CB95J6R4N) and [Jira](https://issues.redhat.com/browse/RHELDST-6698?focusedCommentId=18475590&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18475590) rhsm-pulp does not reliably keep minor z-stream repos updated until the next minor RHEL version releases and the z-stream becomes associated with the minor. So use the major release repos until then.

Did not see a reason to change the content sets.
