### PR TITLE
[4.13] Remove stream permits for rhcos

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -433,9 +433,5 @@ releases:
     assembly:
       type: stream
       permits:
-      - code: INCONSISTENT_RHCOS_RPMS
-        component: 'rhcos'
-      - code: CONFLICTING_GROUP_RPM_INSTALLED
-        component: 'rhcos'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'


### PR DESCRIPTION
Now that 9.2 rhcos builds have stabilized, we want to make
sure rhcos is in line with assembly selected rpms.

Current nightlies are not failing/blocked on these permits
see assembly_issues in
https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/32243/
