### PR TITLE
ART-6592 Reconcile ose-agent-installer-utils name with upstream

### DIFF
--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -19,7 +19,7 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-agent-installer-utils-rhel8
+name: openshift/ose-agent-installer-utils
 owners:
 - afasano@redhat.com
 - zbitter@redhat.com


### PR DESCRIPTION
[slack ref](https://redhat-internal.slack.com/archives/CB95J6R4N/p1682527843540499?thread_ts=1681736898.206669&cid=CB95J6R4N)