### PR TITLE
[ART-5526] publish 4.13 operators in 4.14+ index

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -22,9 +22,9 @@ multi_arch:
   enabled: true
 
 operator_image_ref_mode: manifest-list
-
-# wip see: issues.redhat.com/browse/ART-3107
 operator_channel_stable: default
+# see: https://issues.redhat.com/browse/ART-5526 - REMOVE before 4.14 is GA
+operator_index_mode: ga-plus
 
 signing_advisory: 97866
 


### PR DESCRIPTION
This will make the standard operators available in OperatorHub for 4.14+ public indexes, although only the latest GA version. This is intended for use cases involving testing operator management mechanisms, without too much concern for the operators themselves.