### PR TITLE
[4.14] [scan-osh] disable OCPBUGS workflow

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -491,7 +491,7 @@ external_scanners:
       # Enable feature to raise OCPBUGS Jira tickets if SAST scan issues are found
       # This flag enables for this OCP version, but it also has to be enabled specifically in the image config
       # as well
-      enabled: true
+      enabled: false
 
       exclude_components:
       # Built by CPAAS


### PR DESCRIPTION
Disable temporarily so that we can phase out the deployment.