### PR TITLE
[4.13] Revert to no-fips-enforcing-wrapper golang

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,16 +20,16 @@
 ####################################################################################################
 
 golang:
-  # fips_image: openshift/golang-builder:v1.19.10-202306161322.el8.g42c8e14
-  image: openshift/golang-builder:<> # no_fips
+  # fips_wrapper_image: openshift/golang-builder:v1.19.10-202306161322.el8.g42c8e14
+  image: openshift/golang-builder:v1.19.10-202307131621.el8.gba7a391 # no_fips
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
-  # fips_image: openshift/golang-builder:v1.19.10-202306161424.el9.g372eaca
-  image: openshift/golang-builder:<> # no_fips
+  # fips_wrapper_image: openshift/golang-builder:v1.19.10-202306161424.el9.g372eaca
+  image: openshift/golang-builder:v1.19.10-202307131626.el9.g446ea7c # no_fips
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -54,7 +54,7 @@ rhel-9-golang-ci-build-root:
 # approval to diverge from what kube apiserver uses for a given release.
 # https://coreos.slack.com/archives/CB95J6R4N/p1598453188186800?thread_ts=1598449075.172000&cid=CB95J6R4N
 etcd_golang:
-  # fips_image: openshift/golang-builder:v1.16.12-202306121749.el8.g74bd633
+  # fips_wrapper_image: openshift/golang-builder:v1.16.12-202306121749.el8.g74bd633
   image: openshift/golang-builder:v1.16.12-202301042328.el8.g1dbd0ed # no_fips
   mirror: true
   # No transform required as etcd does not yum install any packages.

--- a/streams.yml
+++ b/streams.yml
@@ -20,14 +20,16 @@
 ####################################################################################################
 
 golang:
-  image: openshift/golang-builder:v1.19.10-202306161322.el8.g42c8e14
+  # fips_image: openshift/golang-builder:v1.19.10-202306161322.el8.g42c8e14
+  image: openshift/golang-builder:<> # no_fips
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
-  image: openshift/golang-builder:v1.19.10-202306161424.el9.g372eaca
+  # fips_image: openshift/golang-builder:v1.19.10-202306161424.el9.g372eaca
+  image: openshift/golang-builder:<> # no_fips
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -52,8 +54,8 @@ rhel-9-golang-ci-build-root:
 # approval to diverge from what kube apiserver uses for a given release.
 # https://coreos.slack.com/archives/CB95J6R4N/p1598453188186800?thread_ts=1598449075.172000&cid=CB95J6R4N
 etcd_golang:
-  # openshift-golang-builder-container-v1.16.12-202301042328.el8.g1dbd0ed
-  image: openshift/golang-builder:v1.16.12-202306121749.el8.g74bd633
+  # fips_image: openshift/golang-builder:v1.16.12-202306121749.el8.g74bd633
+  image: openshift/golang-builder:v1.16.12-202301042328.el8.g1dbd0ed # no_fips
   mirror: true
   # No transform required as etcd does not yum install any packages.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.16


### PR DESCRIPTION
slack ref https://redhat-internal.slack.com/archives/CJARLA942/p1689264000855209

[openshift-golang-builder-container-v1.19.10-202307131621.el8.gba7a391](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2592841)
[openshift-golang-builder-container-v1.19.10-202307131626.el9.g446ea7c](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2592843)