### PR TITLE
Add rpm-build to ci buildroot

### DIFF
--- a/ci_transforms/rhel-9/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-9/ci-build-root/Dockerfile
@@ -19,7 +19,7 @@ RUN set -euxo pipefail && \
 
 # Install common CI tools and epel for other devel packages
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    INSTALL_PKGS="bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute" && \
+    INSTALL_PKGS="bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
     yum install -y $INSTALL_PKGS && \
     yum clean all && \
     touch /os-build-image && \


### PR DESCRIPTION
The command `rpmbuild` disappeared from ci-buildroot image with the move from rhel-8 to rhel-9, as the rpm rpm-build does not get installed. The packages that got removed relative from the rhel8 build-root image is:

```
libvirt-devel
mercurial
tito
```

Tito has a dependency on rpm-build. This brings back the missing package.