### PR TITLE
Rename openstack-machine-controllers to openstack-cluster-api-controllers

### DIFF
--- a/images/ose-openstack-cluster-api-controllers.yml
+++ b/images/ose-openstack-cluster-api-controllers.yml
@@ -18,6 +18,6 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-openstack-machine-controllers
+name: openshift/ose-openstack-cluster-api-controllers
 owners:
 - shiftstack-team@redhat.com


### PR DESCRIPTION
This repository is no longer a Machine API actuator. That role is now fulfilled by `ose-machine-api-provider-openstack`. This repository now hosts an upstream CAPI provider and should be named consistently with:

* ose-aws-cluster-api-controllers.yml
* ose-azure-cluster-api-controllers.yml
* ose-gcp-cluster-api-controllers.yml
* ose-ibmcloud-cluster-api-controllers.yml
* ose-vsphere-cluster-api-controllers.yml

image name updated in https://github.com/openshift/release/pull/43897

/hold