### PR TITLE
Update network-tools container image to refer to new JIRA component

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -691,7 +691,7 @@ bug_mapping:
     ose-network-metrics-daemon-container:
       issue_component: Networking / multus
     ose-network-tools-container:
-      issue_component: Networking / openshift-sdn
+      issue_component: Networking / network-tools
     ose-node-container:
       issue_component: Networking / openshift-sdn
     ose-nutanix-cloud-controller-manager-container:


### PR DESCRIPTION
We created a new component "Networking / network-tools" to classify bugs created for the network-tools repository. This commit updates the image to refer to this new component.