### PR TITLE
Compile CNI binaries for RHCOS RHEL

### DIFF
--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -16,7 +16,8 @@ content:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  # Binaries must be compiled for the RHCOS version of RHEL
+  - stream: rhel-9-golang
   member: openshift-base-rhel8
 name: openshift/ose-multus-whereabouts-ipam-cni
 owners:

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -12,7 +12,8 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  # Binaries must be compiled for the RHCOS version of RHEL
+  - stream: rhel-9-golang
   member: openshift-enterprise-base
 name: openshift/ose-network-interface-bond-cni
 owners:


### PR DESCRIPTION
FIPS compliance has forced binaries which were previously statically linked to compile dynamically linked. This means that binaries that are copied to the host, like these CNI binaries, must be compiled using a builder image that corresponds to the RHCOS RHEL version.