### PR TITLE
Move docker_api builder to osbs2

### DIFF
--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -12,7 +12,6 @@ enabled_repos:
 - rhel-server-ose-rpms-embargoed
 from:
   member: openshift-base-rhel7
-image_build_method: docker_api
 labels:
   License: ASL 2.0
   io.k8s.description: This is the Prometheus Alert Manager image.

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -12,7 +12,6 @@ enabled_repos:
 - rhel-server-ose-rpms-embargoed
 from:
   member: openshift-base-rhel7
-image_build_method: docker_api
 labels:
   License: ASL 2.0
   io.k8s.description: Prometheus exporter for hardware and OS metrics exposed by *NIX

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -16,7 +16,6 @@ enabled_repos:
 - rhel-server-ose-rpms-embargoed
 from:
   member: openshift-enterprise-base
-image_build_method: docker_api
 labels:
   License: GPLv2+
   io.k8s.description: This is a component of OpenShift Container Platform and exposes


### PR DESCRIPTION
docker_api was used in some images for working around some bugs in imagebuilder, e.g. https://github.com/openshift/imagebuilder/issues/87.

I believe those issues no longer exist with the current OSBS 2 builder. Let's try it instead.