### PR TITLE
Adjust 4.14 pipeline configuration

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -495,8 +495,7 @@ csv_namespace: openshift
 
 # whether and how to check if all buildroots have consistent versions of golang compilers (rpm build only)
 # "x.y" (default): only major and minor version; "exact": the z-version must be the same; "no": do not check
-check_golang_versions: "x.y"
-# [2023-01-04 lmeyer] golang-1.19 is a bit behind for rhel9
+check_golang_versions: "exact"
 
 # until feature freeze, prefer to use the golang builder that the upstream CI build is using
 # if different from what ART has configured, encouraging deliberate transitioning.

--- a/releases.yml
+++ b/releases.yml
@@ -3,9 +3,5 @@ releases:
     assembly:
       type: stream
       permits:
-      - code: INCONSISTENT_RHCOS_RPMS
-        component: 'rhcos'
-      - code: CONFLICTING_GROUP_RPM_INSTALLED
-        component: 'rhcos'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'


### PR DESCRIPTION
- reinstate strictness in golang version checks
- Get strict on rhcos content

Background for the last:
- Since the new pipeline, rhcos is behaving better
- New payloads happen ewvery 8 hours because of the payload tests on RC
- New rhcos builds occur faster than these 8 hours
- Better present something releaseable to RC when we get the chance, and take the few hours extra wait