### PR TITLE
4.14 - [ose-tests] Add git repo details

### DIFF
--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -1,6 +1,5 @@
 content:
   source:
-    alias: ose
     dockerfile: images/tests/Dockerfile.rhel
     git:
       branch:

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -2,6 +2,11 @@ content:
   source:
     alias: ose
     dockerfile: images/tests/Dockerfile.rhel
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/origin.git
+      web: https://github.com/openshift/origin
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
While working on a story, noticed that this image is missing github repo details.
I haven't checked why/how this has continued working? how does doozer get to the repo?
and what alias exactly means (seems harmless?)