### PR TITLE
pin ose-secrets-store-csi-mustgather

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -18,7 +18,12 @@ releases:
         release_jira: ART-7691
         upgrades: 4.13.7,4.13.8,4.13.9,4.13.10,4.13.11,4.13.12,4.13.13,4.14.0-ec.0,4.14.0-ec.1,4.14.0-ec.2,4.14.0-ec.3,4.14.0-ec.4,4.14.0-rc.0
       members:
-        images: []
+        images:
+          - distgit_key: ose-secrets-store-csi-mustgather
+            why: Image added after nightly was created
+            metadata:
+              is:
+                nvr: ose-secrets-store-csi-mustgather-container-v4.14.0-202309151627.p0.gb25492f.assembly.stream
         rpms: []
       rhcos:
         machine-os-content:


### PR DESCRIPTION
Image was added to ocp-build-data after nightly for RC was created so that we can unblock prepare release which is looking for this build for rc.1