### PR TITLE
Define what arches should be published for microshift RPM

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -1,5 +1,9 @@
 # Disable automated build because it is intended to be built after a release is promoted.
 mode: disabled
+# This field won't restrict building arches; it will only determine what arches will be published on mirror
+arches:
+- x86_64
+- aarch64
 content:
   source:
     git:


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-6671

We need to configure what arches need to be synced, in order to auto-trigger the `microshift-sync` job