### PR TITLE
stream: no longer needs prerelease tags on everything

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -538,11 +538,3 @@ releases:
         component: '*'
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: rhcos
-      members:
-        images:
-        - distgit_key: '*'
-          why: ART-7318 make everything ship to prerelease tags for now
-          metadata:
-            labels:
-              com.redhat.prerelease: "true"
-


### PR DESCRIPTION
added these for a workaround in ART-7318, but no longer needed.
this will trigger a full rebuild, and it's not especially urgent, so bundle with something else that triggers a rebuild.