### PR TITLE
4.11.36 release

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,4 +1,34 @@
 releases:
+  4.11.36:
+    assembly:
+      basis:
+        assembly: "4.11.34"
+      members:
+        images:
+        - distgit_key: ose-baremetal-installer
+          why: AWS change to s3 permissions. Minimal change atop 4.11.34 to reduce risk.
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: 84dcd4dad2ff22d4689da0b84cd210aa4c1e8172
+        - distgit_key: ose-installer
+          why: AWS change to s3 permissions. Minimal change atop 4.11.34 to reduce risk.
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: 84dcd4dad2ff22d4689da0b84cd210aa4c1e8172
+        - distgit_key: ose-installer-artifacts
+          why: AWS change to s3 permissions. Minimal change atop 4.11.34 to reduce risk.
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: 84dcd4dad2ff22d4689da0b84cd210aa4c1e8172
   4.11.35:
     assembly:
       basis:


### PR DESCRIPTION
AWS has rolled out permissions changes to S3 which are preventing installs. This release minimizes the risk for promoting a release into cincy channels by basing 4.11.36 on 4.11.34.
See #tmp-aws-s3-public-access for details.