### PR TITLE
[ART-6092] update to golang 1.19.9

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -31,9 +31,9 @@ golang:
 
 rhel-9-golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2456490
-  # openshift-golang-builder-container-v1.19.6-202304071357.el9.gf0a0406
-  image: openshift/golang-builder@sha256:54204c4bacaec28330112f9401b290b67e95449ccb5c03676f01a5e315441112
+  # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2527283
+  # openshift-golang-builder-container-v1.19.9-202305291556.el9.g3460409
+  image: openshift/golang-builder@sha256:fc909f550c48f092d8b8a5fb3f9797de25d9fb4d04abf70abc971f84fbbffdf3
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
[openshift-golang-builder-container-v1.19.9-202305291556.el9.g3460409](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2527283)