### PR TITLE
disable OCPBUGS pipeline feature for 4.16

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -517,4 +517,4 @@ external_scanners:
       # Enable feature to raise OCPBUGS Jira tickets if SAST scan issues are found
       # This flag enables for this OCP version, but it also has to be enabled specifically in the image config
       # as well
-      enabled: true
+      enabled: false  # Until 4.16.0 target version exists


### PR DESCRIPTION
Until target version `4.16.0` is created
