### PR TITLE
openstack-cluster-api-controllers-container mapping

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -382,6 +382,8 @@ bug_mapping:
       issue_component: Security Profiles Operator
     openshift-state-metrics-container:
       issue_component: Monitoring
+    openstack-cluster-api-controllers-container:
+      issue_component: Cloud Compute / Other Provider
     openstack-ironic:
       issue_component: Bare Metal Hardware Provisioning / ironic
     openstack-ironic-inspector:


### PR DESCRIPTION
This should help bugs like https://issues.redhat.com/browse/OCPBUGS-24296 automatically be routed to the correct team.