### PR TITLE
[ART-7926] Enable SAST OCPBUGS pipeline for all 4.15 images

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -511,7 +511,10 @@ canonical_builders_from_upstream: "auto"
 software_lifecycle:
   phase: pre-release
 
-# Enable feature to raise OCPBUGS Jira tickets if SAST scan issues are found
-scanning:
-  jira_integration:
-    enabled: true
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      # Enable feature to raise OCPBUGS Jira tickets if SAST scan issues are found
+      # This flag enables for this OCP version, but it also has to be enabled specifically in the image config
+      # as well
+      enabled: true

--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -33,3 +33,7 @@ name: openshift/ose-cluster-autoscaler
 payload_name: cluster-autoscaler
 owners:
 - avagarwa@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -34,3 +34,7 @@ name_in_bundle: descheduler
 owners:
 - jchaloup@redhat.com
 - aos-workloads@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/atomic-openshift-node-problem-detector.yml
+++ b/images/atomic-openshift-node-problem-detector.yml
@@ -32,3 +32,7 @@ labels:
 name: openshift/ose-node-problem-detector
 owners:
 - aos-pod@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/azure-file-csi-driver-operator.yml
+++ b/images/azure-file-csi-driver-operator.yml
@@ -31,3 +31,7 @@ name: openshift/ose-azure-file-csi-driver-operator
 payload_name: azure-file-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -32,3 +32,7 @@ name: openshift/ose-azure-file-csi-driver
 payload_name: azure-file-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -32,3 +32,7 @@ owners:
 - dhellman@redhat.com
 - mhrivnak@redhat.com
 - shardy@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -27,3 +27,7 @@ name: openshift/ose-baremetal-runtimecfg
 payload_name: baremetal-runtimecfg
 owners:
 - asegurap@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -32,3 +32,7 @@ owners:
 - nparekh@redhat.com
 - aputtur@redhat.com
 - ijolliff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-etcd-operator
 payload_name: cluster-etcd-operator
 owners:
 - sbatsche@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/cluster-monitoring-operator.yml
+++ b/images/cluster-monitoring-operator.yml
@@ -33,3 +33,7 @@ name: openshift/ose-cluster-monitoring-operator
 payload_name: cluster-monitoring-operator
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-network-operator
 payload_name: cluster-network-operator
 owners:
 - aos-networking-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -31,3 +31,7 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -28,3 +28,7 @@ name: openshift/ose-cluster-node-tuning-operator-rhel9
 payload_name: cluster-node-tuning-operator
 owners:
 - openshift-psap@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/cluster-policy-controller.yml
+++ b/images/cluster-policy-controller.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-policy-controller
 payload_name: cluster-policy-controller
 owners:
 - mfojtik@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/cluster-storage-operator.yml
+++ b/images/cluster-storage-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-storage-operator
 payload_name: cluster-storage-operator
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -33,3 +33,7 @@ name: openshift/ose-cluster-version-operator
 payload_name: cluster-version-operator
 owners:
 - aos-team-ota@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -31,3 +31,7 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -27,3 +27,7 @@ name: openshift/ose-clusterresourceoverride-rhel9
 name_in_bundle: clusterresourceoverride-rhel8
 owners:
 - aos-node@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/configmap-reload.yml
+++ b/images/configmap-reload.yml
@@ -33,3 +33,7 @@ name: openshift/ose-configmap-reloader
 payload_name: configmap-reloader
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -25,3 +25,7 @@ name: openshift/ose-coredns
 payload_name: coredns
 owners:
 - aos-network-edge@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -35,3 +35,7 @@ name: openshift/ose-csi-external-attacher
 payload_name: csi-external-attacher
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -31,3 +31,7 @@ name: openshift/ose-csi-driver-manila-operator
 payload_name: csi-driver-manila-operator
 owners:
 - shiftstack-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -31,3 +31,7 @@ name: openshift/ose-csi-driver-manila
 payload_name: csi-driver-manila
 owners:
 - shiftstack-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -31,3 +31,7 @@ name: openshift/ose-csi-driver-nfs
 payload_name: csi-driver-nfs
 owners:
 - shiftstack-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -40,3 +40,7 @@ name_in_bundle: csi-livenessprobe
 payload_name: csi-livenessprobe
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -34,3 +34,7 @@ name_in_bundle: csi-node-driver-registrar
 payload_name: csi-node-driver-registrar
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -39,3 +39,7 @@ payload_name: csi-external-provisioner
 name_in_bundle: csi-external-provisioner
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/csi-snapshot-validation-webhook.yml
+++ b/images/csi-snapshot-validation-webhook.yml
@@ -29,3 +29,7 @@ name: openshift/ose-csi-snapshot-validation-webhook
 payload_name: csi-snapshot-validation-webhook
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/dpu-network-operator.yml
+++ b/images/dpu-network-operator.yml
@@ -35,3 +35,7 @@ update-csv:
   manifests-dir: manifests
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -35,3 +35,7 @@ name: openshift/ose-driver-toolkit-rhel9
 payload_name: driver-toolkit
 owners:
 - edge-sro@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -24,3 +24,7 @@ name: openshift/ose-egress-router-cni
 payload_name: egress-router-cni
 owners:
 - aos-networking-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/golang-github-openshift-oauth-proxy.yml
+++ b/images/golang-github-openshift-oauth-proxy.yml
@@ -30,3 +30,7 @@ name: openshift/ose-oauth-proxy
 payload_name: oauth-proxy
 owners:
 - aos-apiserver@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -34,3 +34,7 @@ non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -35,3 +35,7 @@ non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -34,3 +34,7 @@ non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -25,3 +25,7 @@ name: openshift/ose-hypershift
 payload_name: hypershift
 owners:
 - hypershift-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -31,3 +31,7 @@ name: openshift/ose-sriov-infiniband-cni
 name_in_bundle: sriov-infiniband-cni
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ibm-vpc-node-label-updater.yml
+++ b/images/ibm-vpc-node-label-updater.yml
@@ -32,3 +32,7 @@ name: openshift/ose-ibm-vpc-node-label-updater
 payload_name: ibm-vpc-node-label-updater
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ingress-node-firewall-daemon.yml
+++ b/images/ingress-node-firewall-daemon.yml
@@ -27,3 +27,7 @@ name: openshift/ingress-node-firewall-rhel9
 name_in_bundle: ingress-node-firewall-daemon
 owners:
 - mmahmoud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ingress-node-firewall-operator.yml
+++ b/images/ingress-node-firewall-operator.yml
@@ -31,3 +31,7 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -25,3 +25,7 @@ enabled_repos:
 - rhel-9-server-ironic-rpms
 non_shipping_repos:
 - rhel-9-server-ironic-rpms
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -27,3 +27,7 @@ owners:
 - ironic-osp-owners@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -22,3 +22,7 @@ name: openshift/ose-ironic-static-ip-manager-rhel9
 payload_name: ironic-static-ip-manager
 owners:
 - ironic-osp-owners@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -29,3 +29,7 @@ owners:
 non_shipping_repos:
 - rhel-9-server-ironic-rpms
 - rhel-9-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -25,3 +25,7 @@ name: openshift/ose-kube-proxy
 payload_name: kube-proxy
 owners:
 - aos-networking-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -42,3 +42,7 @@ name_in_bundle: kube-rbac-proxy
 payload_name: kube-rbac-proxy
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -32,3 +32,7 @@ name: openshift/ose-kube-state-metrics
 payload_name: kube-state-metrics
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -31,3 +31,7 @@ name: openshift/ose-ptp-rhel9
 name_in_bundle: ptp
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -30,3 +30,7 @@ name: openshift/ose-local-storage-diskmaker-rhel9
 name_in_bundle: local-storage-diskmaker
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/local-storage-mustgather.yml
+++ b/images/local-storage-mustgather.yml
@@ -28,3 +28,7 @@ name: openshift/ose-local-storage-mustgather-rhel8
 name_in_bundle: local-storage-mustgather
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -35,3 +35,7 @@ update-csv:
   manifests-dir: config/manifests
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-operator-marketplace
 payload_name: operator-marketplace
 owners:
 - aos-marketplace@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -34,3 +34,7 @@ name: openshift/ose-monitoring-plugin-rhel8
 payload_name: monitoring-plugin
 owners:
 - team-observability-ui@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -35,3 +35,7 @@ name: openshift/ose-multus-cni
 payload_name: multus-cni
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/multus-networkpolicy.yml
+++ b/images/multus-networkpolicy.yml
@@ -29,3 +29,7 @@ name: openshift/ose-multus-networkpolicy
 payload_name: multus-networkpolicy
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -40,3 +40,7 @@ owners:
 - yzamir@redhat.com
 - phoracek@redhat.com
 - fge@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -27,3 +27,7 @@ name: openshift/ose-node-feature-discovery-rhel9
 name_in_bundle: node-feature-discovery
 owners:
 - edge-kmm@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/oauth-server.yml
+++ b/images/oauth-server.yml
@@ -27,3 +27,7 @@ name: openshift/ose-oauth-server
 payload_name: oauth-server
 owners:
 - mfojtik@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -27,3 +27,7 @@ owners:
 - jpower@redhat.com
 - dmesser@redhat.com
 - aflom@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-base-nodejs.yml
+++ b/images/openshift-base-nodejs.yml
@@ -31,3 +31,7 @@ labels:
 name: openshift/base-nodejs
 owners:
 - aos-team-art@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-base-rhel8.yml
+++ b/images/openshift-base-rhel8.yml
@@ -35,3 +35,7 @@ from:
 name: openshift/base-rhel8
 owners:
 - aos-team-art@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -38,3 +38,7 @@ from:
 name: openshift/base-rhel9
 owners:
 - aos-team-art@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -32,3 +32,7 @@ owners:
 - fabian@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-base-rhel9.yml
+++ b/images/openshift-enterprise-base-rhel9.yml
@@ -61,3 +61,7 @@ labels:
 name: openshift/openshift-enterprise-base-rhel9
 owners:
 - lmeyer@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-base.yml
+++ b/images/openshift-enterprise-base.yml
@@ -61,3 +61,7 @@ labels:
 name: openshift/ose-base
 owners:
 - lmeyer@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -35,3 +35,7 @@ owners:
 - openshift-build-api@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -33,3 +33,7 @@ name: openshift/ose-cli
 payload_name: cli
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -34,3 +34,7 @@ name: openshift/ose-cluster-capacity
 owners:
 - jchaloup@redhat.com
 - aos-workloads@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -27,3 +27,7 @@ owners:
 - bpeterse@redhat.com
 - spadgett@redhat.com
 - jforrest@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -44,3 +44,7 @@ name: openshift/ose-console
 payload_name: console
 owners:
 - spadgett@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -28,3 +28,7 @@ name: openshift/ose-deployer
 payload_name: deployer
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -28,3 +28,7 @@ owners:
 - aos-network-edge@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -25,3 +25,7 @@ labels:
 name: openshift/ose-egress-router
 owners:
 - aos-network-edge@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -31,3 +31,7 @@ owners:
 - aos-network-edge@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -29,3 +29,7 @@ owners:
 - jlanford@redhat.com
 - fabian@redhat.com
 - cmacedo@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -37,3 +37,7 @@ name: openshift/ose-hyperkube-rhel9
 payload_name: hyperkube
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -27,3 +27,7 @@ name: openshift/ose-keepalived-ipfailover
 payload_name: keepalived-ipfailover
 owners:
 - aos-network-edge@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-operator-sdk.yml
+++ b/images/openshift-enterprise-operator-sdk.yml
@@ -29,3 +29,7 @@ owners:
 - jlanford@redhat.com
 - fabian@redhat.com
 - cmacedo@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -38,3 +38,7 @@ non_shipping_repos:
 - rhel-9-codeready-builder-rpms
 owners:
 - aos-pod@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -33,3 +33,7 @@ name: openshift/ose-docker-registry
 payload_name: docker-registry
 owners:
 - openshift-image-registry@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -46,3 +46,7 @@ payload_name: tests
 owners:
 - aos-master@redhat.com
 - openshift-technical-release-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -35,3 +35,7 @@ owners:
 - yboaron@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -36,3 +36,7 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-proxy-pull-test.yml
+++ b/images/openshift-proxy-pull-test.yml
@@ -15,3 +15,7 @@ from:
 name: openshift/ose-openshift-proxy-pull-test
 owners:
 - qiwan@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openshift-state-metrics.yml
+++ b/images/openshift-state-metrics.yml
@@ -26,3 +26,7 @@ name: openshift/ose-openshift-state-metrics
 payload_name: openshift-state-metrics
 owners:
 - haowang@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/openstack-cluster-api-controllers.yml
+++ b/images/openstack-cluster-api-controllers.yml
@@ -25,3 +25,7 @@ name: openshift/ose-openstack-cluster-api-controllers
 payload_name: openstack-cluster-api-controllers
 owners:
 - shiftstack-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -33,3 +33,7 @@ name: openshift/ose-operator-lifecycle-manager
 payload_name: operator-lifecycle-manager
 owners:
 - aos-odin@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -25,3 +25,7 @@ name: openshift/ose-operator-registry
 payload_name: operator-registry
 owners:
 - aos-odin@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -32,3 +32,7 @@ owners:
 - ocp-agent-team@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -29,3 +29,7 @@ name: openshift/ose-agent-installer-csr-approver
 payload_name: agent-installer-csr-approver
 owners:
 - ocp-agent-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -31,3 +31,7 @@ owners:
 - ocp-agent-team@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-agent-installer-orchestrator.yml
+++ b/images/ose-agent-installer-orchestrator.yml
@@ -28,3 +28,7 @@ name: openshift/ose-agent-installer-orchestrator
 payload_name: agent-installer-orchestrator
 owners:
 - ocp-agent-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -33,3 +33,7 @@ owners:
 non_shipping_repos:
 - rhel-9-codeready-builder-rpms
 - rhel-9-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-alibaba-cloud-controller-manager.yml
+++ b/images/ose-alibaba-cloud-controller-manager.yml
@@ -31,3 +31,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-alibaba-cloud-csi-driver.yml
+++ b/images/ose-alibaba-cloud-csi-driver.yml
@@ -31,3 +31,7 @@ name: openshift/ose-alibaba-cloud-csi-driver
 payload_name: alibaba-cloud-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-alibaba-disk-csi-driver-operator.yml
+++ b/images/ose-alibaba-disk-csi-driver-operator.yml
@@ -29,3 +29,7 @@ name: openshift/ose-alibaba-disk-csi-driver-operator
 payload_name: alibaba-disk-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-alibaba-machine-controllers.yml
+++ b/images/ose-alibaba-machine-controllers.yml
@@ -31,3 +31,7 @@ owners:
 - mfedosin@redhat.com
 - dmoiseev@redhat.com
 - ademicev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -25,3 +25,7 @@ name: openshift/ose-apiserver-network-proxy
 payload_name: apiserver-network-proxy
 owners:
 - hypershift-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-aws-cloud-controller-manager.yml
+++ b/images/ose-aws-cloud-controller-manager.yml
@@ -40,3 +40,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -32,3 +32,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -35,3 +35,7 @@ name: openshift/ose-aws-ebs-csi-driver-operator
 payload_name: aws-ebs-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -32,3 +32,7 @@ name: openshift/ose-aws-ebs-csi-driver
 payload_name: aws-ebs-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -37,3 +37,7 @@ update-csv:
   manifests-dir: config/manifests
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -34,3 +34,7 @@ name: openshift/ose-aws-efs-csi-driver-container-rhel8
 name_in_bundle: aws-efs-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-aws-efs-utils.yml
+++ b/images/ose-aws-efs-utils.yml
@@ -24,3 +24,7 @@ from:
 name: openshift/ose-aws-efs-utils-base
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-aws-pod-identity-webhook.yml
+++ b/images/ose-aws-pod-identity-webhook.yml
@@ -28,3 +28,7 @@ name: openshift/ose-aws-pod-identity-webhook
 payload_name: aws-pod-identity-webhook
 owners:
 - sjenning@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-azure-cloud-controller-manager.yml
+++ b/images/ose-azure-cloud-controller-manager.yml
@@ -41,3 +41,7 @@ owners:
 - elmiko@redhat.com
 - dmoiseev@redhat.com
 
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-azure-cloud-node-manager.yml
+++ b/images/ose-azure-cloud-node-manager.yml
@@ -41,3 +41,7 @@ owners:
 - elmiko@redhat.com
 - dmoiseev@redhat.com
 
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -32,3 +32,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-azure-disk-csi-driver-operator.yml
+++ b/images/ose-azure-disk-csi-driver-operator.yml
@@ -31,3 +31,7 @@ name: openshift/ose-azure-disk-csi-driver-operator
 payload_name: azure-disk-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -32,3 +32,7 @@ name: openshift/ose-azure-disk-csi-driver
 payload_name: azure-disk-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -24,3 +24,7 @@ name: openshift/ose-azure-workload-identity-webhook-rhel8
 payload_name: azure-workload-identity-webhook
 owners:
 - aos-hive@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -25,3 +25,7 @@ name: openshift/ose-baremetal-cluster-api-controllers-rhel9
 payload_name: baremetal-cluster-api-controllers
 owners:
 - metal-platform@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -27,3 +27,7 @@ name: openshift/ose-baremetal-installer
 payload_name: baremetal-installer
 owners:
 - kni-devel-deployment@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -31,3 +31,7 @@ owners:
 - zbitter@redhat.com
 - mhrivnak@redhat.com
 - shardy@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -27,3 +27,7 @@ payload_name: cli-artifacts
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cloud-credential-operator.yml
+++ b/images/ose-cloud-credential-operator.yml
@@ -24,3 +24,7 @@ name: openshift/ose-cloud-credential-operator
 payload_name: cloud-credential-operator
 owners:
 - aos-hive@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cloud-network-config-controller.yml
+++ b/images/ose-cloud-network-config-controller.yml
@@ -21,3 +21,7 @@ name: openshift/ose-cloud-network-config-controller
 payload_name: cloud-network-config-controller
 owners:
 - aos-networking-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -26,3 +26,7 @@ name: openshift/ose-cluster-capi-controllers
 payload_name: cluster-capi-controllers
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-authentication-operator.yml
+++ b/images/ose-cluster-authentication-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-authentication-operator
 payload_name: cluster-authentication-operator
 owners:
 - aos-apiserver@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-autoscaler-operator.yml
+++ b/images/ose-cluster-autoscaler-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-autoscaler-operator
 payload_name: cluster-autoscaler-operator
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -24,3 +24,7 @@ name: openshift/ose-cluster-baremetal-operator
 payload_name: cluster-baremetal-operator
 owners:
 - kni-devel-deployment@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-bootstrap.yml
+++ b/images/ose-cluster-bootstrap.yml
@@ -24,3 +24,7 @@ name: openshift/ose-cluster-bootstrap
 payload_name: cluster-bootstrap
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-capi-operator.yml
+++ b/images/ose-cluster-capi-operator.yml
@@ -21,3 +21,7 @@ name: openshift/ose-cluster-capi-operator
 payload_name: cluster-capi-operator
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -30,3 +30,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-config-api.yml
+++ b/images/ose-cluster-config-api.yml
@@ -22,3 +22,7 @@ payload_name: cluster-config-api
 owners:
 - jspeed@redhat.com
 - deads@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-config-operator.yml
+++ b/images/ose-cluster-config-operator.yml
@@ -22,3 +22,7 @@ payload_name: cluster-config-operator
 owners:
 - aos-master@redhat.com
 - tnozicka@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-control-plane-machine-set-operator.yml
+++ b/images/ose-cluster-control-plane-machine-set-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-control-plane-machine-set-operator
 payload_name: cluster-control-plane-machine-set-operator
 owners:
 - aos-cloud-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-csi-snapshot-controller-operator.yml
+++ b/images/ose-cluster-csi-snapshot-controller-operator.yml
@@ -28,3 +28,7 @@ name: openshift/ose-cluster-csi-snapshot-controller-operator
 payload_name: cluster-csi-snapshot-controller-operator
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-dns-operator.yml
+++ b/images/ose-cluster-dns-operator.yml
@@ -24,3 +24,7 @@ name: openshift/ose-cluster-dns-operator
 payload_name: cluster-dns-operator
 owners:
 - aos-network-edge@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-image-registry-operator.yml
+++ b/images/ose-cluster-image-registry-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-image-registry-operator
 payload_name: cluster-image-registry-operator
 owners:
 - openshift-image-registry@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-ingress-operator.yml
+++ b/images/ose-cluster-ingress-operator.yml
@@ -24,3 +24,7 @@ name: openshift/ose-cluster-ingress-operator
 payload_name: cluster-ingress-operator
 owners:
 - aos-network-edge@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-kube-apiserver-operator.yml
+++ b/images/ose-cluster-kube-apiserver-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-kube-apiserver-operator
 payload_name: cluster-kube-apiserver-operator
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-kube-cluster-api-operator.yml
+++ b/images/ose-cluster-kube-cluster-api-operator.yml
@@ -29,3 +29,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-kube-controller-manager-operator.yml
+++ b/images/ose-cluster-kube-controller-manager-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-kube-controller-manager-operator
 payload_name: cluster-kube-controller-manager-operator
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-kube-descheduler-operator.yml
+++ b/images/ose-cluster-kube-descheduler-operator.yml
@@ -31,3 +31,7 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-kube-scheduler-operator
 payload_name: cluster-kube-scheduler-operator
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-kube-storage-version-migrator-operator.yml
+++ b/images/ose-cluster-kube-storage-version-migrator-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-kube-storage-version-migrator-operator
 payload_name: cluster-kube-storage-version-migrator-operator
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-machine-approver.yml
+++ b/images/ose-cluster-machine-approver.yml
@@ -25,3 +25,7 @@ name: openshift/ose-cluster-machine-approver
 payload_name: cluster-machine-approver
 owners:
 - aos-apiserver@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -26,3 +26,7 @@ payload_name: cluster-olm-operator
 owners:
 - angoldst@redhat.com
 - aos-odin@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-openshift-apiserver-operator.yml
+++ b/images/ose-cluster-openshift-apiserver-operator.yml
@@ -24,3 +24,7 @@ name: openshift/ose-cluster-openshift-apiserver-operator
 payload_name: cluster-openshift-apiserver-operator
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-openshift-controller-manager-operator.yml
+++ b/images/ose-cluster-openshift-controller-manager-operator.yml
@@ -24,3 +24,7 @@ name: openshift/ose-cluster-openshift-controller-manager-operator
 payload_name: cluster-openshift-controller-manager-operator
 owners:
 - openshift-build-api@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-ovirt-csi-operator.yml
+++ b/images/ose-cluster-ovirt-csi-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-ovirt-csi-driver-operator
 payload_name: ovirt-csi-driver-operator
 owners:
 - rgolan@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-platform-operators-manager.yml
+++ b/images/ose-cluster-platform-operators-manager.yml
@@ -29,3 +29,7 @@ name: openshift/ose-cluster-platform-operators-manager
 payload_name: cluster-platform-operators-manager
 owners:
 - aos-odin@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-samples-operator.yml
+++ b/images/ose-cluster-samples-operator.yml
@@ -24,3 +24,7 @@ name: openshift/ose-cluster-samples-operator
 payload_name: cluster-samples-operator
 owners:
 - openshift-build-api@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-update-keys
 payload_name: cluster-update-keys
 owners:
 - aos-team-art@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -34,3 +34,7 @@ owners:
 - fpan@redhat.com
 - tohayash@redhat.com
 - dcbw@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-csi-driver-shared-resource-mustgather.yml
+++ b/images/ose-csi-driver-shared-resource-mustgather.yml
@@ -18,3 +18,7 @@ from:
 name: openshift/ose-csi-driver-shared-resource-mustgather-rhel8
 owners:
 - openshift-build-jenkins-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-csi-driver-shared-resource-operator.yml
+++ b/images/ose-csi-driver-shared-resource-operator.yml
@@ -20,3 +20,7 @@ name: openshift/ose-csi-driver-shared-resource-operator
 payload_name: csi-driver-shared-resource-operator
 owners:
 - openshift-build-jenkins-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-csi-driver-shared-resource-webhook.yml
+++ b/images/ose-csi-driver-shared-resource-webhook.yml
@@ -22,3 +22,7 @@ name: openshift/ose-csi-driver-shared-resource-webhook
 payload_name: csi-driver-shared-resource-webhook
 owners:
 - openshift-build-jenkins-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-csi-driver-shared-resource.yml
+++ b/images/ose-csi-driver-shared-resource.yml
@@ -20,3 +20,7 @@ name: openshift/ose-csi-driver-shared-resource
 payload_name: csi-driver-shared-resource
 owners:
 - openshift-build-jenkins-team@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -32,3 +32,7 @@ payload_name: csi-external-resizer
 name_in_bundle: csi-external-resizer
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-csi-external-snapshotter.yml
+++ b/images/ose-csi-external-snapshotter.yml
@@ -32,3 +32,7 @@ payload_name: csi-external-snapshotter
 name_in_bundle: csi-external-snapshotter
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-csi-snapshot-controller.yml
+++ b/images/ose-csi-snapshot-controller.yml
@@ -29,3 +29,7 @@ name: openshift/ose-csi-snapshot-controller
 payload_name: csi-snapshot-controller
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -25,3 +25,7 @@ labels:
 name: openshift/ose-egress-http-proxy
 owners:
 - aos-network-edge@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -55,3 +55,7 @@ owners:
 - melbeher@redhat.com
 maintainer:
   component: "Etcd"
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -24,3 +24,7 @@ owners:
 - metallb-dev@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -27,3 +27,7 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -33,3 +33,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-gcp-filestore-csi-driver-operator.yml
+++ b/images/ose-gcp-filestore-csi-driver-operator.yml
@@ -38,3 +38,7 @@ update-csv:
   manifests-dir: config/manifests/
   registry: image-registry.openshift-imageregistry.svc:5000
   valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -35,3 +35,7 @@ name: openshift/ose-gcp-filestore-csi-driver-rhel8
 name_in_bundle: gcp-filestore-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -32,3 +32,7 @@ name: openshift/ose-gcp-pd-csi-driver-operator
 payload_name: gcp-pd-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -33,3 +33,7 @@ name: openshift/ose-gcp-pd-csi-driver
 payload_name: gcp-pd-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -33,3 +33,7 @@ labels:
 name: openshift/ose-haproxy-router-base
 owners:
 - aos-network-edge@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -29,3 +29,7 @@ name: openshift/ose-ibm-cloud-controller-manager
 payload_name: ibm-cloud-controller-manager
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-ibm-vpc-block-csi-driver-operator.yml
+++ b/images/ose-ibm-vpc-block-csi-driver-operator.yml
@@ -30,3 +30,7 @@ name: openshift/ose-ibm-vpc-block-csi-driver-operator
 payload_name: ibm-vpc-block-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -32,3 +32,7 @@ name: openshift/ose-ibm-vpc-block-csi-driver
 payload_name: ibm-vpc-block-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -31,3 +31,7 @@ payload_name: ibmcloud-cluster-api-controllers
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -27,3 +27,7 @@ name: openshift/ose-ibmcloud-machine-controllers
 payload_name: ibmcloud-machine-controllers
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -30,3 +30,7 @@ owners:
 - metal-platform@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-insights-operator.yml
+++ b/images/ose-insights-operator.yml
@@ -24,3 +24,7 @@ name: openshift/ose-insights-operator
 payload_name: insights-operator
 owners:
 - ccoleman@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-installer-altinfra.yml
+++ b/images/ose-installer-altinfra.yml
@@ -25,3 +25,7 @@ name: openshift/ose-installer-altinfra-rhel8
 payload_name: installer-altinfra
 owners:
 - aos-install@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -28,3 +28,7 @@ name: openshift/ose-installer-artifacts
 payload_name: installer-artifacts
 owners:
 - aos-install@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -25,3 +25,7 @@ name: openshift/ose-installer
 payload_name: installer
 owners:
 - aos-install@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-kube-metrics-server.yml
+++ b/images/ose-kube-metrics-server.yml
@@ -21,3 +21,7 @@ name: openshift/kube-metrics-server-rhel8
 payload_name: kube-metrics-server
 owners:
 - team-monitoring-incluster@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-kube-storage-version-migrator.yml
+++ b/images/ose-kube-storage-version-migrator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-kube-storage-version-migrator
 payload_name: kube-storage-version-migrator
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-kubevirt-cloud-controller-manager.yml
+++ b/images/ose-kubevirt-cloud-controller-manager.yml
@@ -30,3 +30,7 @@ payload_name: kubevirt-cloud-controller-manager
 owners:
 - dvossel@redhat.com
 - nargaman@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -31,3 +31,7 @@ owners:
 - rgolan@redhat.com
 - nargaman@redhat.com
 - dvossel@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -31,3 +31,7 @@ name: openshift/ose-libvirt-machine-controllers
 payload_name: libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-machine-api-operator
 payload_name: machine-api-operator
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -28,3 +28,7 @@ name: openshift/ose-aws-machine-controllers
 payload_name: aws-machine-controllers
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -28,3 +28,7 @@ name: openshift/ose-azure-machine-controllers
 payload_name: azure-machine-controllers
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -29,3 +29,7 @@ name: openshift/ose-gcp-machine-controllers
 payload_name: gcp-machine-controllers
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -26,3 +26,7 @@ name: openshift/ose-openstack-machine-api-provider
 payload_name: openstack-machine-api-provider
 owners:
 - aos-cloud@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -41,3 +41,7 @@ owners:
 - jkyros@redhat.com
 - skumari@redhat.com
 - zzlotnik@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -29,3 +29,7 @@ non_shipping_repos:
 - rhel-8-appstream-rpms
 - rhel-8-baseos-rpms
 - rhel-8-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -29,3 +29,7 @@ update-csv:
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container
     Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -24,3 +24,7 @@ name: openshift/metallb-rhel9
 name_in_bundle: metallb-rhel9
 owners:
 - metallb-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-multus-admission-controller.yml
+++ b/images/ose-multus-admission-controller.yml
@@ -29,3 +29,7 @@ name: openshift/ose-multus-admission-controller
 payload_name: multus-admission-controller
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -26,3 +26,7 @@ name: openshift/ose-multus-route-override-cni
 payload_name: multus-route-override-cni
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -27,3 +27,7 @@ name: openshift/ose-multus-whereabouts-ipam-cni
 payload_name: multus-whereabouts-ipam-cni
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -25,3 +25,7 @@ name: openshift/ose-must-gather
 payload_name: must-gather
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -23,3 +23,7 @@ name: openshift/ose-network-interface-bond-cni
 payload_name: network-interface-bond-cni
 owners:
 - carlosg@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-network-metrics-daemon.yml
+++ b/images/ose-network-metrics-daemon.yml
@@ -26,3 +26,7 @@ payload_name: network-metrics-daemon
 owners:
 - fpaoline@redhat.com
 - sscheink@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -26,3 +26,7 @@ name: openshift/ose-network-tools
 payload_name: network-tools
 owners:
 - aos-networking-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-nutanix-cloud-controller-manager.yml
+++ b/images/ose-nutanix-cloud-controller-manager.yml
@@ -26,3 +26,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -26,3 +26,7 @@ owners:
 - mfedosin@redhat.com
 - dmoiseev@redhat.com
 - ademicev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-oauth-apiserver.yml
+++ b/images/ose-oauth-apiserver.yml
@@ -25,3 +25,7 @@ name: openshift/ose-oauth-apiserver
 payload_name: oauth-apiserver
 owners:
 - aos-apiserver@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -28,3 +28,7 @@ name: openshift/ose-olm-catalogd-rhel8
 payload_name: olm-catalogd
 owners:
 - aos-odin@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -33,3 +33,7 @@ name: openshift/ose-olm-operator-controller-rhel8
 payload_name: olm-operator-controller
 owners:
 - aos-odin@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-olm-rukpak.yml
+++ b/images/ose-olm-rukpak.yml
@@ -33,3 +33,7 @@ name: openshift/ose-olm-rukpak
 payload_name: olm-rukpak
 owners:
 - aos-odin@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-openshift-apiserver.yml
+++ b/images/ose-openshift-apiserver.yml
@@ -25,3 +25,7 @@ name: openshift/ose-openshift-apiserver
 payload_name: openshift-apiserver
 owners:
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-openshift-controller-manager.yml
+++ b/images/ose-openshift-controller-manager.yml
@@ -25,3 +25,7 @@ name: openshift/ose-openshift-controller-manager
 payload_name: openshift-controller-manager
 owners:
 - openshift-build-api@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-openstack-cinder-csi-driver-operator.yml
+++ b/images/ose-openstack-cinder-csi-driver-operator.yml
@@ -29,3 +29,7 @@ payload_name: openstack-cinder-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
 - mfedosin@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -29,3 +29,7 @@ payload_name: openstack-cinder-csi-driver
 owners:
 - aos-storage-staff@redhat.com
 - mfedosin@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -39,3 +39,7 @@ owners:
 - dmoiseev@redhat.com
 - mbooth@redhat.com
 - m.andre@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -25,3 +25,7 @@ name: openshift/ose-ovirt-csi-driver
 payload_name: ovirt-csi-driver
 owners:
 - rgolan@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-ovirt-machine-controllers.yml
+++ b/images/ose-ovirt-machine-controllers.yml
@@ -26,3 +26,7 @@ name: openshift/ose-ovirt-machine-controllers
 payload_name: ovirt-machine-controllers
 owners:
 - rgolan@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -55,3 +55,7 @@ owners:
 - aos-networking-staff@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -32,3 +32,7 @@ payload_name: powervs-block-csi-driver-operator
 owners:
 - mchellam@redhat.com
 - mkumatag@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -32,3 +32,7 @@ payload_name: powervs-block-csi-driver
 owners:
 - mchellam@redhat.com
 - mkumatag@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-powervs-cloud-controller-manager.yml
+++ b/images/ose-powervs-cloud-controller-manager.yml
@@ -30,3 +30,7 @@ payload_name: powervs-cloud-controller-manager
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -29,3 +29,7 @@ payload_name: powervs-machine-controllers
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-prometheus-adapter.yml
+++ b/images/ose-prometheus-adapter.yml
@@ -25,3 +25,7 @@ name: openshift/ose-k8s-prometheus-adapter
 payload_name: k8s-prometheus-adapter
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-route-controller-manager.yml
+++ b/images/ose-route-controller-manager.yml
@@ -30,3 +30,7 @@ payload_name: route-controller-manager
 owners:
 - jchaloup@redhat.com
 - fkrepins@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -28,3 +28,7 @@ name: openshift/ose-sdn
 payload_name: sdn
 owners:
 - aos-networking-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -34,3 +34,7 @@ update-csv:
   manifests-dir: config/manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -31,3 +31,7 @@ name: openshift/ose-secrets-store-csi-driver-rhel8
 name_in_bundle: secrets-store-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -23,3 +23,7 @@ from:
 name: openshift/ose-secrets-store-csi-mustgather-rhel8
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-service-ca-operator.yml
+++ b/images/ose-service-ca-operator.yml
@@ -25,3 +25,7 @@ name: openshift/ose-service-ca-operator
 payload_name: service-ca-operator
 owners:
 - aos-apiserver@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -32,3 +32,7 @@ payload_name: tools
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-vmware-vsphere-csi-driver-operator.yml
+++ b/images/ose-vmware-vsphere-csi-driver-operator.yml
@@ -30,3 +30,7 @@ name: openshift/ose-vsphere-csi-driver-operator
 payload_name: vsphere-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -31,3 +31,7 @@ name: openshift/ose-vsphere-csi-driver
 payload_name: vsphere-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -28,3 +28,7 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -31,3 +31,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -53,3 +53,7 @@ owners:
 - aos-networking-staff@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -54,3 +54,7 @@ owners:
 - aos-networking-staff@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -28,3 +28,7 @@ non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -32,3 +32,7 @@ name: openshift/ose-prometheus-config-reloader
 payload_name: prometheus-config-reloader
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/prometheus-operator-admission-webhook.yml
+++ b/images/prometheus-operator-admission-webhook.yml
@@ -25,3 +25,7 @@ name: openshift/ose-prometheus-operator-admission-webhook
 payload_name: prometheus-operator-admission-webhook
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -33,3 +33,7 @@ name: openshift/ose-prometheus-operator
 payload_name: prometheus-operator
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -29,3 +29,7 @@ from:
 name: openshift/ose-ptp-operator-must-gather
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -36,3 +36,7 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -31,3 +31,7 @@ name: openshift/sriov-cni-rhel9
 name_in_bundle: sriov-cni
 owners:
 - zshi@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -31,3 +31,7 @@ name: openshift/ose-sriov-dp-admission-controller-rhel9
 name_in_bundle: sriov-dp-admission-controller
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -31,3 +31,7 @@ name: openshift/ose-sriov-network-config-daemon-rhel9
 name_in_bundle: sriov-network-config-daemon
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -31,3 +31,7 @@ name: openshift/ose-sriov-network-device-plugin-rhel9
 name_in_bundle: sriov-network-device-plugin
 owners:
 - zshi@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -35,6 +35,7 @@ update-csv:
   manifests-dir: manifests
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
-scanning:
-  jira_integration:
-    enabled: true
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -31,3 +31,7 @@ name: openshift/ose-sriov-network-webhook-rhel9
 name_in_bundle: sriov-network-webhook
 owners:
 - multus-dev@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -25,3 +25,7 @@ name: openshift/ose-telemeter
 payload_name: telemeter
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -28,3 +28,7 @@ non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -31,3 +31,7 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -31,3 +31,7 @@ name: openshift/ose-vertical-pod-autoscaler-rhel9
 name_in_bundle: vertical-pod-autoscaler-rhel8
 owners:
 - joesmith@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/vmware-vsphere-syncer.yml
+++ b/images/vmware-vsphere-syncer.yml
@@ -31,3 +31,7 @@ name: openshift/ose-vsphere-csi-driver-syncer
 payload_name: vsphere-csi-driver-syncer
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true

--- a/images/vsphere-problem-detector.yml
+++ b/images/vsphere-problem-detector.yml
@@ -30,3 +30,7 @@ name: openshift/ose-vsphere-problem-detector
 payload_name: vsphere-problem-detector
 owners:
 - aos-storage-staff@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: true


### PR DESCRIPTION
```
external_scanners:
  sast_scanning:
    jira_integration:
      enabled: true
```

Used script, after being inspired by @joepvd 
```bash
for f in images/*.yml; do
  echo "external_scanners:" >> $f
  echo "  sast_scanning:" >> $f
  echo "    jira_integration:" >> $f
  echo "      enabled: true" >> $f
done

```
Will create OCPBUGS ticket for builds that have scan issues reported