### PR TITLE
group.yml: end bundle drift from 4.13

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -23,8 +23,7 @@ multi_arch:
 
 operator_image_ref_mode: manifest-list
 operator_channel_stable: default
-# see: https://issues.redhat.com/browse/ART-5526 - REMOVE before 4.14 is GA
-operator_index_mode: ga-plus
+operator_index_mode: ga
 
 signing_advisory: 97866
 


### PR DESCRIPTION
with 4.14 GA imminent, stop publishing 4.13 bundles to 4.14 indexes.