### PR TITLE
Remove redundant advisories field

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -31,9 +31,6 @@ releases:
             non_gc_tag: rhaos-4.14-rhel9
             el9: crun-1.11-1.rhaos4.14.el9
             el8: crun-1.11-1.rhaos4.14.el8
-        advisories:
-          rpm: 123024
-          image: 123025
       rhcos:
         machine-os-content:
           images:


### PR DESCRIPTION
We overrode advisories at https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.14/releases.yml#L19