### PR TITLE
ART-8364 Stop building CI images

### DIFF
--- a/images/ci-openshift-golang-builder-extra.yml
+++ b/images/ci-openshift-golang-builder-extra.yml
@@ -1,3 +1,6 @@
+# CI image should build only when golang stream is updated, see ART-8364
+# this also turns off ci_alignment:mirroring for now
+mode: disabled
 content:
   set_build_variables: false
   source:

--- a/images/ci-openshift-golang-builder-latest.yml
+++ b/images/ci-openshift-golang-builder-latest.yml
@@ -1,3 +1,6 @@
+# CI image should build only when golang stream is updated, see ART-8364
+# this also turns off ci_alignment:mirroring for now
+mode: disabled
 content:
   set_build_variables: false
   source:

--- a/images/ci-openshift-golang-builder-previous.yml
+++ b/images/ci-openshift-golang-builder-previous.yml
@@ -1,4 +1,4 @@
-mode: disabled
+mode: disabled # to be enabled when we start using a golang stream that is not in latest/extra
 content:
   set_build_variables: false
   source:


### PR DESCRIPTION
CI images right now are building whenever any commit lands on the branch,
since their Dockerfile resides on the branch. This leads to unecessary rebuilds 
since the branch is not specific to CI images and gets a lot of churn. 

We still want to build CI images when it's parent `stream:golang` updates.
`mode:disabled` also stops these images from appearing in sync-ci-images job
Good thing is `stream:golang` updates are infrequent, so we will not be out of
sync anytime soon.

https://issues.redhat.com/browse/ART-8364 is for discussing solutions to get 
around this. until then, stop building them
