### PR TITLE
ART-7950 - 4.14 - Bump golang builders

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 ####################################################################################################
 
 golang-1.19:
-  image: openshift/golang-builder:v1.19.10-202307181602.el8.g71f6585
+  image: openshift/golang-builder:v1.19.13-202310161907.el8.g0d095f7
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -31,7 +31,7 @@ golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 golang:
-  image: openshift/golang-builder:v1.20.5-202307110617.el8.gdffc5fc
+  image: openshift/golang-builder:v1.20.10-202310161945.el8.gdc4b478
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -42,7 +42,7 @@ golang:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.19:
-  image: openshift/golang-builder:v1.19.10-202307181602.el9.g305872d
+  image: openshift/golang-builder:v1.19.13-202310161903.el9.g0f9bb4c
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -53,7 +53,7 @@ rhel-9-golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
-  image: openshift/golang-builder:v1.20.5-202307110553.el9.g7ec82b2
+  image: openshift/golang-builder:v1.20.10-202310161945.el9.gbbb66ea
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -115,7 +115,7 @@ etcd_golang:
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.
 etcd_golang-1.19:
-  image: openshift/golang-builder:v1.19.10-202306161322.el8.g42c8e14
+  image: openshift/golang-builder:v1.19.13-202310161907.el8.g0d095f7
   mirror: false
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -126,7 +126,7 @@ etcd_golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-etcd-golang-1.19
 
 etcd_rhel9_golang:
-  image: openshift/golang-builder:v1.19.10-202307181602.el9.g305872d
+  image: openshift/golang-builder:v1.19.13-202310161903.el9.g0f9bb4c
   mirror: false
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-7950

- [openshift-golang-builder-container-v1.20.10-202310161945.el8.gdc4b478](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726932)
- [openshift-golang-builder-container-v1.20.10-202310161945.el9.gbbb66ea](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726933)
- [openshift-golang-builder-container-v1.19.13-202310161903.el9.g0f9bb4c](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726876)
- [openshift-golang-builder-container-v1.19.13-202310161907.el8.g0d095f7](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726878)