### PR TITLE
olm-catalogd/operator-controller: correct payload names

### DIFF
--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -19,5 +19,6 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-olm-catalogd-rhel8
+payload_name: olm-catalogd
 owners:
 - aos-odin@redhat.com

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -24,5 +24,6 @@ labels:
   io.k8s.display-name: OpenShift Operator Framework Operator Controller
   vendor: Red Hat
 name: openshift/ose-olm-operator-controller-rhel8
+payload_name: olm-operator-controller
 owners:
 - aos-odin@redhat.com


### PR DESCRIPTION
[ref slack](https://redhat-internal.slack.com/archives/CB95J6R4N/p1687972687910899)
```
OCP and Origin images should match failures:
Found recent tags downstream that are not built upstream (not in ocp/4.14): olm-catalogd-rhel8, olm-operator-controller-rhel8
```

They'll be published with `-rhel8` in the name, but named without it in the payload tags.