### PR TITLE
ART-7894 don't update ci build root for openshift-enterprise-pod in 4.14

### DIFF
--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -7,10 +7,6 @@ content:
       url: git@github.com:openshift-priv/kubernetes.git
       web: https://github.com/openshift/kubernetes
     path: build/pause
-    ci_alignment:
-      streams_prs:
-        ci_build_root:
-          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
re https://issues.redhat.com/browse/ART-7894
openshift-enterprise-pod in 4.14 ci is using rhel9