### PR TITLE
rhcos: Add definition for build repos [4.9]

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -55,6 +55,12 @@ dist_git_ignore:
   - gating.yaml
 
 rhcos:
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  - rhel-8-rt-rpms
+  - rhel-8-fast-datapath-rpms
+  - rhel-8-server-ose-rpms
   require_consistency:
     driver-toolkit:
     - kernel


### PR DESCRIPTION
Have the build data to define which repos are used in RHCOS so that Doozer can validate if installed rpms in an RHCOS build are latest or not.