### PR TITLE
[ART-7273] add modifications to support rhel-8-golang-1.17

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -20,6 +20,7 @@ insecure_source: true
 
 # default branch because RPMs can't override (yet)
 branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+default_image_build_method: osbs2
 
 repos:
 

--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -73,3 +73,7 @@ RUN [ $(go env GOARCH) != "amd64" ] || (\
 
 # above is conditional; clean up unconditionally
 RUN rm -f cross.tar.gz
+
+# FOD wrapper modification
+COPY go_wrapper.sh /tmp/go_wrapper.sh
+RUN GO_BIN_PATH=$(which go) && mv $GO_BIN_PATH $GO_BIN_PATH.real && mv /tmp/go_wrapper.sh $GO_BIN_PATH && chmod +x $GO_BIN_PATH

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -7,6 +7,11 @@ content:
       branch:
         target: rhel-8-golang-1.17
       url: git@github.com:openshift/ocp-build-data.git
+    modifications:
+    - action: add
+      doozer_source: golang_builder_FIPS_wrapper.sh
+      path: images/go_wrapper.sh
+      overwriting: true
 enabled_repos:
 - rhel-8-server-ose-build-rpms
 # for clang


### PR DESCRIPTION
add go wrapper during golang build process, the wrapper script will get from https://github.com/openshift-eng/doozer/pull/811
rhel-8-golang-1.17 can built with FoD wrapper and don't update new builder to floating tag for now