### PR TITLE
[4.6] Add missing build stage to ose-sdn

### DIFF
--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -17,6 +17,7 @@ from:
   builder:
   - stream: golang
   - stream: rhel-7-golang
+  - member: openshift-enterprise-cli
   member: openshift-enterprise-base
 name: openshift/ose-sdn
 owners:


### PR DESCRIPTION
Fixing this error:
```
OSError: Build metadata for openshift/ose-sdn expected 3 image parent(s), but the upstream Dockerfile contains 4 FROM statements. These counts must match
```

Needed after https://github.com/openshift/sdn/commit/ed6c5da1c2b9feeb5bc5a4d0ac5695d14133d293