### PR TITLE
Allow CONFLICTING_GROUP_RPM_INSTALLED for rhcos in stream

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -102,3 +102,5 @@ releases:
       permits:
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'
+      - code: CONFLICTING_GROUP_RPM_INSTALLED
+        component: rhcos


### PR DESCRIPTION
By default, we allow the code OUTDATED_RPMS_IN_STREAM_BUILD in the stream assembly, yet CONFLICTING_GROUP_RPM_INSTALLED is not allowed.

This leads to the following situation:
```yaml
assembly_issues:
  rhcos:
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (openshift-clients-4.14.0-202305311616.p0.g603c3af.assembly.stream.el9)
      installed in RHCOSBuild:x86_64:414.92.202305311647-0 (x86_64) when openshift-clients-4.14.0-202306012015.p0.g493ee2b.assembly.stream.el9
      is available in repo rhel-9-server-ose-rpms
    permitted: true
  - code: CONFLICTING_GROUP_RPM_INSTALLED
    msg: Expected 414.92.202305311647-0/ppc64le image to contain assembly selected
      RPM build openshift-clients-4.14.0-202306012015.p0.g493ee2b.assembly.stream.el9
      but found openshift-clients-4.14.0-202305311616.p0.g603c3af.assembly.stream.el9
      installed
    permitted: false
```

Allowing `OUTDATED_RPMS_IN_STREAM_BUILD` is intended to be lenient for rhrhcos to lag behind a bit. We need `CONFLICTING_GROUP_RPM_INSTALLED` to be permitted as well to not have nightly creation blocked on this.