### PR TITLE
Revert "4.12 - Freeze automation until mass rebuilds are complete"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: weekdays # until mass rebuilds for 4.15 - 4.13 are complete
+freeze_automation: false
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#3912
Should happen when 4.15-4.13 mass rebuilds are complete https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/ 