### PR TITLE
monitoring-plugin: needs a matching payload name

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -28,5 +28,6 @@ from:
   - stream: nodejs
   member: openshift-enterprise-base
 name: openshift/ose-monitoring-plugin-rhel8
+payload_name: monitoring-plugin
 owners:
 - team-observability-ui@redhat.com


### PR DESCRIPTION
the payload name default is based on the image name. but in the payload its name does not have `-rhel8`