### PR TITLE
monitoring-plugin: use private org

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift/monitoring-plugin.git
+      url: git@github.com:openshift-priv/monitoring-plugin.git
       web: https://github.com/openshift/monitoring-plugin
     ci_alignment:
       streams_prs:


### PR DESCRIPTION
fixes validation complaining about the upstream location; the private location looks good to me so let's use it