### PR TITLE
Update protoc to match k8s 1.26 and etcd in rhel9 builder to match rhel8

### DIFF
--- a/ci_transforms/rhel-8/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-8/ci-build-root/Dockerfile
@@ -11,7 +11,7 @@ FROM replaced-by-buildconfig
 ENV PATH=/opt/google/protobuf/bin:$PATH
 RUN set -euxo pipefail && \
     f=$( mktemp ) && \
-    curl --fail -L https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip > "${f}" && \
+    curl --fail -L https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip > "${f}" && \
     mkdir -p /opt/google/protobuf && \
     unzip "${f}" -d /opt/google/protobuf && \
     curl --fail -L https://github.com/coreos/etcd/releases/download/v3.5.6/etcd-v3.5.6-linux-amd64.tar.gz | tar -f - -xz --no-same-owner -C /usr/local/bin --strip-components=1 etcd-v3.5.6-linux-amd64/etcd
@@ -52,7 +52,7 @@ RUN mkdir -p $GOPATH && \
 
 # Assert packages in separate RUN block so we are sure env variables are set up correctly
 RUN set -euxo pipefail && \
-    command -v protoc && protoc --version && [ "$( protoc --version )" = "libprotoc 3.19.4" ] && \
+    command -v protoc && protoc --version && [ "$( protoc --version )" = "libprotoc 23.4" ] && \
     command -v etcd && etcd --version && [ "$( etcd --version | head -n1 )" = "etcd Version: 3.5.6" ]
 
 # Some image building tools don't create a missing WORKDIR

--- a/ci_transforms/rhel-9/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-9/ci-build-root/Dockerfile
@@ -9,10 +9,10 @@ FROM replaced-by-buildconfig
 ENV PATH=/opt/google/protobuf/bin:$PATH
 RUN set -euxo pipefail && \
     f=$( mktemp ) && \
-    curl --fail -L http://mirror.openshift.com/pub/openshift-static-ci-deps/protobuf-3.0.0/protoc-3.0.0-linux-x86_64.zip > "${f}" && \
+    curl --fail -L https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip > "${f}" && \
     mkdir -p /opt/google/protobuf && \
     unzip "${f}" -d /opt/google/protobuf && \
-    curl --fail -L https://github.com/coreos/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz | tar -f - -xz --no-same-owner -C /usr/local/bin --strip-components=1 etcd-v3.4.13-linux-amd64/etcd
+    curl --fail -L https://github.com/coreos/etcd/releases/download/v3.5.6/etcd-v3.5.6-linux-amd64.tar.gz | tar -f - -xz --no-same-owner -C /usr/local/bin --strip-components=1 etcd-v3.5.6-linux-amd64/etcd
 
 # Install common CI tools and epel for other devel packages
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
@@ -49,8 +49,8 @@ RUN mkdir -p $GOPATH && \
 
 # Assert packages in separate RUN block so we are sure env variables are set up correctly
 RUN set -euxo pipefail && \
-    command -v protoc && protoc --version && [ "$( protoc --version )" = "libprotoc 3.0.0" ] && \
-    command -v etcd && etcd --version && [ "$( etcd --version | head -n1 )" = "etcd Version: 3.4.13" ]
+    command -v protoc && protoc --version && [ "$( protoc --version )" = "libprotoc 23.4" ] && \
+    command -v etcd && etcd --version && [ "$( etcd --version | head -n1 )" = "etcd Version: 3.5.6" ]
 
 # Some image building tools don't create a missing WORKDIR
 RUN mkdir -p /go/src/github.com/openshift/origin


### PR DESCRIPTION
This matches:
- https://github.com/kubernetes/kubernetes/blob/release-1.26/hack/lib/etcd.sh#L19
- https://github.com/kubernetes/kubernetes/blob/release-1.26/hack/lib/protoc.sh#L43

/assign @jupierce @bertinatto