### PR TITLE
Revert "4.14 - Pin older consistent driver toolkit image (#3438)"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -247,10 +247,3 @@ releases:
         component: '*'
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: rhcos
-      members:
-        images:
-        - distgit_key: driver-toolkit
-          why: use older consistent driver-toolkit image to unblock 4.14 nightlies
-          metadata:
-            is:
-              nvr: driver-toolkit-container-v4.14.0-202308230726.p0.gcafed17.assembly.stream


### PR DESCRIPTION
This reverts commit 6fc0676ce86914f42b7e400dc357cf2e26f96849.
Reverting this as latest driver-toolkit is good and will not block nightlies