### PR TITLE
Add secrets-store-csi-driver to product.yml

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -689,6 +689,12 @@ bug_mapping:
       issue_component: route-controller-manager
     ose-sdn-container:
       issue_component: Networking / openshift-sdn
+    ose-secrets-store-csi-driver-container:
+      issue_component: Storage
+    ose-secrets-store-csi-driver-operator-bundle-container:
+      issue_component: Storage / Operators
+    ose-secrets-store-csi-driver-operator-container:
+      issue_component: Storage / Operators
     ose-service-ca-operator-container:
       issue_component: service-ca
     ose-thanos-container:


### PR DESCRIPTION
This adds component mapping for Secrets Store CSI Driver, its operator, and the operator bundle.
/cc @openshift/storage @jupierce
