### PR TITLE
[4.12] Remove some owners in ose-baremetal-operator and baremetal-machine-controller

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -22,9 +22,7 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-baremetal-machine-controllers
 owners:
-- kni-devel@redhat.com
 - kni-deployment-devel@redhat.com
 - rbryant@redhat.com
 - dhellman@redhat.com
 - mhrivnak@redhat.com
-- shardy@redhat.com

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -20,10 +20,8 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-baremetal-operator
 owners:
-- kni-devel@redhat.com
 - kni-deployment-devel@redhat.com
 - rbryant@redhat.com
 - dhellmann@redhat.com
 - zbitter@redhat.com
 - mhrivnak@redhat.com
-- shardy@redhat.com


### PR DESCRIPTION
This commit removes kni-devel ML, so we don't spam it with emails about failures. 
Remove shardy@redhat.com, since he left the company