### PR TITLE
Remove cachito from AWS EBS CSI driver operator

### DIFF
--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -1,10 +1,6 @@
 arches:
 - x86_64
 - aarch64
-cachito:
-  packages:
-    gomod:
-    - path: legacy/aws-ebs-csi-driver-operator
 content:
   source:
     dockerfile: Dockerfile.aws-ebs


### PR DESCRIPTION
We update openshift/csi-operator Dockerfile in
https://github.com/openshift/csi-operator/pull/69 to build the aws-ebs-csi-driver-operator directly from `/` and not from `/legacy/*`.

Reflect that change in the image metadata.