### PR TITLE
[4.11] Remove some owners in ose-baremetal-operator, baremetal-machine-controller and ironic-agent

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -22,9 +22,7 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-baremetal-machine-controllers
 owners:
-- kni-devel@redhat.com
 - kni-deployment-devel@redhat.com
 - rbryant@redhat.com
 - dhellman@redhat.com
 - mhrivnak@redhat.com
-- shardy@redhat.com

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -14,14 +14,12 @@ from:
   member: openshift-base-rhel8
 name: openshift/ose-ironic-agent
 owners:
-- kni-devel@redhat.com
 - dtantsur@redhat.com
 - bfournie@redhat.com
 - rpittau@redhat.com
 - derekh@redhat.com
 - rbryant@redhat.com
 - dhellmann@redhat.com
-- shardy@redhat.com
 enabled_repos:
 - rhel-8-appstream-rpms
 - rhel-8-baseos-rpms

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -20,10 +20,8 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-baremetal-operator
 owners:
-- kni-devel@redhat.com
 - kni-deployment-devel@redhat.com
 - rbryant@redhat.com
 - dhellmann@redhat.com
 - zbitter@redhat.com
 - mhrivnak@redhat.com
-- shardy@redhat.com


### PR DESCRIPTION
This commit removes kni-devel ML, so we don't spam it with emails about failures. 
Remove shardy@redhat.com, since he left the company