### PR TITLE
Updates `ci_alignment` for OLM components

### DIFF
--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/operator-framework-catalogd
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 dependents:

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/operator-framework-operator-controller
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 dependents:

--- a/images/ose-olm-rukpak.yml
+++ b/images/ose-olm-rukpak.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/operator-framework-rukpak
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 distgit:


### PR DESCRIPTION
We need to use `commit_prefix` to comply with `commitchecker` validations.