### PR TITLE
ART-7947 - 4.11 - Bump golang builders

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 ####################################################################################################
 
 golang:
-  image: openshift/golang-builder:v1.18.10-202306261728.el8.g598816d
+  image: openshift/golang-builder:v1.18.10-202310162029.el8.gacd8ae5
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}.art
@@ -42,7 +42,7 @@ rhel-8-golang-ci-build-root:
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.
 etcd_golang:
-  image: openshift/golang-builder:v1.19.10-202306161322.el8.g42c8e14
+  image: openshift/golang-builder:v1.19.13-202310161907.el8.g0d095f7
   mirror: false
   # No transform required as etcd does not yum install any packages.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.19


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-7947

- [openshift-golang-builder-container-v1.18.10-202310162029.el8.gacd8ae5](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726966)
- [openshift-golang-builder-container-v1.19.13-202310161907.el8.g0d095f7](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726878)