### PR TITLE
[4.15-ec.2] manually include advisories w/ prerelease

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -9,6 +9,13 @@ releases:
           s390x: 4.15.0-0.nightly-s390x-2023-11-08-010126
           x86_64: 4.15.0-0.nightly-2023-11-08-062604
       group:
+        advisories:
+          extras: -1
+          image: -1
+          metadata: -1
+          microshift: -1
+          rpm: -1
+          prerelease: 123948
         rhcos:
           payload_tags:
           # this tag was included at the time these nightlies formed, removed after:


### PR DESCRIPTION
to be filled with prepare-release (although it doesn't know about `prerelease` advisories yet so I created that manually - https://github.com/openshift-eng/art-tools/pull/167)