### PR TITLE
sriov-cni: Fix rhel9 image name in operator

### DIFF
--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -24,6 +24,7 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
-name: openshift/ose-sriov-cni
+name: openshift/ose-sriov-cni-rhel9
+name_in_bundle: sriov-cni
 owners:
 - zshi@redhat.com


### PR DESCRIPTION
This should resolve to rhel9 repo https://comet.engineering.redhat.com/containers/repositories/650022db8f57a98d4e3ee969

...and keep current image references intact.