### PR TITLE
[ART-6286] 4.13 - Bump rhel8 builder

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -21,8 +21,9 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # openshift-golang-builder-container-v1.19.4-202301042245.el8.g1832cfe
-  image: openshift/golang-builder@sha256:d027750cda93ab497afbde0e09ef3d12e0aac10e9c89ed6da866b15188c9969c
+  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2414523
+  # openshift-golang-builder-container-v1.19.6-202303140941.el8.g6a2861c
+  image: openshift/golang-builder@sha256:f38f31aef24699bb3dac4f22dcd5692778e612d5ea69633e937756136c8f0176
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
```  
$ elliott go -n openshift-golang-builder-container-v1.19.6-202303140941.el8.g6a2861c
Following nvrs are built with 1.19.6-1.module+el8.8.0+18289+edd6c8b6:
openshift-golang-builder-container-v1.19.6-202303140941.el8.g6a2861c
```

Note: This will trigger mass rebuilds - Do not merge before Friday. 
Also Force rebuild all 4.13 rpms when close to merging this


