### PR TITLE
[ART-6233] group.yml: update RHCOS stream and tags

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -48,14 +48,16 @@ rhcos:
     - name: machine-os-content
       build_metadata_key: oscontainer
       primary: true
-    - name: rhel-coreos-8
+    - name: rhel-coreos
       build_metadata_key: base-oscontainer
-    - name: rhel-coreos-8-extensions
+    - name: rhel-coreos-extensions
       build_metadata_key: extensions-container
   require_consistency:
     driver-toolkit:
     - kernel
     - kernel-rt
+  # allow CentOS content, can remove once RHCOS is using 9.2 beta content.
+  allow_missing_brew_rpms: true
 
 default_image_build_profile: unsigned
 default_rpm_build_profile: default
@@ -68,7 +70,7 @@ urls:
   brew_image_namespace: rh-osbs
   cgit: https://pkgs.devel.redhat.com/cgit
   rhcos_release_base:
-    multi: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/{MAJOR}.{MINOR}/builds
+    multi: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/{MAJOR}.{MINOR}-9.2/builds
 dist_git_ignore:
   - gating.yaml
 


### PR DESCRIPTION
/hold
until MCO is ready for the change and [ART-6053](https://issues.redhat.com//browse/ART-6053) is complete (https://github.com/openshift/doozer/pull/738).
along with this, revert the pin in https://github.com/openshift/ocp-build-data/pull/2618 (or similar)

if prior to branch-cut, cherry-pick this to 4.14 as well.