### PR TITLE
WIP: Add component ose-azure-workload-identity-container.

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -415,6 +415,8 @@ bug_mapping:
       issue_component: Storage / Operators
     ose-azure-machine-controllers-container:
       issue_component: Cloud Compute / Other Provider
+    ose-azure-workload-identity-container:
+      issue_component: Cloud Credential Operator
     ose-baremetal-installer-container:
       issue_component: Installer / openshift-installer
     ose-baremetal-operator-container:


### PR DESCRIPTION
Opening this along with https://github.com/openshift/release/pull/41160 which adds the repo to prow. I assume the naming follows the "ose-azure-workload-identity-container" scheme used by other components.

I'm working through https://source.redhat.com/groups/public/openshift/openshift_wiki/guidelines_for_requesting_new_content_managed_by_ocp_art#jive_content_id_ProdSec_review_of_component.

https://github.com/openshift/azure-workload-identity/pull/1 adds a Dockerfile to the forked repo for the component.
