### PR TITLE
[ART-7926] Activate sast scanning bugs pipeline for 4.15 sriov

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -510,3 +510,8 @@ canonical_builders_from_upstream: "auto"
 # For early access without an errata (state=pre-release), that is not required
 software_lifecycle:
   phase: pre-release
+
+# Enable feature to raise OCPBUGS Jira tickets if SAST scan issues are found
+scanning:
+  jira_integration:
+    enabled: true

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -33,3 +33,6 @@ update-csv:
   manifests-dir: manifests
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+scanning:
+  jira_integration:
+    enabled: true


### PR DESCRIPTION
Following https://github.com/openshift-eng/art-tools/pull/141

We have granular control on how this feature is activated.

 - [Image metadata level](https://github.com/openshift-eng/art-tools/blob/22dc7ad1f3ee331acaf1bb08f818d97d6ba13a78/doozer/doozerlib/cli/scan_osh.py#L181)
 - [group.yaml level](https://github.com/openshift-eng/art-tools/blob/22dc7ad1f3ee331acaf1bb08f818d97d6ba13a78/doozer/doozerlib/cli/scan_osh.py#L521) 

_Requesting /lgtm only_