### PR TITLE
Fix ose-apiserver-network-proxy branch

### DIFF
--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: master
+        target: release-4.14
       url: git@github.com:openshift-priv/apiserver-network-proxy.git
       web: https://github.com/openshift/apiserver-network-proxy
     ci_alignment:


### PR DESCRIPTION
Point to 4.14 for all releases till 4.14