### PR TITLE
Revert "[4.14] freeze scheduled automation to allow ocp4 testing"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: scheduled
+freeze_automation: false
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#3053