### PR TITLE
4.15: Remove golang-1.19

### DIFF
--- a/images/ci-openshift-golang-builder-previous.yml
+++ b/images/ci-openshift-golang-builder-previous.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   set_build_variables: false
   source:
@@ -14,7 +15,7 @@ content:
       upstream_image: registry.ci.openshift.org/ocp-multi/builder:rhel-9-golang-previous-openshift-{MAJOR}.{MINOR}
 
 from:
-  stream: rhel-9-golang-1.19
+  stream: rhel-9-golang # was 1.19, but we removed it from stream
 
 labels:
   io.k8s.description: golang builder image for Red Hat CI

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -40,7 +40,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang-1.19
+  - stream: golang
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+

--- a/streams.yml
+++ b/streams.yml
@@ -58,24 +58,6 @@ rhel-9-golang-1.21:
 #   mirror_manifest_list: true
 #   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-golang-1.19:
-  image: openshift/golang-builder:v1.19.13-202310161907.el8.g0d095f7
-  mirror: true
-  transform: rhel-8/golang
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
-  upstream_image_mirror:
-  - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
-
-ibm-rhel-8-golang-1.19:
-  # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.19.13-202310161907.el8.g0d095f7
-  mirror: true
-  mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
-
 golang:
   image: openshift/golang-builder:v1.20.10-202310161945.el8.gdc4b478
   mirror: true
@@ -94,24 +76,6 @@ ibm-rhel-8-golang-1.20:
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang-1.19:
-  image: openshift/golang-builder:v1.19.13-202310161903.el9.g0f9bb4c
-  mirror: true
-  transform: rhel-9/golang
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
-  upstream_image_mirror:
-  - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
-
-ibm-rhel-9-golang-1.19:
-  # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.19.13-202310161903.el9.g0f9bb4c
-  mirror: true
-  mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
-
 rhel-9-golang:
   image: openshift/golang-builder:v1.20.10-202310161945.el9.gbbb66ea
   mirror: true
@@ -129,15 +93,6 @@ ibm-rhel-9-golang-1.20:
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
-
-# This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
-# Our transform is designed to create a buildconfig atop a specific golang version, layering on
-# packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-1.19-ci-build-root:
-  image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
-  transform: rhel-8/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on


### PR DESCRIPTION
Golang-1.19 should not be used anymore in 4.15. This removes all stanzas to keep the builds updated in CI. We missed to update ovn to 1.20. This is already updated in upstream CI.