### PR TITLE
[4.14] Make image label bool into string

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -438,5 +438,5 @@ releases:
           why: ART-7318 make everything ship to prerelease tags for now
           metadata:
             labels:
-              com.redhat.prerelease: true
+              com.redhat.prerelease: "true"
 


### PR DESCRIPTION
follow up from https://github.com/openshift-eng/ocp-build-data/pull/3560 
doozer doesn't like bools as image labels 
This is blocking all 4.14 rebase & builds right now