### PR TITLE
Pin rhcos images to stream assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -231,3 +231,22 @@ releases:
         component: 'driver-toolkit'
       - code: FAILED_CROSS_RPM_VERSIONS_REQUIREMENT
         component: 'rhcos'
+      rhcos:
+        machine-os-content:
+          images:
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c12338f958f673d7063a6d6df3c86b95e88fa67f138bd5b2d635431585bd85c
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a8de2e0841703c547d893b6b65b5a32b81b08fbeeb65e7eb1708854bfe676b6c
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e128bffc6034e7092f63bbf7c0b481df2cc3d067bfd65c6a97c1e0615d43226b
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2a13ef4e47798a58c3598c0c17b62dc2c41373be9dc6fa16c2d3d203f3a68597
+        rhel-coreos:
+          images:
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fd6526980224b08ab6b69153644c27c0c04be5d0d70f9028e5c0c910e055ebdd
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:187bfd333b5f8248e265727bb82ff4dcdb5981524e9418538eac1bf53ab08179
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8a2ffe8debc9f41dade72ab2e3af06dce3fd08de177db73df9b766ad85ea03c4
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cd299b2bf3cc98fb70907f152b4281633064fe33527b5d6a42ddc418ff00eec1
+        rhel-coreos-extensions:
+          images:
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c5394106ccff9d4b59b073b2f80df99020b90dd927dd0a00b8ef7b649d57ca5
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:30835cc1832ab4b4d66a9d888d4f2156c3e10f3da76247708753e036055e2024
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3077adbdf7d5a4e736a2d5df28f4b31a15a98919ebc6487cd74bdf92630ad61b
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d5cf49fcaf9e291f5096783124e45e82395ccf895c16d3f4b56566128fc19625


### PR DESCRIPTION
Currently, build-sync is complaining about wrong labels in rhcos images. Temporarily pin rhcos images to stream.

To silence validator complaints: https://github.com/openshift-eng/ocp-build-data-validator/pull/91

PR created with:
```sh
amd64=registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2023-03-14-192553
ppc=registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.13.0-0.nightly-ppc64le-2023-03-14-173649
s390x=registry.ci.openshift.org/ocp-s390x/release-s390x:4.13.0-0.nightly-s390x-2023-03-14-173649
arm=registry.ci.openshift.org/ocp-arm64/release-arm64:4.13.0-0.nightly-arm64-2023-03-14-173645

for image in machine-os-content rhel-coreos rhel-coreos-extensions; do
cat <<EOF
  $image:
    images:
      aarch64: $(oc adm release info --image-for=$image $arm)
      s390x: $(oc adm release info --image-for=$image $s390x)
      ppc64le: $(oc adm release info --image-for=$image $ppc)
      x86_64: $(oc adm release info --image-for=$image $amd64)
EOF
done
```