### PR TITLE
Switch NTO to use RHEL-9 payload

### DIFF
--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -1,6 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.rhel8
+    dockerfile: Dockerfile.rhel9
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -11,15 +11,17 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-fast-datapath-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-fast-datapath-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: rhel-9-golang
   member: openshift-enterprise-base
 name: openshift/ose-cluster-node-tuning-operator
 owners:


### PR DESCRIPTION
Changes:
  * use RHEL-9 Containerfile for NTO
  * use RHEL-9 baseos/appstream/FDP repos for NTO

The following dependent PRs are now merged:
  * https://github.com/openshift/cluster-node-tuning-operator/pull/665
  * https://github.com/openshift/release/pull/40516