### PR TITLE
[4.16] Remove some owners in ose-baremetal-operator and baremetal-machine-controller

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -26,9 +26,7 @@ from:
 name: openshift/ose-baremetal-machine-controllers-rhel9
 payload_name: baremetal-machine-controllers
 owners:
-- kni-devel@redhat.com
 - kni-deployment-devel@redhat.com
 - rbryant@redhat.com
 - dhellman@redhat.com
 - mhrivnak@redhat.com
-- shardy@redhat.com

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -24,10 +24,8 @@ from:
 name: openshift/ose-baremetal-rhel9-operator
 payload_name: baremetal-operator
 owners:
-- kni-devel@redhat.com
 - kni-deployment-devel@redhat.com
 - rbryant@redhat.com
 - dhellmann@redhat.com
 - zbitter@redhat.com
 - mhrivnak@redhat.com
-- shardy@redhat.com


### PR DESCRIPTION
This commit removes kni-devel ML, so we don't spam it with emails about failures. Remove shardy@redhat.com, since he left the company