### PR TITLE
OCPBUGS-21942: Revert "[ART-7960] disable clusterresourceoverride until fixed"

### DIFF
--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled  # ART-7960 disable until CSV is valid
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -1,4 +1,3 @@
-mode: disabled  # ART-7960 disable until CSV is valid
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
This reverts commit e94ff58c8b908c3f960d92c7ac5d1f4c7a4dfd0c.

CRO's manifests have been updated for 4.15, should be able to be safely re-enabled. 