### PR TITLE
ART-7629: Enable enforce_same_version for kernel tagging

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -81,6 +81,7 @@ rpm_deliveries:
     stop_ship_tag: early-kernel-stop-ship
     ship_ok_tag: early-kernel-ship-ok
     target_tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
+    enforce_same_version: True
 
 branch: rhaos-{MAJOR}.{MINOR}-rhel-8
 name: openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
To enable https://github.com/openshift-eng/art-tools/pull/24/files
Should go after it