### PR TITLE
Move aws-ebs-csi-driver-operator from its own repo to csi-operator

### DIFF
--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -3,12 +3,12 @@ arches:
 - aarch64
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile.aws-ebs
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/aws-ebs-csi-driver-operator.git
-      web: https://github.com/openshift/aws-ebs-csi-driver-operator
+      url: git@github.com:openshift-priv/csi-operator.git
+      web: https://github.com/openshift/csi-operator
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
OCP storage team is merging all CSI driver operators into a single repo, github.com/openshift/csi-operator.

AWS EBS CSI driver operator is the first one. All code is already in https://github.com/openshift/csi-operator + there is Dockerfile.aws-ebs there.

The resulting image has the same binary as before, just built from a different source repo. No image is renamed.

Details: https://github.com/openshift/enhancements/blob/master/enhancements/storage/csi-driver-operator-merge.md#building-and-shipping-the-operators

Explicitly, we keep WORKDIR of the new  [Dockerfile.aws-ebs](https://github.com/openshift/csi-operator/blob/5cc6a6b66ff3b773996ee68adc948e14377fff2c/Dockerfile.aws-ebs#L2)  the same as the old  [Dockerfile.rhel7](https://github.com/openshift/aws-ebs-csi-driver-operator/blob/9f6f8a06dea31fb3b1bed748622c8b60bc806965/Dockerfile.rhel7#L2), for cachito to work. See discussion in the enhancement review : https://github.com/openshift/enhancements/pull/1471#discussion_r1335701658
