### PR TITLE
ec.3 set operator index mode to pre-release

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -13,6 +13,7 @@ releases:
           microshift: 123985
           rpm: 123986
           prerelease: 124846
+        operator_index_mode: pre-release
         release_jira: ART-8258
         upgrades: 4.14.4,4.14.5,4.15.0-ec.0,4.15.0-ec.1,4.15.0-ec.2
       permits:


### PR DESCRIPTION
Keeping the `operator_index_mode` as `pre-release` will add the `com.redhat.prerelease` which is needed by the pre-release advisory