### PR TITLE
4.14 - Disable ptp operator builds until blocker is resolved

### DIFF
--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled  # Until https://issues.redhat.com/browse/OCPBUGS-16041 is resolved
 arches:
 - x86_64
 - aarch64


### PR DESCRIPTION
ptp operator builds are failing due to known blocker https://issues.redhat.com/browse/OCPBUGS-16041
Which is showing up in various places (images:health, failed ocp4/olm_bundle jobs)
Disable it until blocker is resolved