### PR TITLE
Pin dtk until newer rhcos

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -165,3 +165,8 @@ releases:
             scan_sources:
               exempted_packages:
               - tzdata
+        - distgit_key: driver-toolkit
+          why: pin to latest rhcos with matching kernel version
+          metadata:
+            is:
+              nvr: driver-toolkit-container-v4.15.0-202311220209.p0.gf259897.assembly.stream


### PR DESCRIPTION
rhcos builds are failing, and the consistency requirement that dtk and rhcos have the same kernel build prevents us from creating nightlies.

This commit pins dtk to the build of the most recent nightly.

Note that nightly creation will fail again when rhcos builds succeed. Which is what we want, because then we will not forget to revert this.