### PR TITLE
Add config for tag-rpms and scan-for-kernel-bugs jobs [4.10]

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -17,6 +17,23 @@ version:
   - "4.10"
   - "4.10.z"
 
+# Configure how elliott find-bugs:kernel[-clones] finds and clones kernel bugs (ART-6964)
+kernel_bug_sweep:
+  tracker_jira:
+    project: KMAINT
+    labels:
+    - early-kernel-track
+  bugzilla:
+    target_releases:
+    - "{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}.0"
+  target_jira:
+    project: OCPBUGS
+    component: RHCOS
+    version: "{MAJOR}.{MINOR}"
+    target_release: "{MAJOR}.{MINOR}.z"
+    candidate_brew_tag: "rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate"
+    prod_brew_tag: "rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}"
+
 # List of OCP components for which advisories are not maintained by ART
 # to be ignored when looking for bugs to be attached to OCP advisories
 filters:

--- a/group.yml
+++ b/group.yml
@@ -5,6 +5,8 @@ vars:
   MINOR: 10
   IMPACT: Low
   CVES: None
+  RHCOS_EL_MAJOR: 8
+  RHCOS_EL_MINOR: 4
 
 arches:
 - x86_64
@@ -54,6 +56,16 @@ rhcos:
 
 default_image_build_profile: unsigned
 default_rpm_build_profile: default
+
+# rpm_deliveries is mainly to support for "Weekly" kernel delivery through OCP (ART-6100)
+rpm_deliveries:
+  - packages:
+      - kernel
+      - kernel-rt
+    integration_tag: early-kernel-integration-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}
+    stop_ship_tag: early-kernel-stop-ship
+    ship_ok_tag: early-kernel-ship-ok
+    target_tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
 
 branch: rhaos-{MAJOR}.{MINOR}-rhel-8
 name: openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
This config is required for tag-rpms and scan-for-kernel-bugs job. Otherwise those 2 jobs will do nothing.

See https://issues.redhat.com/browse/ART-6099 and https://issues.redhat.com/browse/ART-6964 for explanations.