### PR TITLE
[4.15] update ec.2 with advisories and jira

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -10,11 +10,11 @@ releases:
           x86_64: 4.15.0-0.nightly-2023-11-08-062604
       group:
         advisories:
-          extras: -1
-          image: -1
-          metadata: -1
-          microshift: -1
-          rpm: -1
+          extras: 123982
+          image: 123983
+          metadata: 123984
+          microshift: 123985
+          rpm: 123986
           prerelease: 123948
         rhcos:
           payload_tags:
@@ -22,6 +22,7 @@ releases:
           - name: machine-os-content
             build_metadata_key: oscontainer
         upgrades: 4.14.0-rc.0,4.14.0-rc.1,4.14.0-rc.2,4.14.0-rc.3,4.14.0-rc.4,4.14.0-rc.5,4.14.0-rc.6,4.14.0-rc.7,4.14.0,4.14.1,4.14.2,4.15.0-ec.0,4.15.0-ec.1
+        release_jira: ART-8258
       members:
         images:
         - distgit_key: ose-aws-ebs-csi-driver-operator


### PR DESCRIPTION
Created in
https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fprepare-release/949/console but had a conflict with another commit, so following up manually.