### PR TITLE
Include rhel-9-golang builder stream in ose-machine-config-operator.yml

### DIFF
--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -29,6 +29,7 @@ for_payload: true
 from:
   builder:
   - stream: golang
+  - stream: rhel-9-golang
   member: openshift-enterprise-base
 name: openshift/ose-machine-config-operator
 owners:


### PR DESCRIPTION
with PR https://github.com/openshift/machine-config-operator/pull/3799 merged, MCO is using rhel-9-golang to build mcd daemon binary for RHEL 9 target