### PR TITLE
[sast] exclude kernel and systemd

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -534,3 +534,7 @@ external_scanners:
       - numaresources-operator-container
       - topology-aware-lifecycle-manager-operator-container
       - baremetal-hardware-event-proxy-container
+      # Requested ART to exclude
+      - kernel
+      - kernel-rt
+      - systemd


### PR DESCRIPTION
Respective teams have requested ART to exclude them from SAST workflow