### PR TITLE
nmstate-console-plugin: Update image name

### DIFF
--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -27,7 +27,7 @@ from:
   builder:
   - stream: nodejs16
   stream: nginx
-name: openshift/nmstate-console-plugin
+name: openshift/nmstate-console-plugin-rhel8
 owners:
 - upalatuc@redhat.com
 - bnemec@redhat.com


### PR DESCRIPTION
The image name needs to match the delivery repo name.