### PR TITLE
Add prefix to automatic PR in storage repos

### DIFF
--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -11,6 +11,7 @@ content:
       web: https://github.com/openshift/azure-file-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/csi-external-attacher
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/csi-livenessprobe
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/csi-node-driver-registrar
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/csi-external-provisioner
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/csi-snapshot-validation-webhook.yml
+++ b/images/csi-snapshot-validation-webhook.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/csi-external-snapshotter
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ibm-vpc-node-label-updater.yml
+++ b/images/ibm-vpc-node-label-updater.yml
@@ -11,6 +11,7 @@ content:
       web: https://github.com/openshift/ibm-vpc-node-label-updater
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-alibaba-cloud-csi-driver.yml
+++ b/images/ose-alibaba-cloud-csi-driver.yml
@@ -10,6 +10,7 @@ content:
       web: https://github.com/openshift/alibaba-cloud-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -11,6 +11,7 @@ content:
       web: https://github.com/openshift/aws-ebs-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -11,6 +11,7 @@ content:
       web: https://github.com/openshift/aws-efs-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -11,6 +11,7 @@ content:
       web: https://github.com/openshift/azure-disk-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/csi-external-resizer
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-csi-external-snapshotter.yml
+++ b/images/ose-csi-external-snapshotter.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/csi-external-snapshotter
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-csi-snapshot-controller.yml
+++ b/images/ose-csi-snapshot-controller.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/csi-external-snapshotter
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -9,7 +9,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/gcp-filestore-csi-driver.git
-      web: https://github.com/openshift/gcp-filestore-csi-driver.git
+      web: https://github.com/openshift/gcp-filestore-csi-driver
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -12,6 +12,7 @@ content:
       web: https://github.com/openshift/gcp-filestore-csi-driver.git
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -12,6 +12,7 @@ content:
       web: https://github.com/openshift/gcp-pd-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -11,6 +11,7 @@ content:
       web: https://github.com/openshift/ibm-vpc-block-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/secrets-store-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 dependents:

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -10,6 +10,7 @@ content:
       web: https://github.com/openshift/vmware-vsphere-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/vmware-vsphere-syncer.yml
+++ b/images/vmware-vsphere-syncer.yml
@@ -10,6 +10,7 @@ content:
       web: https://github.com/openshift/vmware-vsphere-csi-driver
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:


### PR DESCRIPTION
Add `"UPSTREAM: <carry>:"` to forks of upstream CSI drivers, CSI sidecars and similar storage repos.