### PR TITLE
[4.14] freeze scheduled automation to allow ocp4 testing

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: false
+freeze_automation: scheduled
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
This will be reverted in a few hours.