### PR TITLE
Updates to MCO 4.13

### DIFF
--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -21,7 +21,7 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-machine-config-operator
 owners:
-- acrawfor@redhat.com
-- imcleod@redhat.com
-- runcom@redhat.com
-- smilner@redhat.com
+- jerzhang@redhat.com
+- jkyros@redhat.com
+- skumari@redhat.com
+- zzlotnik@redhat.com

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -18,7 +18,6 @@ for_payload: true
 from:
   builder:
   - stream: golang
-  - stream: rhel-9-golang
   member: openshift-enterprise-base
 name: openshift/ose-machine-config-operator
 owners:


### PR DESCRIPTION
This reverts commit https://github.com/openshift-eng/ocp-build-data/commit/3282312e60f92f87071c5d0dda01aff802af2c92. The MCO
change was reverted in https://github.com/openshift/machine-config-operator/pull/3802
due to a regression, so update the build here accordingly.

Also cherry-pick in the owners change so the emails gets sent out to the correct MCO members