### PR TITLE
[SAST] add missing product mappings

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -39,6 +39,12 @@ bug_mapping:
       issue_component: Build
     butane:
       issue_component: RHCOS
+    ci-openshift-golang-builder-extra-container:
+      issue_component: Release
+    ci-openshift-golang-builder-latest-container:
+      issue_component: Release
+    ci-openshift-golang-builder-previous-container:
+      issue_component: Release
     cincinnati-operator-container:
       issue_component: OpenShift Update Service / operator
     cloud-event-proxy-container:
@@ -288,6 +294,12 @@ bug_mapping:
       issue_component: kube-apiserver
     openshift-ansible:
       issue_component: Installer / openshift-ansible
+    openshift-base-nodejs-container:
+      issue_component: Release
+    openshift-base-rhel8-container:
+      issue_component: Release
+    openshift-base-rhel9-container:
+      issue_component: Release
     openshift-clients:
       issue_component: oc
     openshift-compliance-content-container:
@@ -306,6 +318,8 @@ bug_mapping:
       issue_component: Service Broker
     openshift-enterprise-asb-container:
       issue_component: Service Broker
+    openshift-enterprise-base-rhel9-container:
+      issue_component: Release
     openshift-enterprise-builder-container:
       issue_component: Build
     openshift-enterprise-cli-alt-container:
@@ -439,6 +453,8 @@ bug_mapping:
     ose-aws-efs-csi-driver-operator-bundle-container:
       issue_component: Storage
     ose-aws-efs-csi-driver-operator-container:
+      issue_component: Storage
+    ose-aws-efs-utils-container:
       issue_component: Storage
     ose-aws-machine-controllers-container:
       issue_component: Cloud Compute / Other Provider


### PR DESCRIPTION
Since ART builds
```
openshift-base-nodejs-container
openshift-base-rhel8-container
ci-openshift-golang-builder-extra-container
ci-openshift-golang-builder-latest-container
ci-openshift-golang-builder-previous-container
openshift-base-rhel9-container
openshift-enterprise-base-rhel9-container
```
adding them to `Release`

And adding `ose-aws-efs-utils-container` to `Storage` along with the other `ose-aws-efs-*`