### PR TITLE
Revert "Pin dtk to get nightlies"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -19,8 +19,3 @@ releases:
               exempt_rpms:
               - redhat-release  # documents rhel release notes and concerns
               - tzdata
-        - distgit_key: driver-toolkit
-          why: pin to latest rhcos with matching kernel version
-          metadata:
-            is:
-              nvr: driver-toolkit-container-v4.16.0-202312090830.p0.gbbe9ffc.assembly.stream


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#4084

There is a good rhcos now. Unpinning. 