### PR TITLE
Fix owners for ironic-agent 4.12

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -14,14 +14,7 @@ from:
   member: openshift-base-rhel9
 name: openshift/ose-ironic-agent
 owners:
-- kni-devel@redhat.com
-- dtantsur@redhat.com
-- bfournie@redhat.com
-- rpittau@redhat.com
-- derekh@redhat.com
-- rbryant@redhat.com
-- dhellmann@redhat.com
-- shardy@redhat.com
+- ironic-osp-owners@redhat.com
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms


### PR DESCRIPTION
This commit fix the owners listed in the 4.12 config