### PR TITLE
More mappings for Cloud Compute / Other Provider

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -454,6 +454,8 @@ bug_mapping:
       issue_component: Cloud Compute / Cloud Controller Manager
     ose-cluster-config-operator-container:
       issue_component: config-operator
+    ose-cluster-control-plane-machine-set-operator-container:
+      issue_component: Cloud Compute / Other Provider
     ose-cluster-csi-snapshot-controller-operator-container:
       issue_component: Storage / Operators
     ose-cluster-dns-operator-container:
@@ -832,7 +834,7 @@ bug_mapping:
       issue_component: Windows Containers
     ose-apiserver-network-proxy-container:
       issue_component: openshift-apiserver
-    ose-gcp-cluster-api-controllers:
+    ose-gcp-cluster-api-controllers-container:
       issue_component: Cloud Compute / Other Provider
     ose-contour-container:
       issue_component: Networking / ovn-kubernetes


### PR DESCRIPTION
Trying to make sure the following bugs are automatically routed to the correct component:

https://issues.redhat.com/browse/OCPBUGS-17288
ose-cluster-control-plane-machine-set-operator-container 
\* I confirmed with the owner that "Cloud Compute / Other Provider" is the correct component

https://issues.redhat.com/browse/OCPBUGS-17290
ose-gcp-cluster-api-controllers-container

The second one was just missing "-container" on the end.