### PR TITLE
microshift: Disable el8 build

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -16,13 +16,8 @@ content:
         # of lvms-operator-bundle, hardcode v4.12 for now.
         # # https://github.com/openshift/microshift/blob/main/docs/rebase.md#getting-release-image-build-references
         LVMS_OPERATOR_BUNDLE: registry.access.redhat.com/lvms4/lvms-operator-bundle:v4.12
-
 name: microshift
-targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
-- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
-hotfix_targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
-- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 owners:
 - microshift-devel@redhat.com


### PR DESCRIPTION
dhellmann requested stopping building MicroShift 4.14 and later for RHEL 8. 