### PR TITLE
4.16 - Inject art repos in ci golang builder

### DIFF
--- a/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
@@ -22,6 +22,8 @@ ADD inject-art-repos.sh /
 RUN chmod +x /inject-art-repos.sh
 RUN rm -f /etc/yum.repos.d/*
 # todo: ADD localdev.repo /etc/yum.repos.d
+ONBUILD ARG MAJOR=''
+ONBUILD ARG MINOR=''
 ONBUILD RUN /inject-art-repos.sh
 
 # Some image building tools don't create a missing WORKDIR

--- a/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
@@ -18,6 +18,12 @@ RUN mkdir -p $GOPATH && \
     chmod g+xw -R $GOPATH && \
     chmod g+xw -R $(go env GOROOT)
 
+ADD inject-art-repos.sh
+RUN chmod +x /inject-art-repos.sh
+RUN rm -f /etc/yum.repos.d/*
+ADD localdev.repo /etc/yum.repos.d
+ONBUILD RUN inject-art-repos.sh
+
 # Some image building tools don't create a missing WORKDIR
 RUN mkdir -p /go/src/github.com/openshift/origin
 WORKDIR /go/src/github.com/openshift/origin

--- a/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
@@ -18,11 +18,11 @@ RUN mkdir -p $GOPATH && \
     chmod g+xw -R $GOPATH && \
     chmod g+xw -R $(go env GOROOT)
 
-ADD inject-art-repos.sh
+ADD inject-art-repos.sh /
 RUN chmod +x /inject-art-repos.sh
 RUN rm -f /etc/yum.repos.d/*
 ADD localdev.repo /etc/yum.repos.d
-ONBUILD RUN inject-art-repos.sh
+ONBUILD RUN /inject-art-repos.sh
 
 # Some image building tools don't create a missing WORKDIR
 RUN mkdir -p /go/src/github.com/openshift/origin

--- a/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p $GOPATH && \
 ADD inject-art-repos.sh /
 RUN chmod +x /inject-art-repos.sh
 RUN rm -f /etc/yum.repos.d/*
-ADD localdev.repo /etc/yum.repos.d
+# todo: ADD localdev.repo /etc/yum.repos.d
 ONBUILD RUN /inject-art-repos.sh
 
 # Some image building tools don't create a missing WORKDIR

--- a/images/ci-openshift-golang-builder-latest.yml
+++ b/images/ci-openshift-golang-builder-latest.yml
@@ -15,6 +15,11 @@ content:
       mirror: true
       mirror_manifest_list: true
       upstream_image: registry.ci.openshift.org/ocp-multi/builder:rhel-9-golang-latest-openshift-{MAJOR}.{MINOR}
+    modifications:
+    - action: add
+      doozer_source: inject-art-repos.sh
+      path: inject-art-repos.sh
+      overwriting: true
 from:
   stream: rhel-9-golang
 labels:

--- a/images/ci-openshift-golang-builder-latest.yml
+++ b/images/ci-openshift-golang-builder-latest.yml
@@ -20,6 +20,12 @@ content:
       doozer_source: inject-art-repos.sh
       path: inject-art-repos.sh
       overwriting: true
+    - action: replace
+      match: "ARG MAJOR=''"
+      replacement: "ARG MAJOR='{MAJOR}'"
+    - action: replace
+      match: "ARG MINOR=''"
+      replacement: "ARG MINOR='{MINOR}'"
 from:
   stream: rhel-9-golang
 labels:

--- a/images/ci-openshift-golang-builder-latest.yml
+++ b/images/ci-openshift-golang-builder-latest.yml
@@ -7,9 +7,9 @@ content:
     dockerfile: ci_images/rhel-9/ci-openshift-golang-builder-latest/Dockerfile
     git:
       branch:
-        target: openshift-{MAJOR}.{MINOR}
+        target: art_6804_416
       url: git@github.com:openshift-eng/ocp-build-data.git
-      web: https://github.com/openshift-eng/ocp-build-data
+      web: https://github.com/thegreyd/ocp-build-data
     ci_alignment:
       enabled: false
       mirror: true

--- a/images/ci-openshift-golang-builder-latest.yml
+++ b/images/ci-openshift-golang-builder-latest.yml
@@ -8,8 +8,8 @@ content:
     git:
       branch:
         target: art_6804_416
-      url: git@github.com:openshift-eng/ocp-build-data.git
-      web: https://github.com/thegreyd/ocp-build-data
+      url: git@github.com:thegreyd/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       enabled: false
       mirror: true


### PR DESCRIPTION
Should go with https://github.com/openshift-eng/art-tools/pull/255 

## Test
Fetch the above PR branch locally `thegreyd:art_6804`, then run
```bash
# rebase
$ doozer --data-path https://github.com/thegreyd/ocp-build-data --assembly test -g openshift-4.16@art_6804_416 -i ci-openshift-golang-builder-latest images:rebase --version v1 --release "20231213.el9.p?" -m "testing" --push
# build
$ doozer --data-path https://github.com/thegreyd/ocp-build-data --assembly test -g openshift-4.16@art_6804_416 -i ci-openshift-golang-builder-latest --latest-parent-version images:build
```

https://pkgs.devel.redhat.com/cgit/containers/ci-openshift-golang-builder-latest/commit/?h=v1.0.0-20231213.el9.p0.g070b361.assembly.test&id=34180098170d4dced293d6b7ac76a26b35a5d434

[ci-openshift-golang-builder-latest-container-v1.0.0-20231213.el9.p0.g070b361.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820445)

Mirrored to `registry.ci.openshift.org/ocp-multi/builder:rhel-9-golang-test-openshift-4.16`

Test PR: https://github.com/openshift/oc/pull/1634

Update: `ONBUILD is not supported for OCI image format, %s will be ignored. Must use 'docker' format` since we are building in brew and using oci format we cannot use onbuild. [slack convo](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1702505152726879?thread_ts=1702488458.827119&cid=GDBRP5YJH)