### PR TITLE
Migrate dtk to use rhel 9.2

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -405,47 +405,38 @@ repos:
     reposync:
       enabled: true
 
-
-  # CENTOS repos have been added temporarily to allow us to build Centos 9.2 based DTK images before
-  # RHEL's 9.2 beta makes it possible to use RHEL 9.2 publicly. A snapshot of CentOS 9 stream was mirrored
-  # to ocp-artifacts and should be deleted (due to its size) after this phase of the migration is over.
-
-  centos-92-baseos-rpms:
+  rhel-92-baseos-rpms:
     conf:
       extra_options:
         module_hotfixes: 1
         includepkgs: "kernel*"
-        gpgcheck: "0"   # centos gpg key would otherwise fail verification.
       baseurl:
-        aarch64: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/
-        ppc64le: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/BaseOS/ppc64le/os/
-        s390x: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/BaseOS/s390x/os/
-        x86_64: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/
+        aarch64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/BaseOS/aarch64/os/
+        ppc64le: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/BaseOS/ppc64le/os/
+        s390x: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/BaseOS/s390x/os/
+        x86_64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/BaseOS/x86_64/os/
     content_set:
-      # Not real since these are CentOS, but needed to get beyond data validation.
-      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_0
-      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_0
-      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_0
-      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_0
+      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_2
+      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_2
+      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_2
+      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_2
     reposync:
       enabled: false
-  centos-92-appstream-rpms:
+  rhel-92-appstream-rpms:
     conf:
       extra_options:
         module_hotfixes: 1
         includepkgs: "kernel*"
-        gpgcheck: "0"   # centos gpg key would otherwise fail verification.
       baseurl:
-        aarch64: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/AppStream/aarch64/os/
-        ppc64le: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/
-        s390x: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/AppStream/s390x/os/
-        x86_64: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
+        aarch64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/AppStream/aarch64/os/
+        ppc64le: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/AppStream/ppc64le/os/
+        s390x: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/AppStream/s390x/os/
+        x86_64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/AppStream/x86_64/os/
     content_set:
-      # Not real since these are CentOS, but needed to get beyond data validation.
-      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_0
-      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_0
-      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_0
-      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_0
+      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
+      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_2
+      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2
+      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
     reposync:
       enabled: false
   centos-92-rt-rpms:
@@ -453,21 +444,19 @@ repos:
       extra_options:
         module_hotfixes: 1
         includepkgs: "kernel-rt*"
-        gpgcheck: "0"   # centos gpg key would otherwise fail verification.
       baseurl:
         # Kernel RT is x86 only, so fake repos for other arches. The driver-toolkit Dockerfile only installs the kernel-rt
         # for x86_64.
-        aarch64: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/AppStream/aarch64/os/
-        ppc64le: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/AppStream/ppc64le/os/
-        s390x: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/AppStream/s390x/os/
+        aarch64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/BaseOS/aarch64/os/
+        ppc64le: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/BaseOS/ppc64le/os/
+        s390x: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/BaseOS/s390x/os/
 
-        x86_64: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/CentOS/mirror.stream.centos.org/9-stream/RT/x86_64/os/
+        x86_64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2/compose/RT/x86_64/os/
     content_set:
-      # Not real since these are CentOS, but needed to get beyond data validation.
-      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_0
-      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_0
-      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_0
-      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_0
+      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
+      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_2
+      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2
+      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
     reposync:
       enabled: false
 

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -27,12 +27,10 @@ content:
       url: git@github.com:jupierce/driver-toolkit.git
       web: https://github.com/jupierce/driver-toolkit
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-server-ose-rpms-embargoed
-- rhel-9-appstream-rpms
-- centos-92-baseos-rpms
-- centos-92-appstream-rpms
-- centos-92-rt-rpms
+- rhel-92-baseos-rpms
+- rhel-92-server-ose-rpms-embargoed
+- rhel-92-appstream-rpms
+- rhel-92-rt-rpms
 for_payload: true
 from:
   member: openshift-enterprise-base-rhel9


### PR DESCRIPTION
CoreOS for 4.14 has pivoted to using RHEL 9.2 beta bits. Following along.