### PR TITLE
Define arches for mucroshift rpm to be synced

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -1,5 +1,9 @@
 # Disable automated build because it is intended to be built after a release is promoted.
 mode: disabled
+# This field won't restrict building arches; it will only determine what arches will be published on mirror
+arches:
+- x86_64
+- aarch64
 content:
   source:
     git:


### PR DESCRIPTION
To fix `ERROR: No arches configured.` as in https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fmicroshift_sync/38/console