### PR TITLE
[4.14] Update dpu-network-operator Dockerfile

### DIFF
--- a/images/dpu-network-operator.yml
+++ b/images/dpu-network-operator.yml
@@ -3,7 +3,7 @@ arches:
 - aarch64
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel9
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
[This change](https://github.com/openshift/dpu-network-operator/commit/a293f35609ba1a42d828b1b4fb1cba2b1b1085c4) renamed Dockerfile.rhel7 into Dockerfile.rhel9