### PR TITLE
Experiment assert same openssl

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -68,6 +68,8 @@ rhcos:
     driver-toolkit:
     - kernel
     - kernel-rt
+    ose-etcd:
+    - openssl
   # To allow CentOS content, set to true
   allow_missing_brew_rpms: false
 


### PR DESCRIPTION
We need to assert that some images have artifacts compiled on the same rhel version as rhcos. This is an experiment to assert in a lightweight way that the openssl version of the resulting image is the same as rhcos. It makes use of a mechanism that was developed for assertions about driver-toolkit and rhcos kernel and kernel-rt versions.

etcd moved to rhel9 as its base image after 4.13 GA. Test runs with this patch:

```
doozer \
  --data-path $(pwd) \
  --group openshift-4.13 \
  --images ose-etcd,openshift-enterprise-pod \
  --assembly 4.13.6 \
  release:gen-payload \
  --moist-run
...
ose-etcd:
- code: FAILED_CONSISTENCY_REQUIREMENT
  msg: RHCOS and 'ose-etcd' should use the same build of package 'openssl', but
    RHCOSBuild:x86_64:413.92.202307182034-0 has openssl-3.0.7-16.el9_2 and ose-etcd-container-v4.13.0-202307170916.p0.gf70da9d.assembly.stream
    has openssl-1.1.1k-9.el8_6
  permitted: false
```

The same but with `--assembly 4.13.14` does not complain.

So, is this useful in the context of ART-7850? Yes, but this is not complete:
- This only looks at the last layer. For some images, a rhel9 artifact is compiled only in a single build layer, and gets put in a rhel8 image.
- This asserts that the rhel9 minor version is the same between RHCOS and images.