### PR TITLE
Add web links to RPMs

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -10,6 +10,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/microshift.git
+      web: https://github.com/openshift/microshift
     specfile: packaging/rpm/microshift.spec
     modifications:
     - action: command

--- a/rpms/openshift-ansible.yml
+++ b/rpms/openshift-ansible.yml
@@ -4,6 +4,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/openshift-ansible.git
+      web: https://github.com/openshift/openshift-ansible
     specfile: openshift-ansible.spec
 name: openshift-ansible
 targets:

--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -4,6 +4,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oc.git
+      web: https://github.com/openshift/oc
     specfile: oc.spec
 name: openshift-clients
 owners:

--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -5,6 +5,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes.git
+      web: https://github.com/openshift/kubernetes
   build:
     use_source_tito_config: false
     tito_target: aos-{MAJOR}.{MINOR}

--- a/rpms/openshift4-aws-iso.yml
+++ b/rpms/openshift4-aws-iso.yml
@@ -4,6 +4,7 @@ content:
       branch:
         target: main
       url: git@github.com:openshift/c2s-install.git
+      web: https://github.com/openshift/c2s-install
     specfile: rpm.spec
 name: openshift4-aws-iso
 owners:


### PR DESCRIPTION
SAST pipeline looks at the `web` part to get the URL to display upstream commit.