### PR TITLE
[4.14] Remove nginx stream; use ocp base as last build layer

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -26,7 +26,7 @@ for_payload: true
 from:
   builder:
   - stream: nodejs16
-  stream: nginx
+  member: openshift-enterprise-base
 name: openshift/ose-monitoring-plugin-rhel8
 owners:
 - team-observability-ui@redhat.com

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -26,7 +26,7 @@ for_payload: false
 from:
   builder:
   - stream: nodejs16
-  stream: nginx
+  member: openshift-enterprise-base
 name: openshift/nmstate-console-plugin-rhel8
 owners:
 - upalatuc@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -121,8 +121,3 @@ nodejs16:
   image: ubi8/nodejs-16:1-82.1675799501
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs16-base-{MAJOR}.{MINOR}.art
   mirror: true
-
-nginx:
-  image: ubi8/nginx-120:1-84.1675799502
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nginx-base-{MAJOR}.{MINOR}.art
-  mirror: true


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-6289

Follows:
- https://github.com/openshift/nmstate-console-plugin/pull/9
- https://github.com/openshift/monitoring-plugin/pull/19