### PR TITLE
4.14: Allow CONFLICTING_GROUP_RPM_INSTALLED for rhcos

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -39,3 +39,5 @@ releases:
       permits:
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'
+      - code: CONFLICTING_GROUP_RPM_INSTALLED
+        component: rhcos


### PR DESCRIPTION
Some pipeline issues prevent rhcos to have the latest rpms. Allow this for now.