### PR TITLE
ART-7991 Bump nodejs to 18

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -181,6 +181,6 @@ rhel9:
   mirror: true
 
 nodejs:
-  image: ubi8/nodejs-16:1-82.1675799501
+  image: ubi8/nodejs-18:1-71.1697671458
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true


### PR DESCRIPTION
Currently, these components build on top of nodejs:
- console
- monitoring-plugin
- nmstate-console-plugin

The console uses `openshift-base-nodejs` member as its last build stage: a test run has been build successfully: [openshift-enterprise-console-container-v4.15.0-202310201407.p0.g2b34cb0.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2740005)

`monitoring-plugin` and `nmstate-console-plugin` build from `nodejs` stream, that is mirrored  to `registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs-base-4.15.art`. Since this does not happen for `test` assemblies, their builds have been tested by replacing `- stream: nodejs` with `- member: openshift-base-nodejs`. This led to:
- [monitoring-plugin-container-v4.15.0-202310230802.p0.gfc4303c.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2744834)
- [nmstate-console-plugin-container-v4.15.0-202310230908.p0.g9489088.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2744930)