### PR TITLE
Fixing typo in ose-gcp-cluster-api-controllers-container mapping

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -584,7 +584,7 @@ bug_mapping:
       issue_component: Networking / Metal LB
     ose-gcp-cloud-controller-manager-container:
       issue_component: Cloud Compute / Cloud Controller Manager
-    ose-gcp-cluster-api-controllers:
+    ose-gcp-cluster-api-controllers-container:
       issue_component: Cloud Compute / Other Provider
     ose-gcp-filestore-csi-driver-container:
       issue_component: Storage


### PR DESCRIPTION
This allows bugs like https://issues.redhat.com/browse/OCPBUGS-24076 to be routed automatically to the correct team.