### PR TITLE
cvo: label alignment PRs with `qe-approved`

### DIFF
--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -15,6 +15,7 @@ content:
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - qe-approved
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:


### PR DESCRIPTION
Having `qe-approved` allows linked OCPBUGS cards to automatically move to `VERIFIED` once the PR merges and is included in a subsequent green nightly.

4.15 PRs were already filed, I assume the `openshift-4.16` branch will be populated from `openshift-4.15`.