### PR TITLE
OSDOCS-8829: fix url in microshift 4.14 errata text

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -157,16 +157,14 @@ boilerplates:
 
       All of the bug fixes may not be documented in this advisory. Read the following release notes documentation for details about these changes:
 
-      https://access.redhat.com/documentation/en-us/microshift/4.14/html/release_notes/index
+      https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14/html/release_notes/index
 
 
       All Red Hat build of MicroShift 4.14 users are advised to use these updated packages and images when they are available in the RPM repository.
     solution: |
-      MicroShift 4.[y].[z] - RPMs
+      For MicroShift 4.14, read the following documentation, which will be updated shortly for this release, for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
 
-      For MicroShift 4.[y], read the following documentation, which will be updated shortly for this release, for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
-
-      https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.[y]/html/release_notes/index
+      https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14/html/release_notes/index
   cve:
     synopsis: OpenShift Container Platform 4.14.z security update
     topic: |


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-8825](https://issues.redhat.com/browse/OSDOCS-8825)

Updates broken URL in Product Description and inserts version numbering as applicable.
