### PR TITLE
descheduler[-operator]: bump rhel version to rhel9

### DIFF
--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -9,17 +9,17 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 dependents:
 - ose-cluster-kube-descheduler-operator
 enabled_repos:
-- rhel-8-appstream-rpms
-- rhel-8-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-base-rhel8
+  - stream: rhel-9-golang
+  member: openshift-base-rhel9
 labels:
   License: GPLv2+
   io.k8s.description: Descheduler for Opensift and Kubernetes
@@ -28,5 +28,5 @@ labels:
   vendor: Red Hat
 name: openshift/ose-descheduler
 owners:
-- rgudimet@redhat.com
+- jchaloup@redhat.com
 - aos-workloads@redhat.com

--- a/images/ose-cluster-kube-descheduler-operator.yml
+++ b/images/ose-cluster-kube-descheduler-operator.yml
@@ -9,15 +9,15 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-kube-descheduler-operator
 owners:
 - jchaloup@redhat.com


### PR DESCRIPTION
In parallel with https://github.com/openshift/cluster-kube-descheduler-operator/pull/311 and https://github.com/openshift/descheduler/pull/97