### PR TITLE
ART-6865 Create basic metadata for CI base images

### DIFF
--- a/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
@@ -1,0 +1,1 @@
+FROM registry.redhat.io/ubi9:latest

--- a/group.yml
+++ b/group.yml
@@ -362,6 +362,29 @@ repos:
     reposync:
       latest_only: false
 
+  rhel-9-server-ose-build-rpms:
+    conf:
+      extra_options:
+        module_hotfixes: 1
+        # this repo is for our own buildroot, which also inherits a complete RHEL 8 build env;
+        # restrict to specific necessary content, because RHEL 8 build dev content may include
+        # pending unreleased content that can cause conflicts for later CI installs lacking access
+        # to that content.
+        includepkgs: goversioninfo gpgme-devel libassuan-devel mingw* golang*
+      baseurl:
+        aarch64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
+        ppc64le: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
+        s390x: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
+        x86_64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
+
+    # These content sets are not used, so just putting something here
+    content_set:
+      default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
+      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
+      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
+      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
+      optional: true
+
   rhel-9-server-ironic-rpms:
     conf:
       extra_options:

--- a/images/ci-openshift-golang-builder-latest.yml
+++ b/images/ci-openshift-golang-builder-latest.yml
@@ -1,0 +1,39 @@
+content:
+  set_build_variables: false
+  source:
+    dockerfile: ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
+    git:
+      branch:
+        target: "openshift-{MAJOR}.{MINOR}"
+      url: git@github.com:openshift-eng/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      enabled: false
+      mirror: true
+      mirror_manifest_list: true
+      upstream_image: registry.ci.openshift.org/ocp-multi/builder:rhel-9-base-openshift-{MAJOR}.{MINOR}
+
+enabled_repos:
+- rhel-9-server-ose-build-rpms
+- rhel-9-baseos-rpms
+# for clang
+- rhel-9-appstream-rpms
+      
+from:
+  stream: rhel9
+
+labels:
+  io.k8s.description: golang builder image for Red Hat internal builds
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+
+name: openshift/ci-golang-builder-latest
+
+owners:
+- aos-team-art@redhat.com
+
+additional_tags:
+- 'rhel_9_golang_ci_latest'
+maintainer:
+  component: Release


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-6865

This is recreating https://github.com/openshift-eng/ocp-build-data/blob/rhel-9-golang-1.20/images/openshift-golang-builder.yml but for ci and in each release branch

Disgit repo https://pkgs.devel.redhat.com/cgit/containers/ci-openshift-golang-builder-latest/

Depends on https://github.com/openshift-eng/doozer/pull/805

## Testing
- `doozer --data-path https://github.com/thegreyd/ocp-build-data --assembly test -g openshift-4.14@art-6865 -i ci-openshift-golang-builder-latest images:rebase --version v1 --release "20230624.el9.p?" -m "testing" --push`
- `doozer --data-path https://github.com/thegreyd/ocp-build-data --group openshift-4.14@art-6865 --assembly test --latest-parent-version -i ci-openshift-golang-builder-latest images:build`

Test build [ci-openshift-golang-builder-latest-container-v1.0.0-20230724.el9.p0.g31a41d7.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2609231)