### PR TITLE
Rename nodejs ci image

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -133,5 +133,5 @@ rhel9:
 
 nodejs:
   image: ubi8/nodejs-16:1-82.1675799501
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs16-base-{MAJOR}.{MINOR}.art
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true


### PR DESCRIPTION
Console has trouble building in CI because nodejs16 builder wasn't renamed, so `registry.ci.openshift.org/ocp/builder:rhel-8-base-nodejs-openshift-4.14` still contains node14. 

Follows https://github.com/openshift-eng/ocp-build-data/pull/2947

Ref. https://issues.redhat.com/browse/ART-6294