### PR TITLE
4.16: Revert default golang to 1.20

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -19,7 +19,7 @@
 #
 ####################################################################################################
 
-golang:
+golang-1.21:
   image: openshift/golang-builder:v1.21.3-202311221709.el8.gf79bf9c 
   mirror: true
   transform: rhel-8/golang
@@ -30,7 +30,7 @@ golang:
   upstream_image_mirror:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang:
+rhel-9-golang-1.21:
   image: openshift/golang-builder:v1.21.3-202311211941.el9.g7b42730
   mirror: true
   transform: rhel-9/golang
@@ -55,7 +55,7 @@ ibm-rhel-8-golang-1.21:
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-golang-1.20:
+golang:
   image: openshift/golang-builder:v1.20.10-202310161945.el8.gdc4b478
   mirror: true
   transform: rhel-8/golang
@@ -73,7 +73,7 @@ ibm-rhel-8-golang-1.20:
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang-1.20:
+rhel-9-golang:
   image: openshift/golang-builder:v1.20.10-202310161945.el9.gbbb66ea
   mirror: true
   transform: rhel-9/golang
@@ -94,7 +94,7 @@ ibm-rhel-9-golang-1.20:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-1.20-ci-build-root:
+rhel-8-golang-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
@@ -103,7 +103,7 @@ rhel-8-golang-1.20-ci-build-root:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-ci-build-root:
+rhel-8-golang-1.21-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
@@ -112,7 +112,7 @@ rhel-8-golang-ci-build-root:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-9-golang-ci-build-root:
+rhel-9-golang-1.21-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
   transform: rhel-9/ci-build-root
@@ -121,7 +121,7 @@ rhel-9-golang-ci-build-root:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-9-golang-1.20-ci-build-root:
+rhel-9-golang-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-9/ci-build-root


### PR DESCRIPTION
We currently have `canonical_builders_from_upstream: False` in group.yml. This means that the golang builders defined in ocp-build-data for images are taken, without consideration of what builder images are defined in upstream dockerfiles.

Recently, while adding the 1.21 golang, we made it the default. This means that the production builds made the change immediately.

To set `canonical_builders_from_upstream` to the value we'd expect at this phase of 4.16, is a bit risky. Image builds will potentially break for those images that made the switch to rhel9, but have not had that switch reflected through reconciliation PRs.

The proposal of this PR is:
- to restore the default golang builder to 1.20
- to work to get existing reconciliation prs merged, in order to switch canonical_builders_from_upstream to true
- if anyone needs 1.21, open a PR to this repo for your image to consume the 1.21 builder