### PR TITLE
Suggest moving to golang-1.21, listen to upstream for base images

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -503,7 +503,7 @@ check_golang_versions: "exact"
 
 # until feature freeze, prefer to use the golang builder that the upstream CI build is using
 # if different from what ART has configured, encouraging deliberate transitioning.
-canonical_builders_from_upstream: False
+canonical_builders_from_upstream: True
 
 # To decide whether to build and use signed RPMs, and to decide if a strict bug validation flow is necessary.
 # If it will ship via errata (state=release), we want to build signed.

--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -21,7 +21,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-base-rhel9
 labels:
   License: ASL 2.0
@@ -33,3 +33,4 @@ name: openshift/ose-cluster-autoscaler-rhel9
 payload_name: cluster-autoscaler
 owners:
 - avagarwa@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -21,9 +21,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-baremetal-runtimecfg-rhel9
 payload_name: baremetal-runtimecfg
 owners:
 - asegurap@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -21,9 +21,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-etcd-rhel9-operator
 payload_name: cluster-etcd-operator
 owners:
 - sbatsche@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/cluster-monitoring-operator.yml
+++ b/images/cluster-monitoring-operator.yml
@@ -20,7 +20,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang-1.21
+  - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 labels:
   License: ASL 2.0

--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-network-rhel9-operator
 payload_name: cluster-network-operator
 owners:
 - aos-networking-staff@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-coredns-rhel9
 payload_name: coredns
 owners:
 - aos-network-edge@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/golang-github-openshift-oauth-proxy.yml
+++ b/images/golang-github-openshift-oauth-proxy.yml
@@ -18,7 +18,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-base-rhel9
 labels:
   License: GPLv2+
@@ -30,3 +30,4 @@ name: openshift/ose-oauth-proxy-rhel9
 payload_name: oauth-proxy
 owners:
 - aos-apiserver@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-hypershift-rhel9
 payload_name: hypershift
 owners:
 - hypershift-team@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-kube-proxy-rhel9
 payload_name: kube-proxy
 owners:
 - aos-networking-staff@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/oauth-server.yml
+++ b/images/oauth-server.yml
@@ -21,9 +21,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-oauth-server-rhel9
 payload_name: oauth-server
 owners:
 - mfojtik@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -19,7 +19,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-console-rhel9-operator
 payload_name: console-operator
@@ -27,3 +27,4 @@ owners:
 - bpeterse@redhat.com
 - spadgett@redhat.com
 - jforrest@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -27,3 +27,4 @@ name: openshift/ose-keepalived-ipfailover-rhel9
 payload_name: keepalived-ipfailover
 owners:
 - aos-network-edge@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -21,7 +21,7 @@ envs:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+
@@ -33,3 +33,4 @@ name: openshift/ose-operator-lifecycle-manager-rhel9
 payload_name: operator-lifecycle-manager
 owners:
 - aos-odin@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-apiserver-network-proxy-rhel9
 payload_name: apiserver-network-proxy
 owners:
 - hypershift-team@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-cluster-config-operator.yml
+++ b/images/ose-cluster-config-operator.yml
@@ -15,10 +15,11 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-config-rhel9-operator
 payload_name: cluster-config-operator
 owners:
 - aos-master@redhat.com
 - tnozicka@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-cluster-dns-operator.yml
+++ b/images/ose-cluster-dns-operator.yml
@@ -18,9 +18,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-dns-rhel9-operator
 payload_name: cluster-dns-operator
 owners:
 - aos-network-edge@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-cluster-ingress-operator.yml
+++ b/images/ose-cluster-ingress-operator.yml
@@ -18,9 +18,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-ingress-rhel9-operator
 payload_name: cluster-ingress-operator
 owners:
 - aos-network-edge@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-cluster-kube-apiserver-operator.yml
+++ b/images/ose-cluster-kube-apiserver-operator.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-kube-apiserver-rhel9-operator
 payload_name: cluster-kube-apiserver-operator
 owners:
 - aos-master@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-cluster-kube-cluster-api-operator.yml
+++ b/images/ose-cluster-kube-cluster-api-operator.yml
@@ -20,7 +20,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-kube-cluster-api-rhel9-operator
 payload_name: cluster-kube-cluster-api-operator
@@ -29,3 +29,4 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-cluster-kube-storage-version-migrator-operator.yml
+++ b/images/ose-cluster-kube-storage-version-migrator-operator.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-kube-storage-version-migrator-rhel9-operator
 payload_name: cluster-kube-storage-version-migrator-operator
 owners:
 - aos-master@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-cluster-openshift-apiserver-operator.yml
+++ b/images/ose-cluster-openshift-apiserver-operator.yml
@@ -18,9 +18,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-openshift-apiserver-rhel9-operator
 payload_name: cluster-openshift-apiserver-operator
 owners:
 - aos-master@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-cluster-openshift-controller-manager-operator.yml
+++ b/images/ose-cluster-openshift-controller-manager-operator.yml
@@ -18,9 +18,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-openshift-controller-manager-rhel9-operator
 payload_name: cluster-openshift-controller-manager-operator
 owners:
 - openshift-build-api@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-kube-storage-version-migrator.yml
+++ b/images/ose-kube-storage-version-migrator.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-kube-storage-version-migrator-rhel9
 payload_name: kube-storage-version-migrator
 owners:
 - aos-master@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-kubevirt-cloud-controller-manager.yml
+++ b/images/ose-kubevirt-cloud-controller-manager.yml
@@ -23,10 +23,11 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-kubevirt-cloud-controller-manager-rhel9
 payload_name: kubevirt-cloud-controller-manager
 owners:
 - dvossel@redhat.com
 - nargaman@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-oauth-apiserver.yml
+++ b/images/ose-oauth-apiserver.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-oauth-apiserver-rhel9
 payload_name: oauth-apiserver
 owners:
 - aos-apiserver@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-openshift-apiserver.yml
+++ b/images/ose-openshift-apiserver.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-openshift-apiserver-rhel9
 payload_name: openshift-apiserver
 owners:
 - aos-master@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-openshift-controller-manager.yml
+++ b/images/ose-openshift-controller-manager.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-openshift-controller-manager-rhel9
 payload_name: openshift-controller-manager
 owners:
 - openshift-build-api@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ovirt-csi-driver-rhel9
 payload_name: ovirt-csi-driver
 owners:
 - rgolan@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-ovirt-machine-controllers.yml
+++ b/images/ose-ovirt-machine-controllers.yml
@@ -20,9 +20,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-ovirt-machine-controllers-rhel9
 payload_name: ovirt-machine-controllers
 owners:
 - rgolan@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -24,7 +24,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-secrets-store-csi-driver-rhel9-operator
 name_in_bundle: secrets-store-csi-driver-operator # name in image reference
@@ -35,3 +35,4 @@ update-csv:
   manifests-dir: config/manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -24,7 +24,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang-1.21
+  - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-secrets-store-csi-driver-rhel9-operator
 name_in_bundle: secrets-store-csi-driver-operator # name in image reference

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -27,3 +27,4 @@ from:
 name: openshift/ose-secrets-store-csi-mustgather-rhel9
 owners:
 - aos-storage-staff@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-service-ca-operator.yml
+++ b/images/ose-service-ca-operator.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-service-ca-rhel9-operator
 payload_name: service-ca-operator
 owners:
 - aos-apiserver@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -25,9 +25,10 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sriov-network-device-plugin-rhel9
 name_in_bundle: sriov-network-device-plugin
 owners:
 - zshi@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-telemeter-rhel9
 payload_name: telemeter
 owners:
 - team-monitoring@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/streams.yml
+++ b/streams.yml
@@ -19,7 +19,7 @@
 #
 ####################################################################################################
 
-golang-1.21:
+golang:
   image: openshift/golang-builder:v1.21.3-202311221709.el8.gf79bf9c 
   mirror: true
   transform: rhel-8/golang
@@ -30,7 +30,7 @@ golang-1.21:
   upstream_image_mirror:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang-1.21:
+rhel-9-golang:
   image: openshift/golang-builder:v1.21.3-202311211941.el9.g7b42730
   mirror: true
   transform: rhel-9/golang
@@ -55,7 +55,7 @@ ibm-rhel-8-golang-1.21:
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-golang:
+golang-1.20:
   image: openshift/golang-builder:v1.20.10-202310161945.el8.gdc4b478
   mirror: true
   transform: rhel-8/golang
@@ -73,7 +73,7 @@ ibm-rhel-8-golang-1.20:
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang:
+rhel-9-golang-1.20:
   image: openshift/golang-builder:v1.20.10-202310161945.el9.gbbb66ea
   mirror: true
   transform: rhel-9/golang
@@ -94,7 +94,7 @@ ibm-rhel-9-golang-1.20:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-ci-build-root:
+rhel-8-golang-1.20-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
@@ -103,7 +103,7 @@ rhel-8-golang-ci-build-root:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-1.21-ci-build-root:
+rhel-8-golang-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
@@ -112,7 +112,7 @@ rhel-8-golang-1.21-ci-build-root:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-9-golang-1.21-ci-build-root:
+rhel-9-golang-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
   transform: rhel-9/ci-build-root
@@ -121,7 +121,7 @@ rhel-9-golang-1.21-ci-build-root:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-9-golang-ci-build-root:
+rhel-9-golang-1.20-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-9/ci-build-root


### PR DESCRIPTION
...but not all.

Some images do not have a matching rhel versions between upstream
Dockerfiles and production build config. Do not listen to upstream
Dockerfile's FROMs for these images for now.