### PR TITLE
update for newer reality

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -8,7 +8,7 @@ arches:
 
 vars:
   MAJOR: 4
-  MINOR: 12
+  MINOR: 13
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -17,8 +17,6 @@ enabled_repos:
 from:
   stream: rhel8
 
-image_build_method: imagebuilder
-
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds
 


### PR DESCRIPTION
there is no longer an "imagebuilder" build type.
and we would update the 4.13 buildroot before backporting to 4.12