### PR TITLE
Bump csi-external-snapshotter to rhel9

### DIFF
--- a/images/ose-csi-external-snapshotter.yml
+++ b/images/ose-csi-external-snapshotter.yml
@@ -10,24 +10,24 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-external-snapshotter-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 dependents:
 - ose-gcp-filestore-csi-driver-operator
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-csi-external-snapshotter
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-csi-external-snapshotter-rhel9
 payload_name: csi-external-snapshotter
 name_in_bundle: csi-external-snapshotter
 owners:


### PR DESCRIPTION
Depends on https://github.com/openshift/csi-external-snapshotter/pull/120

Test build: [ose-gcp-filestore-csi-driver-operator-container-v4.15.0-202312011134.p0.g83afb87.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2802488)