### PR TITLE
OCPBUGS-17795: secrets-store-csi-driver-operator should not contain stable channel

### DIFF
--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -26,6 +26,7 @@ owners:
 - aos-storage-staff@redhat.com
 update-csv:
   bundle-dir: 'preview/'
+  channel: preview
   manifests-dir: config/manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-17795
/cc @openshift/storage
