### PR TITLE
4.12.12 release

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,4 +1,34 @@
 releases:
+  4.12.12:
+    assembly:
+      basis:
+        assembly: "4.12.10"
+      members:
+        images:
+        - distgit_key: ose-baremetal-installer
+          why: AWS change to s3 permissions. Minimal change atop 4.12.10 to reduce risk.
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: 370d30cbcd9e22b2b882f99df11fea2321489f14
+        - distgit_key: ose-installer
+          why: AWS change to s3 permissions. Minimal change atop 4.12.10 to reduce risk.
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: 370d30cbcd9e22b2b882f99df11fea2321489f14
+        - distgit_key: ose-installer-artifacts
+          why: AWS change to s3 permissions. Minimal change atop 4.12.10 to reduce risk.
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: 370d30cbcd9e22b2b882f99df11fea2321489f14
   4.12.11:
     assembly:
       basis:


### PR DESCRIPTION
AWS has rolled out permissions changes to S3 which are preventing installs.
This release minimizes the risk for promoting a release into cincy channels by basing 4.12.12 on 4.12.10.
See #tmp-aws-s3-public-access for details.