### PR TITLE
ART-8110 Bump golang for 4.9

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -28,8 +28,7 @@ rhel-7-ci-build-root:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-7-release-openshift-{MAJOR}.{MINOR}
 
 golang:
-  # openshift-golang-builder-container-v1.16.12-202208011952.el8.g58dffad
-  image: openshift/golang-builder:v1.16.12-202306231227.el8.g7bb6f69
+  image: openshift/golang-builder:v1.16.12-202310201409.el8.g1370b35
   # Disable mirroring and transform until art6883 is complete.
   mirror: false
   # transform: rhel-8/golang
@@ -52,7 +51,7 @@ rhel-8-golang-ci-build-root:
 # approval to diverge from what kube apiserver uses for a given release.
 # https://coreos.slack.com/archives/CB95J6R4N/p1598453188186800?thread_ts=1598449075.172000&cid=CB95J6R4N
 etcd_golang:
-  image: openshift/golang-builder:v1.16.12-202306231227.el8.g7bb6f69
+  image: openshift/golang-builder:v1.16.12-202310201409.el8.g1370b35
   # Disable mirroring and transform until art6883 is complete.
   mirror: false
   # No transform required as etcd does not yum install any packages.
@@ -61,7 +60,7 @@ etcd_golang:
 
 # This image must only be used by -alt images, as this image cannot be built for aarch64.
 rhel-7-golang:
-  image: openshift/golang-builder:v1.16.12-202306231323.el7.g3708627
+  image: openshift/golang-builder:v1.16.12-202310311649.el7.g5db8891
   # Disable mirroring and transform until art6883 is complete.
   mirror: false
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.16-openshift-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-8110

Builder nvrs
- [openshift-golang-builder-container-v1.16.12-202310311649.el7.g5db8891](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2759456)
- [openshift-golang-builder-container-v1.16.12-202310201409.el8.g1370b35](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2739965)