### PR TITLE
[4.14] build GA operator bundles

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -22,7 +22,7 @@ multi_arch:
   enabled: true
 
 operator_image_ref_mode: manifest-list
-operator_index_mode: pre-release
+operator_index_mode: ga-plus
 
 signing_advisory: 97866
 


### PR DESCRIPTION
We won't have another operator pre-release for 4.14.

PR is ready for review and merge. Requesting lgtm 