### PR TITLE
4.11: Do not rebuild because of redhat-release 

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -2163,8 +2163,9 @@ releases:
       members:
         images:
         - distgit_key: '*'
-          why: Exclude tzdata updates
+          why: Exclude package updates that should not cause mass rebuilds
           metadata:
             scan_sources:
               exempted_packages:
+              - redhat-release  # documents rhel release notes and concerns
               - tzdata


### PR DESCRIPTION
Cherrypick of https://github.com/openshift-eng/ocp-build-data/pull/3967