### PR TITLE
OCP-4.14-linkfix: updates links for 4.14 docs url move

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -65,7 +65,7 @@ solution: |
   (For aarch64 architecture)
   The image digest is sha256:<SHASUM_HERE>
 
-  All OpenShift Container Platform 4.14 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.14/updating/updating-cluster-cli.html
+  All OpenShift Container Platform 4.14 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at  https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating-cluster-cli.html
 
 topic: "Red Hat OpenShift Container Platform release 4.14.z is now available with updates to packages and images that fix several bugs and add enhancements."
 
@@ -82,13 +82,13 @@ boilerplates:
 
       <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
 
-      All OpenShift Container Platform 4.14 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.14/updating/updating-cluster-cli.html
+      All OpenShift Container Platform 4.14 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating-cluster-cli.html
     solution: &common_solution |
       See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
       https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html
 
-      Details on how to access this content are available at https://docs.openshift.com/container-platform/4.14/updating/updating-cluster-cli.html
+      Details on how to access this content are available at https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating-cluster-cli.html
   image:
     synopsis: "OpenShift Container Platform 4.14.z bug fix update"
     topic: *common_topic
@@ -124,7 +124,7 @@ boilerplates:
       (For aarch64 architecture)
       The image digest is sha256:<SHASUM_HERE>
 
-      All OpenShift Container Platform 4.14 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.14/updating/updating-cluster-cli.html
+      All OpenShift Container Platform 4.14 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating-cluster-cli.html
   extras:
     synopsis: OpenShift Container Platform 4.14.z extras update
     topic: *common_topic
@@ -142,7 +142,7 @@ boilerplates:
 
       This advisory will be used to release the corresponding Operator manifests via new Operator metadata containers.
 
-      All OpenShift Container Platform 4.14 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.14/updating/updating-cluster-cli.html
+      All OpenShift Container Platform 4.14 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating-cluster-cli.html
     solution: *common_solution
   microshift:
     synopsis: "Red Hat build of MicroShift 4.14.z bug fix and enhancement update"
@@ -171,6 +171,8 @@ boilerplates:
     synopsis: OpenShift Container Platform 4.14.z security update
     topic: |
       Red Hat OpenShift Container Platform release 4.14.z is now available with updates to packages and images that fix several bugs and add enhancements.
+
+      This release includes a security update for Red Hat OpenShift Container Platform 4.14.
 
       Red Hat Product Security has rated this update as having a security impact of {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
     description: |


### PR DESCRIPTION
This PR is from the core OCP docs writers. It updates a URL change for our updating link in the errata. 

@thiagoalessio PTAL

cc: @dfitzmau @cbippley

Issue:
https://issues.redhat.com/browse/OSDOCS-6742