### PR TITLE
4.9 - Add rhcos primary payload tag

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -71,6 +71,10 @@ dist_git_ignore:
   - gating.yaml
 
 rhcos:
+  payload_tags:
+    - name: machine-os-content
+      build_metadata_key: oscontainer
+      primary: true
   enabled_repos:
   - rhel-8-baseos-rpms
   - rhel-8-appstream-rpms


### PR DESCRIPTION
This will make doozer ensure this key exists in meta.json
and skip builds that don't have it.
Right now it crashes since it doesn't have this info.