### PR TITLE
ART-5546 Bump 4.14 golang to 1.20.3

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -21,9 +21,9 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=<>
-  # <>
-  image: openshift/golang-builder@sha256:<>
+  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2468004
+  # openshift-golang-builder-container-v1.20.3-202304171839.el8.g3464689
+  image: openshift/golang-builder@sha256:2ea0030fbc9bc9e65c5d20d0a447e51e7facbec3300456e7338b724d01e0f99e
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}.art

--- a/streams.yml
+++ b/streams.yml
@@ -21,6 +21,16 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
+  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2414523
+  # openshift-golang-builder-container-v1.19.6-202303140941.el8.g6a2861c
+  image: openshift/golang-builder@sha256:f38f31aef24699bb3dac4f22dcd5692778e612d5ea69633e937756136c8f0176
+  mirror: true
+  transform: rhel-8/golang
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
+
+golang-1.20:
+  # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
   # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2468004
   # openshift-golang-builder-container-v1.20.3-202304171839.el8.g3464689
   image: openshift/golang-builder@sha256:2ea0030fbc9bc9e65c5d20d0a447e51e7facbec3300456e7338b724d01e0f99e
@@ -30,6 +40,16 @@ golang:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
+  # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
+  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2456490
+  # openshift-golang-builder-container-v1.19.6-202304071357.el9.gf0a0406
+  image: openshift/golang-builder@sha256:54204c4bacaec28330112f9401b290b67e95449ccb5c03676f01a5e315441112
+  mirror: true
+  transform: rhel-9/golang
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
+
+rhel-9-golang-1.20:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
   # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467997
   # openshift-golang-builder-container-v1.20.3-202304171838.el9.g169fa12
@@ -44,6 +64,15 @@ rhel-9-golang:
 # packages that upstream has traditionally had present in its build_roots.
 rhel-8-golang-ci-build-root:
   image: not_applicable
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
+  transform: rhel-8/ci-build-root
+  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-{MAJOR}.{MINOR}
+
+# This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
+# Our transform is designed to create a buildconfig atop a specific golang version, layering on
+# packages that upstream has traditionally had present in its build_roots.
+rhel-8-golang-1.20-ci-build-root:
+  image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-{MAJOR}.{MINOR}
@@ -53,9 +82,9 @@ rhel-8-golang-ci-build-root:
 # packages that upstream has traditionally had present in its build_roots.
 rhel-9-golang-ci-build-root:
   image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
   transform: rhel-9/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-{MAJOR}.{MINOR}
+  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.

--- a/streams.yml
+++ b/streams.yml
@@ -21,18 +21,9 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2414523
-  # openshift-golang-builder-container-v1.19.6-202303140941.el8.g6a2861c
-  image: openshift/golang-builder@sha256:f38f31aef24699bb3dac4f22dcd5692778e612d5ea69633e937756136c8f0176
-  mirror: true
-  transform: rhel-8/golang
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
-
-golang-1.20:
-  # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # openshift-golang-builder-container-v1.20.1-1.202302170000.nofips.testonly.el8.ga291c02
-  image: openshift/golang-builder@sha256:7595f3dcb38a81f2ca57c1fee34fac88c43609579efaccb9c118c31bb31e32ce
+  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=<>
+  # <>
+  image: openshift/golang-builder@sha256:<>
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}.art
@@ -40,18 +31,9 @@ golang-1.20:
 
 rhel-9-golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2456490
-  # openshift-golang-builder-container-v1.19.6-202304071357.el9.gf0a0406
-  image: openshift/golang-builder@sha256:54204c4bacaec28330112f9401b290b67e95449ccb5c03676f01a5e315441112
-  mirror: true
-  transform: rhel-9/golang
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
-
-rhel-9-golang-1.20:
-  # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # openshift-golang-builder-container-v1.20.1-1.202302170000.nofips.testonly.el9.g575aa38
-  image: openshift/golang-builder@sha256:fb2360844f0d87d72fb90864998ac9ae8f29416ca377ebd6feffcf14480c1f44
+  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467997
+  # openshift-golang-builder-container-v1.20.3-202304171838.el9.g169fa12
+  image: openshift/golang-builder@sha256:5ea8ea58e2c5bb9ecc6f3e10469fb884495f145b447362ac25de69a0f7f04075
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}.art
@@ -62,15 +44,6 @@ rhel-9-golang-1.20:
 # packages that upstream has traditionally had present in its build_roots.
 rhel-8-golang-ci-build-root:
   image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
-  transform: rhel-8/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-{MAJOR}.{MINOR}
-
-# This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
-# Our transform is designed to create a buildconfig atop a specific golang version, layering on
-# packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-1.20-ci-build-root:
-  image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-{MAJOR}.{MINOR}
@@ -80,9 +53,9 @@ rhel-8-golang-1.20-ci-build-root:
 # packages that upstream has traditionally had present in its build_roots.
 rhel-9-golang-ci-build-root:
   image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-9/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-{MAJOR}.{MINOR}
+  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-{MAJOR}.{MINOR}
 
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.

--- a/streams.yml
+++ b/streams.yml
@@ -19,7 +19,7 @@
 #
 ####################################################################################################
 
-golang:
+golang-1.19:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
   # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2414523
   # openshift-golang-builder-container-v1.19.6-202303140941.el8.g6a2861c
@@ -29,7 +29,7 @@ golang:
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
-golang-1.20:
+golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
   # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2468004
   # openshift-golang-builder-container-v1.20.3-202304171839.el8.g3464689
@@ -39,7 +39,7 @@ golang-1.20:
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang:
+rhel-9-golang-1.19:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
   # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2456490
   # openshift-golang-builder-container-v1.19.6-202304071357.el9.gf0a0406
@@ -49,7 +49,7 @@ rhel-9-golang:
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang-1.20:
+rhel-9-golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
   # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467997
   # openshift-golang-builder-container-v1.20.3-202304171838.el9.g169fa12
@@ -62,7 +62,7 @@ rhel-9-golang-1.20:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-ci-build-root:
+rhel-8-golang-1.19-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
@@ -71,7 +71,7 @@ rhel-8-golang-ci-build-root:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-1.20-ci-build-root:
+rhel-8-golang-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
@@ -80,11 +80,20 @@ rhel-8-golang-1.20-ci-build-root:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-9-golang-ci-build-root:
+rhel-9-golang-1.19-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
   transform: rhel-9/ci-build-root
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-{MAJOR}.{MINOR}
+
+# This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
+# Our transform is designed to create a buildconfig atop a specific golang version, layering on
+# packages that upstream has traditionally had present in its build_roots.
+rhel-9-golang-ci-build-root:
+  image: not_applicable
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
+  transform: rhel-9/ci-build-root
+  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-{MAJOR}.{MINOR}
 
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-5546
[openshift-golang-builder-container-v1.20.3-202304171838.el9.g169fa12](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467997)
[openshift-golang-builder-container-v1.20.3-202304171839.el8.g3464689](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2468004)

Verified the right rpms were picked
```
$ elliott go -n  openshift-golang-builder-container-v1.20.3-202304171838.el9.g169fa12
Following nvrs are built with 1.20.3-1.el9:
openshift-golang-builder-container-v1.20.3-202304171838.el9.g169fa12

$ elliott go -n openshift-golang-builder-container-v1.20.3-202304171839.el8.g3464689
Following nvrs are built with 1.20.3-1.el8:
openshift-golang-builder-container-v1.20.3-202304171839.el8.g3464689
```

