### PR TITLE
4.10: Build on x86_64 exclusively

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -14,9 +14,6 @@ compliance:
 
 arches:
 - x86_64
-- ppc64le
-- s390x
-- aarch64
 
 operator_image_ref_mode: manifest-list
 


### PR DESCRIPTION
The e4s repositories do not get updated for all arches. Preferring building x86_64 over not building at all.