### PR TITLE
rhel9 builds should happen in rhel9 branches/tags

### DIFF
--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -13,6 +13,7 @@ content:
 distgit:
   component: ose-kubernetes-nmstate-operator-container
   bundle_component: ose-kubernetes-nmstate-operator-bundle-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -10,6 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms


### PR DESCRIPTION
when building something for rhel9, should have rhel9 branch; this causes it to build against the rhel9 tag, which when attached to errata is associated with rhel9 CDN repo.

/cherry-pick openshift-4.15