### PR TITLE
ART-8111 Update rhel-9 golang-1.21 branch

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -39,10 +39,12 @@ repos:
         # this repo provides complete RHEL 8 build env; we just want the go-toolset content
         includepkgs: module-build-macros golang*
       baseurl:
-        aarch64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
-        ppc64le: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
-        s390x: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
-        x86_64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
+        # golang-1.21.3-5.el9
+        # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2770477
+        aarch64: https://brew-task-repos.engineering.redhat.com/repos/official/golang/1.21.3/5.el9/aarch64/
+        ppc64le: https://brew-task-repos.engineering.redhat.com/repos/official/golang/1.21.3/5.el9/ppc64le/
+        s390x: https://brew-task-repos.engineering.redhat.com/repos/official/golang/1.21.3/5.el9/s390x/
+        x86_64: https://brew-task-repos.engineering.redhat.com/repos/official/golang/1.21.3/5.el9/x86_64/
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms

--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-name: rhel-9-golang-1.20
+name: rhel-9-golang-1.21
 
 arches:
 - x86_64
@@ -8,7 +8,7 @@ arches:
 
 vars:
   MAJOR: 4
-  MINOR: 14
+  MINOR: 16
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub

--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -6,7 +6,7 @@ ENV SUMMARY="RHEL9 based Go builder image for OpenShift ART" \
     GOFLAGS='-mod=vendor' \
     GOPATH=${GOPATH:-/go} \
     GOMAXPROCS=8 \
-    VERSION="1.20"
+    VERSION="1.21"
 
 LABEL summary="$SUMMARY" \
       description="$SUMMARY" \

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: openshift-golang-builder.Dockerfile
     git:
       branch:
-        target: rhel-9-golang-1.20
+        target: rhel-9-golang-1.21
       url: git@github.com:openshift-eng/ocp-build-data.git
     modifications:
     - action: add
@@ -30,9 +30,9 @@ name: openshift/golang-builder
 owners:
 - aos-team-art@redhat.com
 
-# Don't add floating tag to FoD builder for now, until we confident CPASS can use it
+# for CPaaS
 additional_tags:
-- 'rhel_9_golang_1.20'
-- 'rhel_9_1.20'
+- 'rhel_9_golang_1.21'
+- 'rhel_9_1.21'
 maintainer:
   component: Release


### PR DESCRIPTION
- [ART-8111](https://issues.redhat.com/browse/ART-8111)
- [golang-1.21.3-5.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2770477)
- https://brew-task-repos.engineering.redhat.com/repos/official/golang/1.21.3/5.el9/