### PR TITLE
[4.15] group: only do bundle pre-release on demand

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -28,7 +28,7 @@ multi_arch:
   enabled: true
 
 operator_image_ref_mode: manifest-list
-operator_index_mode: pre-release
+operator_index_mode: ga-plus
 
 signing_advisory: 97866
 


### PR DESCRIPTION
I have a new strategy for pre-releases, which is to just rebuild the bundles that are going to be pre-released. The rest of the time it makes sense to build them as normal. This way we don't have to remember to switch the setting at the right time.