### PR TITLE
ART-8170: Use 4.16-9.2 for 4.16

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -96,7 +96,7 @@ urls:
   brew_image_namespace: rh-osbs
   cgit: https://pkgs.devel.redhat.com/cgit
   rhcos_release_base:
-    multi: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/4.15-9.2/builds
+    multi: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/4.16-9.2/builds
 dist_git_ignore:
   - gating.yaml
 


### PR DESCRIPTION
rhcos 4.16 pipeline is created now https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/4.16-9.2/builds/416.92.202312090309-0/x86_64/meta.json