### PR TITLE
Mark 3.11 as EOL

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -183,3 +183,6 @@ image_build_log_scanner:
   - ppc64le.log
   - task_failed.log
   - orchestrator.log
+
+software_lifecycle:
+  phase: eol


### PR DESCRIPTION
By marking 3.11 as `eol` instead of `release`, we will keep signing artifacts but skip jobs like `check-bugs`, `nag-upstream` and the like that can produce undesired spam in private and public channels