### PR TITLE
product mapping for openshift-kubernetes-nmstate-handler

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -339,6 +339,8 @@ bug_mapping:
       issue_component: Jenkins
     openshift-kubernetes-nmstate-handler-rhel-8-container:
       issue_component: Networking / kubernetes-nmstate-operator
+    openshift-kubernetes-nmstate-handler:
+      issue_component: Networking / kubernetes-nmstate-operator
     openshift-kuryr:
       issue_component: Networking / kuryr
     openshift-local-storage-container:


### PR DESCRIPTION
Minor update to have bugs like https://issues.redhat.com/browse/OCPBUGS-16361 be automatically routed to the right component.