### PR TITLE
ovn-kubernetes: switch back to regular Dockerfiles

### DIFF
--- a/images/openshift-enterprise-base-rhel9.yml
+++ b/images/openshift-enterprise-base-rhel9.yml
@@ -1,7 +1,7 @@
 base_only: true
 content:
   source:
-    dockerfile: Dockerfile.rhel9
+    dockerfile: Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -1,6 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.rhel9
+    dockerfile: Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -1,7 +1,7 @@
 base_only: true
 content:
   source:
-    dockerfile: Dockerfile.base.rhel9
+    dockerfile: Dockerfile.base
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -1,6 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.microshift.rhel9
+    dockerfile: Dockerfile.microshift
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
Enabled by https://github.com/openshift/ovn-kubernetes/pull/1695

We're gonna nuke the .rhel9 ones to reduce confusion now that the RHEL9 transition is well over.