### PR TITLE
Change microshift rhel target to just integer

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -29,4 +29,4 @@ owners:
 - microshift-devel@redhat.com
 # This is used by microshift_sync job
 rhel_targets:
-- rhel-9
+- 9


### PR DESCRIPTION
This is making microshift_sync job make "https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp-dev-preview/4.14.0-ec.4/elrhel-9/" dir - and we want `el9`

I looked and rhel_targets looks to be a new key we're introducing, and think it's okay to keep it just an int to simplify parsing