### PR TITLE
[ART-8416] Add check_external_packages config options - 4.16

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -75,6 +75,29 @@ rhcos:
   # Set to true to allow CentOS content in RHCOS
   allow_missing_brew_rpms: false
 
+check_external_packages:
+  - name: cri-o
+    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
+    condition: match
+  - name: cri-tools
+    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
+    condition: match
+  - name: conmon
+    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
+    condition: match
+  - name: skopeo
+    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
+    condition: match
+  - name: runc
+    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
+    condition: match
+  - name: containernetworking-plugins
+    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
+    condition: match
+  - name: NetworkManager
+    tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
+    condition: greater_equal
+
 default_image_build_profile: unsigned
 default_rpm_build_profile: default
 


### PR DESCRIPTION
This PR adds config options for Doozer to check external rpms (rpms tagged into rhaos but not owned by ART).

This config is to support https://github.com/openshift-eng/art-tools/pull/245