### PR TITLE
Remove olm image from any dependents

### DIFF
--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -19,7 +19,6 @@ dependents:
 - local-storage-operator
 - ingress-node-firewall-operator
 - ose-gcp-filestore-csi-driver-operator
-- ose-cluster-olm-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: kube-rbac-proxy-container

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -11,8 +11,6 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
-dependents:
-- ose-cluster-olm-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-olm-catalogd-container

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -11,8 +11,6 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
-dependents:
-- ose-cluster-olm-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-olm-operator-controller-container

--- a/images/ose-olm-rukpak.yml
+++ b/images/ose-olm-rukpak.yml
@@ -14,8 +14,6 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-olm-rukpak-container
-dependents:
-- ose-cluster-olm-operator
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
`dependents` signifies that the dependent image needs to rebuild when this image changes. (This mechanism exists on top of rebuilding when a base image changes). This is useful for operators, as they need to get rebuilt with the updated image references. As olm is a payload image, and thwe images it depends on as well, there is no need to rebuild the olm image when an image this paylooad operator depends on, changes.