### PR TITLE
Disable secrets-store-csi-driver-operator

### DIFF
--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -17,7 +17,7 @@ content:
 dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator
-- ose-secrets-store-csi-driver-operator
+# - ose-secrets-store-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: csi-livenessprobe-container

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -17,7 +17,7 @@ content:
 dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator
-- ose-secrets-store-csi-driver-operator
+# - ose-secrets-store-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: csi-node-driver-registrar-container

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled  # XXX: is not yet set up in brew and related places, disabling image for now
 content:
   source:
     dockerfile: Dockerfile.openshift
@@ -9,23 +10,23 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-secrets-store-csi-driver-operator-container
   bundle_component: ose-secrets-store-csi-driver-operator-bundle-container # name in brew
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-secrets-store-csi-driver-rhel8-operator # name in comet
+  - stream: rhel-9-golang-1.21
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-secrets-store-csi-driver-rhel9-operator
 name_in_bundle: secrets-store-csi-driver-operator # name in image reference
 owners:
 - aos-storage-staff@redhat.com

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -1,3 +1,4 @@
+mode: disabled # operator does not yet have rhel9 bits set up
 content:
   source:
     dockerfile: Dockerfile.openshift
@@ -27,7 +28,7 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-secrets-store-csi-driver-rhel8
+name: openshift/ose-secrets-store-csi-driver-rhel
 name_in_bundle: secrets-store-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -1,3 +1,4 @@
+mode: disabled # brew and related config is not set up for rhel9, disabling for now
 content:
   source:
     dockerfile: Dockerfile.mustgather
@@ -9,17 +10,20 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
+dependents:
+- ose-secrets-store-csi-driver-operator
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-secrets-store-csi-mustgather-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
 for_payload: false
 name_in_bundle: secrets-store-csi-mustgather
 from:
-  member: openshift-enterprise-cli
-name: openshift/ose-secrets-store-csi-mustgather-rhel8
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-secrets-store-csi-mustgather-rhel9
 owners:
 - aos-storage-staff@redhat.com


### PR DESCRIPTION
Brew and product configuration is not yet ready for rhel9. Disabling the operator + operands for now, and configuring all to work for after the product bits are set up.