### PR TITLE
4.14 GA - Add reasons for why some ocpbugs have wrong pscomponents

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -22,14 +22,14 @@ releases:
         # investigate why they are missing component builds in advisories
         # No builds found for CVE (bug, package): [(OCPBUGS-14709, ovn23.03), (OCPBUGS-12610, ose-haproxy-router-base-container), (OCPBUGS-12516, local-storage-static-provisioner-container), (OCPBUGS-13699, python-flask), (OCPBUGS-15089, kubernetes), (OCPBUGS-17316, atomic-openshift-service-idler), (OCPBUGS-8379, python-werkzeug), (OCPBUGS-12596, ose-contour-container)]
         exclude:
-        - id: OCPBUGS-14709
-        - id: OCPBUGS-12610
-        - id: OCPBUGS-12516
-        - id: OCPBUGS-13699
-        - id: OCPBUGS-15089
-        - id: OCPBUGS-17316
-        - id: OCPBUGS-8379
-        - id: OCPBUGS-12596
+        - id: OCPBUGS-14709 # ship: pscomponent should be ovn23.09
+        - id: OCPBUGS-12610 # ship: bug/pscomponent is for base image which we don't ship
+        - id: OCPBUGS-12516 # don't ship: we do not build local-storage-static-provisioner-container
+        - id: OCPBUGS-13699 # ship: bug is for ironic-container but pscomponent is for python-flask which did not get rebuilt
+        - id: OCPBUGS-15089 # don't ship: we do not build / there is no such thing as kubernetes-container
+        - id: OCPBUGS-17316 # don't ship: we removed this image from 4.14
+        - id: OCPBUGS-8379  # ship: bug is for ironic-agent-container but pscomponent is for python-werkzeug which did not get rebuilt
+        - id: OCPBUGS-12596 # don't ship: we do not build ose-contour-container since 4.13
       members:
         images:
         - distgit_key: ose-secrets-store-csi-mustgather


### PR DESCRIPTION
Investigate bugs that have pscomponent package that do not have a corresponding build in any of our advisories.
We want to ship some of these, indicate that as well.