### PR TITLE
4.15 - Remove operator channel stable config

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -23,9 +23,6 @@ multi_arch:
 
 operator_image_ref_mode: manifest-list
 
-# wip see: issues.redhat.com/browse/ART-3107
-operator_channel_stable: default
-
 signing_advisory: 97866
 
 build_profiles:


### PR DESCRIPTION
We started forcing olm operators to have default channel set to `stable` from 4.9+ 
and get operators to switch from 4.Y naming convention to stable. 
Now that all operators (4.14/15) are using the "stable" naming convention,
there are requests to override it (for example: operator in tech preview using preview channel).

So removing this config will let doozer use the `update-csv.channel` as the only channel
in annotations (https://github.com/openshift-eng/doozer/blob/0a73132bc3e97901f0651d99463c47e4e8267b1e/doozerlib/olm/bundle.py#L570)

https://redhat-internal.slack.com/archives/CB95J6R4N/p1692646497373029?thread_ts=1692638515.176259&cid=CB95J6R4N