### PR TITLE
Revert "Add config for tag-rpms and scan-for-kernel-bugs jobs - 4.9"

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -17,23 +17,6 @@ version:
   - "4.9"
   - "4.9.z"
 
-# Configure how elliott find-bugs:kernel[-clones] finds and clones kernel bugs (ART-6964)
-kernel_bug_sweep:
-  tracker_jira:
-    project: KMAINT
-    labels:
-    - early-kernel-track
-  bugzilla:
-    target_releases:
-    - "{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}.0"
-  target_jira:
-    project: OCPBUGS
-    component: RHCOS
-    version: "{MAJOR}.{MINOR}"
-    target_release: "{MAJOR}.{MINOR}.z"
-    candidate_brew_tag: "rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate"
-    prod_brew_tag: "rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}"
-
 # List of OCP components for which advisories are not maintained by ART
 # to be ignored when looking for bugs to be attached to OCP advisories
 filters:

--- a/group.yml
+++ b/group.yml
@@ -5,8 +5,6 @@ vars:
   MINOR: 9
   IMPACT: Low
   CVES: None
-  RHCOS_EL_MAJOR: 8
-  RHCOS_EL_MINOR: 4
 
 arches:
 - x86_64
@@ -43,16 +41,6 @@ cachito:
 default_image_build_method: osbs2
 default_image_build_profile: unsigned
 default_rpm_build_profile: default
-
-# rpm_deliveries is mainly to support for "Weekly" kernel delivery through OCP (ART-6100)
-rpm_deliveries:
-  - packages:
-      - kernel
-      - kernel-rt
-    integration_tag: early-kernel-integration-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}
-    stop_ship_tag: early-kernel-stop-ship
-    ship_ok_tag: early-kernel-ship-ok
-    target_tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
 
 branch: rhaos-{MAJOR}.{MINOR}-rhel-8
 name: openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#3051

Temporarily revert this to avoid to clone kernel bugs for 4.9 since JIRA might have breaking change at this moment.