### PR TITLE
fix ose-secrets-store-csi-driver-operator reference

### DIFF
--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -26,7 +26,7 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-secrets-store-csi-driver-rhel8-operator # name in comet
-name_in_bundle: secrets-store-csi-driver-rhel8-operator # name in image reference
+name_in_bundle: secrets-store-csi-driver-operator # name in image reference
 owners:
 - aos-storage-staff@redhat.com
 update-csv:


### PR DESCRIPTION
ref https://github.com/openshift/secrets-store-csi-driver-operator/blob/release-4.16/config/manifests/preview/image-references#L6
failed build : https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/50427/