### PR TITLE
Update protoc to match k8s 1.27

### DIFF
--- a/ci_transforms/rhel-8/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-8/ci-build-root/Dockerfile
@@ -12,7 +12,7 @@ FROM replaced-by-buildconfig
 ENV PATH=/opt/google/protobuf/bin:$PATH
 RUN set -euxo pipefail && \
     f=$( mktemp ) && \
-    curl --fail -L https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip > "${f}" && \
+    curl --fail -L https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip > "${f}" && \
     mkdir -p /opt/google/protobuf && \
     unzip "${f}" -d /opt/google/protobuf && \
     curl --fail -L https://github.com/coreos/etcd/releases/download/v3.5.7/etcd-v3.5.7-linux-amd64.tar.gz | tar -f - -xz --no-same-owner -C /usr/local/bin --strip-components=1 etcd-v3.5.7-linux-amd64/etcd
@@ -53,7 +53,7 @@ RUN mkdir -p $GOPATH && \
 
 # Assert packages in separate RUN block so we are sure env variables are set up correctly
 RUN set -euxo pipefail && \
-    command -v protoc && protoc --version && [ "$( protoc --version )" = "libprotoc 3.19.4" ] && \
+    command -v protoc && protoc --version && [ "$( protoc --version )" = "libprotoc 23.4" ] && \
     command -v etcd && etcd --version && [ "$( etcd --version | head -n1 )" = "etcd Version: 3.5.7" ]
 
 # Some image building tools don't create a missing WORKDIR

--- a/ci_transforms/rhel-9/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-9/ci-build-root/Dockerfile
@@ -12,7 +12,7 @@ FROM replaced-by-buildconfig
 ENV PATH=/opt/google/protobuf/bin:$PATH
 RUN set -euxo pipefail && \
     f=$( mktemp ) && \
-    curl --fail -L https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip > "${f}" && \
+    curl --fail -L https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip > "${f}" && \
     mkdir -p /opt/google/protobuf && \
     unzip "${f}" -d /opt/google/protobuf && \
     curl --fail -L https://github.com/coreos/etcd/releases/download/v3.5.7/etcd-v3.5.7-linux-amd64.tar.gz | tar -f - -xz --no-same-owner -C /usr/local/bin --strip-components=1 etcd-v3.5.7-linux-amd64/etcd
@@ -52,7 +52,7 @@ RUN mkdir -p $GOPATH && \
 
 # Assert packages in separate RUN block so we are sure env variables are set up correctly
 RUN set -euxo pipefail && \
-    command -v protoc && protoc --version && [ "$( protoc --version )" = "libprotoc 3.19.4" ] && \
+    command -v protoc && protoc --version && [ "$( protoc --version )" = "libprotoc 23.4" ] && \
     command -v etcd && etcd --version && [ "$( etcd --version | head -n1 )" = "etcd Version: 3.5.7" ]
 
 # Some image building tools don't create a missing WORKDIR


### PR DESCRIPTION
This matches:
- https://github.com/kubernetes/kubernetes/blob/release-1.27/hack/lib/etcd.sh#L19
- https://github.com/kubernetes/kubernetes/blob/release-1.27/hack/lib/protoc.sh#L28

/assign @jupierce @bertinatto