### PR TITLE
add cluster-config-api component mapping

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -488,6 +488,8 @@ bug_mapping:
       issue_component: Cloud Compute / Other Provider
     ose-cluster-cloud-controller-manager-operator-container:
       issue_component: Cloud Compute / Cloud Controller Manager
+    ose-cluster-config-api-container:
+      issue_component: config-operator
     ose-cluster-config-operator-container:
       issue_component: config-operator
     ose-cluster-control-plane-machine-set-operator-container:


### PR DESCRIPTION
Adding the new cluster-config-api image, following directions here: https://source.redhat.com/groups/public/openshift/openshift_wiki/guidelines_for_requesting_new_content_managed_by_ocp_art