### PR TITLE
ART-7727 move ose-metallb to RHEL9

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   member: openshift-base-rhel9
 name: openshift/frr-rhel9
-name_in_bundle: metallb-frr-rhel8
+name_in_bundle: metallb-frr-rhel9
 owners:
 - metallb-dev@redhat.com
 non_shipping_repos:

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -9,16 +9,17 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
   bundle_component: ose-metallb-operator-bundle-container
-name: openshift/metallb-rhel8-operator
-name_in_bundle: metallb-rhel8-operator # matches exactly the name in image-references
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+name: openshift/metallb-rhel9-operator
+name_in_bundle: metallb-rhel9-operator # matches exactly the name in image-references
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-base-rhel8
+  - stream: rhel-9-golang
+  member: openshift-base-rhel9
 owners:
 - metallb-dev@redhat.com
 update-csv:

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -9,15 +9,17 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 dependents:
 - ose-metallb-operator
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-base-rhel8
-name: openshift/metallb-rhel8
-name_in_bundle: metallb-rhel8
+  - stream: rhel-9-golang
+  member: openshift-base-rhel9
+name: openshift/metallb-rhel9
+name_in_bundle: metallb-rhel9
 owners:
 - metallb-dev@redhat.com


### PR DESCRIPTION
test build: [ose-metallb-container-v4.15.0-202310240847.p0.ge3846ec.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2747316)
[ose-metallb-operator-container-v4.15.0-202310240847.p0.g7a0395f.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2747314)

depends on https://github.com/openshift/metallb-operator/pull/190