### PR TITLE
4.12: Enable auto-lgtm+approve on storage image PRs

### DIFF
--- a/images/cluster-storage-operator.yml
+++ b/images/cluster-storage-operator.yml
@@ -9,6 +9,9 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
+        auto_label:
+        - approved
+        - lgtm
 distgit:
   component: ose-cluster-storage-operator-container
 enabled_repos:

--- a/images/ose-cluster-csi-snapshot-controller-operator.yml
+++ b/images/ose-cluster-csi-snapshot-controller-operator.yml
@@ -10,6 +10,9 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
+        auto_label:
+        - approved
+        - lgtm
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
All images owned by aos-storage-staff should have enabled auto lgtm + approve on "Updating %s images to be consistent with ART" PRs.