### PR TITLE
Add auto-lgtm to new storage repos

### DIFF
--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -10,6 +10,9 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
+        auto_label:
+        - approved
+        - lgtm
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -11,6 +11,9 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
+        auto_label:
+        - approved
+        - lgtm
 dependents:
 - ose-secrets-store-csi-driver-operator
 name_in_bundle: secrets-store-csi-driver-container-rhel8


### PR DESCRIPTION
ose-secrets-store-csi-driver and ose-secrets-store-csi-driver-operator are relatively new storage team repos and we'd like auto-lgtm + auto-approve on base image / go version changes.