### PR TITLE
bump 4.11 golang to 4.18.10

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -21,8 +21,8 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # openshift-golang-builder-container-v1.18.9-202302170201.el8.g635add7
-  image: openshift/golang-builder@sha256:4344a45bc74171d975347ce952fb7ff9a0404ed083cd9d32bea5efc17c0b5959
+  # openshift-golang-builder-container-v1.18.10-202304070931.el8.g1aea229
+  image: openshift/golang-builder@sha256:dc49275e9bfee88ec316f263a5bb791e9b5126a9a36dd65e146d308651bf9c66
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
ref [ART-6416](https://issues.redhat.com/browse/ART-6416)