### PR TITLE
[ART-7130] Refactor microshift-rebase script for hardened containerization.

### DIFF
--- a/modifications/Dockerfile
+++ b/modifications/Dockerfile
@@ -10,10 +10,6 @@ RUN go env -w GOPRIVATE=*
 RUN go env -w GOPROXY=file:///go/mod
 RUN export GOPROXY=direct
 
-# Set environment variables for Go
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-
 RUN yum -y install python3 && \
     python3 -m ensurepip && \
     pip3 install --upgrade pip && \
@@ -45,19 +41,3 @@ RUN wget ${OC_URL} -O openshift-client-linux.tar.gz && \
 RUN yum -y install epel-release && \
     yum -y install git && \
     yum clean all
-
-ARG BRANCH_NAME=release-4.13
-# Clone the microshift repository and set user information
-WORKDIR /workdir
-RUN git clone -b $BRANCH_NAME https://github.com/openshift/microshift.git && \
-    cd microshift && \
-    git config user.email "nobody@nowhere.com" && \
-    git config user.name "Docker"
-WORKDIR /workdir/microshift
-
-# Run the rebase script
-CMD if [ -n "$RELEASE_NAME" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then \
-            ./scripts/auto-rebase/rebase.sh to "$RELEASE_REPO":"$RELEASE_NAME"-x86_64 "$RELEASE_REPO":"$RELEASE_NAME"-aarch64 "$LVMS_OPERATOR_BUNDLE"; \
-        elif [ -n "$MICROSHIFT_PAYLOAD_X86_64" ] && [ -n "$MICROSHIFT_PAYLOAD_AARCH64" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then \
-            ./scripts/auto-rebase/rebase.sh to "$MICROSHIFT_PAYLOAD_X86_64" "$MICROSHIFT_PAYLOAD_AARCH64" "$LVMS_OPERATOR_BUNDLE"; \
-    fi \

--- a/modifications/Dockerfile
+++ b/modifications/Dockerfile
@@ -1,0 +1,63 @@
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.19.10-202306161424.el9.g372eaca
+
+USER root
+
+# Unset GOFLAGS
+ENV GOFLAGS=""
+
+# Set up a local module proxy
+RUN go env -w GOPRIVATE=*
+RUN go env -w GOPROXY=file:///go/mod
+RUN export GOPROXY=direct
+
+# Set environment variables for Go
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN yum -y install python3 && \
+    python3 -m ensurepip && \
+    pip3 install --upgrade pip && \
+    pip3 install PyYAML && \
+    yum clean all
+
+# Install yq using wget and make it executable
+RUN YQ_VER=4.26.1 \
+    && YQ_URL=https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_$(go env GOARCH) \
+    && wget -O /usr/bin/yq $YQ_URL \
+    && chmod +x /usr/bin/yq
+
+# Install jq from source
+RUN wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+    chmod +x ./jq && \
+    cp jq /usr/bin
+
+# Manually download and install OpenShift client (oc)
+ENV OC_VERSION=4.13.4
+ENV OC_URL=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz
+
+RUN wget ${OC_URL} -O openshift-client-linux.tar.gz && \
+    tar -zxvf openshift-client-linux.tar.gz && \
+    cp oc /usr/local/bin/ && \
+    cp kubectl /usr/local/bin/ && \
+    rm -rf openshift-client-linux.tar.gz oc kubectl
+
+# Make sure to install git before cloning the repository
+RUN yum -y install epel-release && \
+    yum -y install git && \
+    yum clean all
+
+ARG BRANCH_NAME=release-4.13
+# Clone the microshift repository and set user information
+WORKDIR /workdir
+RUN git clone -b $BRANCH_NAME https://github.com/openshift/microshift.git && \
+    cd microshift && \
+    git config user.email "nobody@nowhere.com" && \
+    git config user.name "Docker"
+WORKDIR /workdir/microshift
+
+# Run the rebase script
+CMD if [ -n "$RELEASE_NAME" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then \
+            ./scripts/auto-rebase/rebase.sh to "$RELEASE_REPO":"$RELEASE_NAME"-x86_64 "$RELEASE_REPO":"$RELEASE_NAME"-aarch64 "$LVMS_OPERATOR_BUNDLE"; \
+        elif [ -n "$MICROSHIFT_PAYLOAD_X86_64" ] && [ -n "$MICROSHIFT_PAYLOAD_AARCH64" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then \
+            ./scripts/auto-rebase/rebase.sh to "$MICROSHIFT_PAYLOAD_X86_64" "$MICROSHIFT_PAYLOAD_AARCH64" "$LVMS_OPERATOR_BUNDLE"; \
+    fi \

--- a/modifications/Dockerfile
+++ b/modifications/Dockerfile
@@ -1,19 +1,7 @@
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.19.10-202306161424.el9.g372eaca
-
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.19.10-202307181602.el8.g71f6585
 USER root
 
-# Unset GOFLAGS
-ENV GOFLAGS=""
-
-# Set up a local module proxy
-RUN go env -w GOPRIVATE=*
-RUN go env -w GOPROXY=file:///go/mod
-RUN export GOPROXY=direct
-
-RUN yum -y install python3 && \
-    python3 -m ensurepip && \
-    pip3 install --upgrade pip && \
-    pip3 install PyYAML && \
+RUN yum -y install python3 jq gettext python3-pyyaml && \
     yum clean all
 
 # Install yq using wget and make it executable
@@ -21,11 +9,6 @@ RUN YQ_VER=4.26.1 \
     && YQ_URL=https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_$(go env GOARCH) \
     && wget -O /usr/bin/yq $YQ_URL \
     && chmod +x /usr/bin/yq
-
-# Install jq from source
-RUN wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    chmod +x ./jq && \
-    cp jq /usr/bin
 
 # Manually download and install OpenShift client (oc)
 ENV OC_VERSION=4.13.4
@@ -36,8 +19,3 @@ RUN wget ${OC_URL} -O openshift-client-linux.tar.gz && \
     cp oc /usr/local/bin/ && \
     cp kubectl /usr/local/bin/ && \
     rm -rf openshift-client-linux.tar.gz oc kubectl
-
-# Make sure to install git before cloning the repository
-RUN yum -y install epel-release && \
-    yum -y install git && \
-    yum clean all

--- a/modifications/microshift-rebase
+++ b/modifications/microshift-rebase
@@ -21,8 +21,8 @@ if [ -n "$MICROSHIFT_NO_REBASE" ] && [ "$MICROSHIFT_NO_REBASE" -ne 0 ] ; then
     exit 0
 fi
 
-
-PODMAN_BUILD_CMD="podman build -t microshift-rebase ."
+DIR=$(dirname $(readlink -f $0))
+PODMAN_BUILD_CMD="podman build -t microshift-rebase-$BREW_TAG $DIR"
 echo $PODMAN_BUILD_CMD
 eval $PODMAN_BUILD_CMD
 
@@ -32,6 +32,7 @@ PODMAN_RUN_CMD="podman run --rm \
 -e LVMS_OPERATOR_BUNDLE \
 -e MICROSHIFT_PAYLOAD_X86_64 \
 -e MICROSHIFT_PAYLOAD_AARCH64 \
-microshift-rebase"
-echo $PODMAN_BUILD_CMD
-eval $PODMAN_BUILD_CMD
+-v $PWD:/workdir/microshift \
+microshift-rebase-$BREW_TAG"
+echo $PODMAN_RUN_CMD
+eval $PODMAN_RUN_CMD

--- a/modifications/microshift-rebase
+++ b/modifications/microshift-rebase
@@ -21,17 +21,21 @@ if [ -n "$MICROSHIFT_NO_REBASE" ] && [ "$MICROSHIFT_NO_REBASE" -ne 0 ] ; then
     exit 0
 fi
 
-DIR=$(dirname $(readlink -f $0))
-PODMAN_BUILD_CMD="podman build -t microshift-rebase-$BREW_TAG $DIR"
-echo $PODMAN_BUILD_CMD
-eval $PODMAN_BUILD_CMD
-
 # Determine which rebase command to run
 if [ -n "$RELEASE_NAME" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then
-    REBASE_CMD="./scripts/auto-rebase/rebase.sh to "$RELEASE_REPO":"$RELEASE_NAME"-x86_64 "$RELEASE_REPO":"$RELEASE_NAME"-aarch64 "$LVMS_OPERATOR_BUNDLE""
+    REBASE_CMD="./scripts/auto-rebase/rebase.sh to $RELEASE_REPO:$RELEASE_NAME-x86_64 $RELEASE_REPO:$RELEASE_NAME-aarch64 $LVMS_OPERATOR_BUNDLE"
 elif [ -n "$MICROSHIFT_PAYLOAD_X86_64" ] && [ -n "$MICROSHIFT_PAYLOAD_AARCH64" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then
-    REBASE_CMD="./scripts/auto-rebase/rebase.sh to "$MICROSHIFT_PAYLOAD_X86_64" "$MICROSHIFT_PAYLOAD_AARCH64" "$LVMS_OPERATOR_BUNDLE""
+    REBASE_CMD="./scripts/auto-rebase/rebase.sh to $MICROSHIFT_PAYLOAD_X86_64 $MICROSHIFT_PAYLOAD_AARCH64 $LVMS_OPERATOR_BUNDLE"
+else
+    fail "Environment variable RELEASE_NAME or LVMS_OPERATOR_BUNDLE is not set."
 fi
+
+# Build the podman image
+DIR=$(dirname $(readlink -f $0))
+PODMAN_BUILD_CMD="podman build  -t microshift-rebase:$BREW_TAG $DIR"
+echo $PODMAN_BUILD_CMD
+eval $PODMAN_BUILD_CMD
+podman image prune -f  # clean up unused images
 
 # Run the podman container
 PODMAN_RUN_CMD="podman run --rm \
@@ -39,8 +43,9 @@ PODMAN_RUN_CMD="podman run --rm \
 -e LVMS_OPERATOR_BUNDLE \
 -e MICROSHIFT_PAYLOAD_X86_64 \
 -e MICROSHIFT_PAYLOAD_AARCH64 \
--v $PWD:/workdir/microshift \
-microshift-rebase-$BREW_TAG \
-$REBASE_CMD"
+-v $PWD:/workdir/microshift:z \
+-w /workdir/microshift \
+microshift-rebase:$BREW_TAG \
+bash -c 'git config user.email noreply@redhat.com && $REBASE_CMD'"
 echo $PODMAN_RUN_CMD
 eval $PODMAN_RUN_CMD

--- a/modifications/microshift-rebase
+++ b/modifications/microshift-rebase
@@ -15,28 +15,23 @@ fail() {
     exit 1
 }
 
+# If MICROSHIFT_NO_REBASE is set and non-zero, stop execution here
 if [ -n "$MICROSHIFT_NO_REBASE" ] && [ "$MICROSHIFT_NO_REBASE" -ne 0 ] ; then
     echo "MICROSHIFT_NO_REBASE is defined. Rebase will not be run."
     exit 0
 fi
 
-# FIXME: rebase.sh requires Go yq (https://github.com/mikefarah/yq) instead of Python yq (https://github.com/kislyuk/yq),
-# which is used in the rest of the pipeline.
-# We install Go yq to /opt/yq-go/bin/ on buildvm to avoid conflict.
-# Use Go 1.19.5 as the version installed on buildvm (1.17) is no longer supported.
-# In the future we might have to run rebase.sh inside of a container to use specific versions of dependencies (including golang).
-export PATH=/opt/go-1.19.5/bin:/opt/yq-go/bin:$PATH
 
-if [ -n "$RELEASE_NAME" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then
-    # rebase against a named release
-    ./scripts/auto-rebase/rebase.sh to "$RELEASE_REPO":"$RELEASE_NAME"-x86_64 "$RELEASE_REPO":"$RELEASE_NAME"-aarch64 "$LVMS_OPERATOR_BUNDLE"
-    exit 0
-fi
+PODMAN_BUILD_CMD="podman build -t microshift-rebase ."
+echo $PODMAN_BUILD_CMD
+eval $PODMAN_BUILD_CMD
 
-if [ -n "$MICROSHIFT_PAYLOAD_X86_64" ] && [ -n "$MICROSHIFT_PAYLOAD_AARCH64" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then
-    # rebase against specified release payloads
-    ./scripts/auto-rebase/rebase.sh to "$MICROSHIFT_PAYLOAD_X86_64" "$MICROSHIFT_PAYLOAD_AARCH64" "$LVMS_OPERATOR_BUNDLE"
-    exit 0
-fi
-
-fail "Environment variable RELEASE_NAME or LVMS_OPERATOR_BUNDLE is not set."
+# Run the podman container
+PODMAN_RUN_CMD="podman run --rm \
+-e RELEASE_NAME \
+-e LVMS_OPERATOR_BUNDLE \
+-e MICROSHIFT_PAYLOAD_X86_64 \
+-e MICROSHIFT_PAYLOAD_AARCH64 \
+microshift-rebase"
+echo $PODMAN_BUILD_CMD
+eval $PODMAN_BUILD_CMD

--- a/modifications/microshift-rebase
+++ b/modifications/microshift-rebase
@@ -26,6 +26,13 @@ PODMAN_BUILD_CMD="podman build -t microshift-rebase-$BREW_TAG $DIR"
 echo $PODMAN_BUILD_CMD
 eval $PODMAN_BUILD_CMD
 
+# Determine which rebase command to run
+if [ -n "$RELEASE_NAME" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then
+    REBASE_CMD="./scripts/auto-rebase/rebase.sh to "$RELEASE_REPO":"$RELEASE_NAME"-x86_64 "$RELEASE_REPO":"$RELEASE_NAME"-aarch64 "$LVMS_OPERATOR_BUNDLE""
+elif [ -n "$MICROSHIFT_PAYLOAD_X86_64" ] && [ -n "$MICROSHIFT_PAYLOAD_AARCH64" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then
+    REBASE_CMD="./scripts/auto-rebase/rebase.sh to "$MICROSHIFT_PAYLOAD_X86_64" "$MICROSHIFT_PAYLOAD_AARCH64" "$LVMS_OPERATOR_BUNDLE""
+fi
+
 # Run the podman container
 PODMAN_RUN_CMD="podman run --rm \
 -e RELEASE_NAME \
@@ -33,6 +40,7 @@ PODMAN_RUN_CMD="podman run --rm \
 -e MICROSHIFT_PAYLOAD_X86_64 \
 -e MICROSHIFT_PAYLOAD_AARCH64 \
 -v $PWD:/workdir/microshift \
-microshift-rebase-$BREW_TAG"
+microshift-rebase-$BREW_TAG \
+$REBASE_CMD"
 echo $PODMAN_RUN_CMD
 eval $PODMAN_RUN_CMD


### PR DESCRIPTION
This commit involves refactoring the `microshift-rebase` script and the Dockerfile to ensure a safer and more robust containerized operations.

- The Dockerfile  incorporates the environment setup for Go, Python, yq, jq, and the OpenShift client. This ensures all dependencies are packaged within the container, reducing potential conflicts with host dependencies.

- The Dockerfile clones the MicroShift repository from a specific branch (defaulted to 'release-4.13'), allowing for flexible version control.

- The Dockerfile initiates the `./scripts/auto-rebase/rebase.sh` operation directly based on set environment variables. This is a significant change as the logic to perform the rebase operation has been shifted from the `microshift-rebase` script into the Dockerfile. This ensures that the rebase operation is containerized, leading to a more secure and controlled execution.

Overall, these modifications create a more secure and version-controlled workflow for the rebase operations. By relocating the rebase logic into the Dockerfile, the process becomes more hardened, ensuring that it runs in a controlled, containerized environment.