### PR TITLE
Re-enable ose-cluster-kube-descheduler-operator

### DIFF
--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -10,9 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
-# [asdas] Disabled until upstream 4.15 config is defined in stable dir
-#dependents:
-#- ose-cluster-kube-descheduler-operator
+dependents:
+- ose-cluster-kube-descheduler-operator
 enabled_repos:
 - rhel-8-appstream-rpms
 - rhel-8-baseos-rpms

--- a/images/ose-cluster-kube-descheduler-operator.yml
+++ b/images/ose-cluster-kube-descheduler-operator.yml
@@ -1,5 +1,3 @@
-# [asdas] Disabling until upstream adds 4.15 configs to stable dir
-mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
Following upstream [bump](https://github.com/openshift/cluster-kube-descheduler-operator/pull/304) for 4.15

[Tested](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/47734), build started normally.

_PR ready to merge. Requesting lgtm and approve_