### PR TITLE
Revert 4 images to rhel8

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-8-golang-ci-build-root
     pkg_managers:
     - yarn
     artifacts:
@@ -20,17 +20,17 @@ content:
         source-url: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-source-v1.22.19.tar.gz
         source-sha256: 50af0025d2ef942bf3e6cdd0587dc9c4dd8d6e6e69501b84935d09f2b2b5de8b
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: monitoring-plugin-container
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-baseos-rpms
 for_payload: true
 from:
   builder:
   - stream: nodejs
-  member: openshift-enterprise-base-rhel9
-name: openshift/ose-monitoring-plugin-rhel9
+  member: openshift-enterprise-base
+name: openshift/ose-monitoring-plugin-rhel8
 payload_name: monitoring-plugin
 owners:
 - team-observability-ui@redhat.com

--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -10,17 +10,17 @@ content:
         target: release-{MAJOR}.{MINOR}
     dockerfile: Dockerfile.rhel7
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-azure-workload-identity-webhook-container
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
-  member: openshift-enterprise-base-rhel9
-name: openshift/ose-azure-workload-identity-webhook-rhel9
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-azure-workload-identity-webhook-rhel8
 payload_name: azure-workload-identity-webhook
 owners:
 - aos-hive@redhat.com

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -9,19 +9,19 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-8-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-cluster-olm-operator-container
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
-  member: openshift-enterprise-base-rhel9
-name: openshift/ose-cluster-olm-rhel9-operator
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-cluster-olm-operator-rhel8
 payload_name: cluster-olm-operator
 owners:
 - angoldst@redhat.com

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -15,19 +15,19 @@ content:
         - bugzilla/valid-bug
         - cherry-pick-approved
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-8-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-libvirt-machine-controllers-container
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
-  member: openshift-enterprise-base-rhel9
-name: openshift/ose-libvirt-machine-controllers-rhel9
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-libvirt-machine-controllers
 payload_name: libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -15,19 +15,20 @@ content:
         - bugzilla/valid-bug
         - cherry-pick-approved
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-libvirt-machine-controllers-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-codeready-builder-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-libvirt-machine-controllers
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-libvirt-machine-controllers-rhel9
 payload_name: libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com


### PR DESCRIPTION
[monitoring-plugin](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=57235742)
```
ENV NGINX_VERSION=1.20
RUN yum -y module enable nginx:$NGINX_VERSION  &&     INSTALL_PKGS="nginx"  &&     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS
Error: Problems in request:
missing groups or modules: nginx:1.20
```

[azure-workload-identity-webook](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=57235741)
```
BuildError: package (container) ose-azure-workload-identity-webhook-container not in list for tag rhaos-4.15-rhel-9-candidate
```

[ose-cluster-olm-operator](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=57235731)
```
BuildError: package (container) ose-cluster-olm-operator-container not in list for tag rhaos-4.15-rhel-9-candidate
```
[ose-libvirt-machine-controllers](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=57235728)
```
RUN yum install -y libvirt-devel
No match for argument: libvirt-devel
```