### PR TITLE
Revert "Thanos back to golang-1.19"

### DIFF
--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -19,7 +19,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang-1.19
+  - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-thanos
 non_shipping_repos:


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#2818

Taking another approach