### PR TITLE
Build apiserver-network-proxy on etcd_golang stream

### DIFF
--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -19,7 +19,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: etcd_golang  # this image needs a more recent golang, since it consumes from a 4.14 branch
   member: openshift-enterprise-base
 name: openshift/ose-apiserver-network-proxy
 owners:


### PR DESCRIPTION
This is to fix repeated 4.11 failures for [ose-apiserver-network-proxy-container](https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=81734)

`apiserver-network-proxy` is consuming 4.14 content that needs a newer golang builder than the one currently configured for 4.11. `etcd_golang` stream is already high enough, pointing at `openshift/golang-builder:v1.19.13-202310161907.el8.g0d095f7`. So instead of bumping the `golang` stream, we might just reuse that one only for `apiserver-network-proxy`.

Successful test build: [ose-apiserver-network-proxy-container-v4.11.0-202312041132.p0.g3362d67.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2805058)