### PR TITLE
Do not reuse prerelease advisory

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -12,7 +12,7 @@ releases:
           metadata: 123984
           microshift: 123985
           rpm: 123986
-          prerelease: 123948
+          prerelease: -1
         release_jira: ART-8258
         upgrades: 4.14.4,4.14.5,4.15.0-ec.0,4.15.0-ec.1,4.15.0-ec.2
       permits:


### PR DESCRIPTION
Since its already shipped live, we need to create a new one.