### PR TITLE
[ART-6195] Pin DTK with scos kernel so that 9.2 kernels match

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -231,3 +231,10 @@ releases:
         component: 'driver-toolkit'
       - code: FAILED_CROSS_RPM_VERSIONS_REQUIREMENT
         component: 'rhcos'
+      members:
+        images:
+        - distgit_key: driver-toolkit
+          why: "Until rhel 9.2 GA's, we must build with scos. It requires a special build of the DTK to match the kernel version in scos."
+          metadata:
+            is:
+              nvr: driver-toolkit-container-v4.14.0-9999.1.p0.g6d67ca0.assembly.art6195


### PR DESCRIPTION
I realize this is a 4.14 image, but I don't think it will matter.  This is a temporary image that is only needed until we pivot to RHEL 9.2 beta.