### PR TITLE
[4.14] make canonical_builders_from_upstream "auto"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -499,4 +499,4 @@ check_golang_versions: "exact"
 
 # until feature freeze, prefer to use the golang builder that the upstream CI build is using
 # if different from what ART has configured, encouraging deliberate transitioning.
-canonical_builders_from_upstream: on
+canonical_builders_from_upstream: "auto"


### PR DESCRIPTION
[slack ref](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1681827364531299?thread_ts=1681738119.840439&cid=GDBRP5YJH)