### PR TITLE
Set payload_name baremetal-cluster-api-controllers

### DIFF
--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -21,5 +21,6 @@ from:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-baremetal-cluster-api-controllers-rhel9
+payload_name: baremetal-cluster-api-controllers
 owners:
 - metal-platform@redhat.com


### PR DESCRIPTION
The image is bumped to rhel9 but the payload name doesn't have the suffix in upstream