### PR TITLE
ART-7949 - 4.13 - Bump golang builder

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 ####################################################################################################
 
 golang:
-  image: openshift/golang-builder:v1.19.10-202307181602.el8.g71f6585
+  image: openshift/golang-builder:v1.19.13-202310161907.el8.g0d095f7
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -30,7 +30,7 @@ golang:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
-  image: openshift/golang-builder:v1.19.10-202307181602.el9.g305872d
+  image: openshift/golang-builder:v1.19.13-202310161903.el9.g0f9bb4c
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -54,7 +54,7 @@ rhel-9-golang-ci-build-root:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 etcd_rhel9_golang:
-  image: openshift/golang-builder:v1.19.10-202307181602.el9.g305872d
+  image: openshift/golang-builder:v1.19.13-202310161903.el9.g0f9bb4c
   mirror: false
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-7949
Use new builders
- [openshift-golang-builder-container-v1.19.13-202310161903.el9.g0f9bb4c](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726876)
- [openshift-golang-builder-container-v1.19.13-202310161907.el8.g0d095f7](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726878)