### PR TITLE
fix ose-installer-artifacts builder

### DIFF
--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -23,6 +23,7 @@ from:
   - stream: golang
   - stream: golang
   - stream: golang
+  - stream: golang
   member: ose-installer
 name: openshift/ose-installer-artifacts
 payload_name: installer-artifacts


### PR DESCRIPTION
add a new builder item to align with the upstream change https://github.com/openshift/installer/commit/f5c4035dd74271f2bf12b4a33eb93f0d1a05979e