### PR TITLE
ART-7894 move openshift-enterprise-pod to rhel9 in 4.15

### DIFF
--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -10,11 +10,13 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-codeready-builder-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-codeready-builder-rpms
 for_payload: true
 from:
   builder:
@@ -31,6 +33,6 @@ labels:
   vendor: Red Hat
 name: openshift/ose-pod
 non_shipping_repos:
-- rhel-8-codeready-builder-rpms
+- rhel-9-codeready-builder-rpms
 owners:
 - aos-pod@redhat.com


### PR DESCRIPTION
re https://issues.redhat.com/browse/ART-7894
upstream changed to rhel9 https://github.com/openshift/kubernetes/blob/release-4.15/build/pause/Dockerfile.Rhel#L1
test build success https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=56052752