### PR TITLE
Split cli artifacts into two images

### DIFF
--- a/images/ose-cli-artifacts-alt.yml
+++ b/images/ose-cli-artifacts-alt.yml
@@ -1,3 +1,8 @@
+# These arches require compatibility with RHEL 7
+arches:
+- x86_64
+- ppc64le
+- s390x
 content:
   source:
     dockerfile: images/cli-artifacts/Dockerfile.rhel
@@ -19,8 +24,9 @@ for_payload: true
 from:
   builder:
   - stream: golang
-  - stream: golang
+  - stream: rhel-7-golang
   member: openshift-enterprise-cli
-name: openshift/ose-cli-artifacts
+name: openshift/ose-cli-artifacts-alt
+payload_name: cli-artifacts
 owners:
 - aos-master@redhat.com


### PR DESCRIPTION
RHEL7 does not support ARM, so it is necessary to build an alt image which excludes that architecture with RHEL7 builder images.
The ARM image will contain oc.rhel7, but it will only be built for RHEL8. Confusing, but we don't have a better approach at the moment.