### PR TITLE
Fix jira components for images

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -26,9 +26,9 @@ bug_mapping:
     atomic-openshift-service-idler:
       issue_component: Networking / openshift-sdn
     bare-metal-event-relay-operator-bundle-container:
-      issue_component: Cloud Native Events / Hardware Event Proxy Operator
+      issue_component: Cloud Native Events / Hardware Event Proxy
     bare-metal-event-relay-operator-container:
-      issue_component: Cloud Native Events / Hardware Event Proxy Operator
+      issue_component: Cloud Native Events / Hardware Event Proxy
     baremetal-hardware-event-proxy-container:
       issue_component: Cloud Native Events / Hardware Event Proxy
     baremetal-machine-controller-container:
@@ -66,7 +66,7 @@ bug_mapping:
     cluster-version-operator-container:
       issue_component: Cluster Version Operator
     cnf-tests-container:
-      issue_component: Networking
+      issue_component: Cloud Native Events / Cloud Native Events
     compliance-content-container:
       issue_component: Compliance Operator
     configmap-reload-container:
@@ -114,7 +114,7 @@ bug_mapping:
     elasticsearch-operator-metadata-container:
       issue_component: Logging
     federation-v2-container:
-      issue_component: Federation
+      issue_component: Federation # FIXME
     ghostunnel-container:
       issue_component: Metering Operator
     golang-github-openshift-oauth-proxy-container:
@@ -184,7 +184,7 @@ bug_mapping:
     kube-state-metrics-container:
       issue_component: Monitoring
     kubefed-container:
-      issue_component: Federation
+      issue_component: Federation # FIXME
     kuryr-cni-container:
       issue_component: Networking / kuryr
     kuryr-controller-container:
@@ -236,17 +236,17 @@ bug_mapping:
     node-feature-discovery-container:
       issue_component: Node Feature Discovery Operator
     node-problem-detector-operator-container:
-      issue_component: Node
+      issue_component: Node / Node Problem Detector
     noderesourcetopology-scheduler-container:
-      issue_component: Node Resource Topology aware Scheduler
+      issue_component: Node / Numa aware Scheduling
     numaresources-operator-bundle-container:
-      issue_component: NUMA Resources Operator
+      issue_component: Node / Numa aware Scheduling
     numaresources-operator-container:
-      issue_component: NUMA Resources Operator
+      issue_component: Node / Numa aware Scheduling
     oauth-server-container:
       issue_component: apiserver-auth
     oc-compliance-container:
-      issue_component: OC Compliance
+      issue_component: oc-compliance
     oc-mirror-plugin-container:
       issue_component: oc / oc-mirror
     oniguruma:
@@ -520,7 +520,7 @@ bug_mapping:
     ose-file-integrity-operator-container:
       issue_component: File Integrity Operator
     ose-frr-container:
-      issue_component: Networking / frr
+      issue_component: Networking / Metal LB
     ose-gcp-cloud-controller-manager-container:
       issue_component: Cloud Compute / Cloud Controller Manager
     ose-gcp-filestore-csi-driver-container:
@@ -790,9 +790,9 @@ bug_mapping:
     tuned-container:
       issue_component: Node Tuning Operator
     vertical-pod-autoscaler-container:
-      issue_component: Node
+      issue_component: Node / Autoscaler (HPA, VPA)
     vertical-pod-autoscaler-operator-container:
-      issue_component: Node
+      issue_component: Node / Autoscaler (HPA, VPA)
     vmware-vsphere-syncer-container:
       issue_component: Storage / Kubernetes External Components
     windows-machine-config-operator-container:


### PR DESCRIPTION
This commit fixes the declared components of images.

Images that get built by ART got a fix for the declared components. Externally built images were dropped.

The following script was used to find jira components that do not exist:

```python

import os
from requests import get
import sys
import ruamel.yaml as yaml
from jira import JIRA

url = 'https://raw.githubusercontent.com/openshift/ocp-build-data/main/product.yml'

product = yaml.safe_load(get(url).text)

images = product['bug_mapping']['components']
jira_components = {images[i]['issue_component'] for i in images}

token_auth = os.environ["JIRA_TOKEN"]
client = JIRA("https://issues.redhat.com", token_auth=token_auth)
existing_components = {c.name for c in client.project_components('OCPBUGS')}

missing = jira_components - existing_components
if not missing:
    sys.exit(0)

print('The following components do not exist in jira:')
for image in images:
    component = images[image]['issue_component']
    if component in missing:
        print(image, component)
sys.exit(1)
```