### PR TITLE
OCPBUGS-21944: Revert "[ART-7960] disable vertical-pod-autoscaler-operator until fixed"

### DIFF
--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled  # ART-7960 disable until CSV is valid
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -1,4 +1,3 @@
-mode: disabled  # ART-7960 disable until CSV is valid
 content:
   source:
     dockerfile: Dockerfile.rhel


### PR DESCRIPTION
This reverts commit ffc98e62c4c89ad58ecbb0b8a606ca49a8b1ac87.

VPA's manifests have been updated for 4.15, should be able to be safely re-enabled. 