### PR TITLE
Revert "[ART-4932] group.yml: remove machine-os-content"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -55,6 +55,8 @@ cachito:
 
 rhcos:
   payload_tags:
+    - name: machine-os-content
+      build_metadata_key: oscontainer
     - name: rhel-coreos
       build_metadata_key: base-oscontainer
       primary: true


### PR DESCRIPTION
This reverts commit 840fb811b101eff09d0be911fc6fe2861b66c45a.

We can attempt again later when upstream dependencies have cleared up.