### PR TITLE
Explicitly mention name_in_bundle for operators and operands

### DIFF
--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -21,6 +21,7 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-cluster-nfd-operator
+name_in_bundle: cluster-nfd-operator
 owners:
 - edge-kmm@redhat.com
 update-csv:

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -22,6 +22,7 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-clusterresourceoverride-rhel8-operator
+name_in_bundle: clusterresourceoverride-rhel8-operator
 owners:
 - aos-node@redhat.com
 update-csv:

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -24,5 +24,6 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-clusterresourceoverride-rhel8
+name_in_bundle: clusterresourceoverride-rhel8
 owners:
 - aos-node@redhat.com

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -35,6 +35,7 @@ labels:
   io.openshift.tags: csi,storage,probe
   vendor: Red Hat
 name: openshift/ose-csi-livenessprobe
+name_in_bundle: csi-livenessprobe
 payload_name: csi-livenessprobe
 owners:
 - aos-storage-staff@redhat.com

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -29,6 +29,7 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-csi-node-driver-registrar
+name_in_bundle: csi-node-driver-registrar
 payload_name: csi-node-driver-registrar
 owners:
 - aos-storage-staff@redhat.com

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -27,5 +27,6 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-sriov-infiniband-cni
+name_in_bundle: sriov-infiniband-cni
 owners:
 - multus-dev@redhat.com

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -37,6 +37,7 @@ labels:
   io.openshift.tags: kubernetes
   vendor: Red Hat
 name: openshift/ose-kube-rbac-proxy
+name_in_bundle: kube-rbac-proxy
 payload_name: kube-rbac-proxy
 owners:
 - team-monitoring@redhat.com

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -26,5 +26,6 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-local-storage-diskmaker
+name_in_bundle: local-storage-diskmaker
 owners:
 - aos-storage-staff@redhat.com

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -24,6 +24,7 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-local-storage-operator
+name_in_bundle: local-storage-operator
 owners:
 - aos-storage-staff@redhat.com
 update-csv:

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -32,6 +32,7 @@ from:
   - stream: nodejs
   member: openshift-enterprise-base
 name: openshift/nmstate-console-plugin-rhel8
+name_in_bundle: nmstate-console-plugin-rhel8
 owners:
 - upalatuc@redhat.com
 - bnemec@redhat.com

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -23,5 +23,6 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-node-feature-discovery
+name_in_bundle: node-feature-discovery
 owners:
 - edge-kmm@redhat.com

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -28,6 +28,7 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-aws-efs-csi-driver-rhel8-operator
+name_in_bundle: aws-efs-csi-driver-rhel8-operator
 owners:
 - aos-storage-staff@redhat.com
 update-csv:

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -30,5 +30,6 @@ from:
   - stream: golang
   member: ose-aws-efs-utils
 name: openshift/ose-aws-efs-csi-driver-container-rhel8
+name_in_bundle: aws-efs-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -26,6 +26,7 @@ from:
   - stream: golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-ptp-operator
+name_in_bundle: ptp-operator
 labels:
   summary: Operator that manages PTP (Precision Time Protocol) configuration on an openshift cluster
 owners:

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -27,5 +27,6 @@ from:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sriov-dp-admission-controller
+name_in_bundle: sriov-dp-admission-controller
 owners:
 - multus-dev@redhat.com

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -27,5 +27,6 @@ from:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sriov-network-config-daemon
+name_in_bundle: sriov-network-config-daemon
 owners:
 - multus-dev@redhat.com

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -27,5 +27,6 @@ from:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sriov-network-device-plugin
+name_in_bundle: sriov-network-device-plugin
 owners:
 - zshi@redhat.com

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -25,6 +25,7 @@ from:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sriov-network-operator
+name_in_bundle: sriov-network-operator
 owners:
 - multus-dev@redhat.com
 update-csv:

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -27,5 +27,6 @@ from:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sriov-network-webhook
+name_in_bundle: sriov-network-webhook
 owners:
 - multus-dev@redhat.com

--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -22,6 +22,7 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-vertical-pod-autoscaler-rhel8-operator
+name_in_bundle: vertical-pod-autoscaler-rhel8-operator
 owners:
 - joesmith@redhat.com
 update-csv:

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -28,5 +28,6 @@ from:
 maintainer:
   component: Node
 name: openshift/ose-vertical-pod-autoscaler-rhel8
+name_in_bundle: vertical-pod-autoscaler-rhel8
 owners:
 - joesmith@redhat.com


### PR DESCRIPTION
Found operators
```
(venv) asdas@asdas-thinkpadp1gen3:~/PycharmProjects/ocp-build-data$ grep -l update-csv images/*
images/cluster-nfd-operator.yml
images/clusterresourceoverride-operator.yml
images/dpu-network-operator.yml
images/ingress-node-firewall-operator.yml
images/local-storage-operator.yml
images/openshift-kubernetes-nmstate-operator.yml
images/ose-aws-efs-csi-driver-operator.yml
images/ose-cluster-kube-descheduler-operator.yml
images/ose-gcp-filestore-csi-driver-operator.yml
images/ose-metallb-operator.yml
images/ose-secrets-store-csi-driver-operator.yml
images/ptp-operator.yml
images/sriov-network-operator.yml
images/vertical-pod-autoscaler-operator.yml
```
Added `name_in_bundle` to ones that were missing

Opreators: https://github.com/openshift-eng/ocp-build-data/pull/3881/commits/6755b76cad84c72f9d93c19775a983f67f65819c
Operands: https://github.com/openshift-eng/ocp-build-data/pull/3881/commits/e9d2975cdfb04ad8ff36f9fdc7b8164c20bb99b2