### PR TITLE
ose-frr: temporarily keep building on rhel-8 branch

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -7,7 +7,7 @@ content:
       url: git@github.com:openshift-priv/frr.git
       web: https://github.com/openshift/frr
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms


### PR DESCRIPTION
brew isn't configured to allow the build into our rhel9 tag yet; we can still build on the "wrong" tag for now