### PR TITLE
Revert "Disable early kernel tagging for 4.13"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -74,15 +74,14 @@ default_image_build_profile: unsigned
 default_rpm_build_profile: default
 
 # rpm_deliveries is mainly to support for "Weekly" kernel delivery through OCP (ART-6100)
-# Disabled until 4.14 GA
-# rpm_deliveries:
-#   - packages:
-#       - kernel
-#       - kernel-rt
-#     integration_tag: early-kernel-integration-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}
-#     stop_ship_tag: early-kernel-stop-ship
-#     ship_ok_tag: early-kernel-ship-ok
-#     target_tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
+rpm_deliveries:
+  - packages:
+      - kernel
+      - kernel-rt
+    integration_tag: early-kernel-integration-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}
+    stop_ship_tag: early-kernel-stop-ship
+    ship_ok_tag: early-kernel-ship-ok
+    target_tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
 
 branch: rhaos-{MAJOR}.{MINOR}-rhel-8
 name: openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#3715