### PR TITLE
Restore libvirt-machine-controllers to rhel8

### DIFF
--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -15,20 +15,19 @@ content:
         - bugzilla/valid-bug
         - cherry-pick-approved
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-8-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-libvirt-machine-controllers-container
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
-- rhel-9-codeready-builder-rpms
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
-  member: openshift-enterprise-base-rhel9
-name: openshift/ose-libvirt-machine-controllers-rhel9
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-libvirt-machine-controllers
 payload_name: libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com


### PR DESCRIPTION
The image build is looking to install genisoimage, which does not seem shipped in rhel9. Reverting to rhel8 for now.