### PR TITLE
revert #3722 'disable operators until fixed' due to fixing

### DIFF
--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled  # ART-7960 disable until CSV is valid
 content:
   source:
     dockerfile: Dockerfile

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -12,7 +12,7 @@ content:
           stream: rhel-8-golang-ci-build-root
 dependents:
 - ptp-operator
-# - cluster-nfd-operator  # ART-7960 disable until CSV is valid
+- cluster-nfd-operator
 # - dpu-network-operator  # ART-7960 disable until CSV is valid
 - ose-aws-efs-csi-driver-operator
 - ose-metallb-operator

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -10,8 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
-# dependents:
-# - cluster-nfd-operator  # ART-7960 disable until CSV is valid
+dependents:
+- cluster-nfd-operator  # ART-7960 disable until CSV is valid
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
OCPBUGS-21904 reports cluster-nfd-operator is disabled in 4.15 awaiting fixes. These changes have now been made and this PR re-enables building