### PR TITLE
microshift: explicitly set target to rhel 9

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -20,5 +20,7 @@ content:
 name: microshift
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
 owners:
 - microshift-devel@redhat.com


### PR DESCRIPTION
group.yml has default target `rhaos-{MAJOR}.{MINOR}-rhel-8-candidate`. We need to explicitly set the build target to
`rhaos-{MAJOR}.{MINOR}-rhel-9-candidate` for microshift.