### PR TITLE
Exclude some member froms from upstream initiative

### DIFF
--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -25,3 +25,4 @@ name: openshift/ose-operator-marketplace-rhel9
 payload_name: operator-marketplace
 owners:
 - aos-marketplace@redhat.com
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -28,3 +28,4 @@ name: openshift/ose-deployer
 payload_name: deployer
 owners:
 - aos-master@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -31,3 +31,4 @@ owners:
 - aos-network-edge@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: openshift-enterprise-tests-container
@@ -30,7 +30,7 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: golang-1.20
   member: ose-tools
 labels:
   License: GPLv2+
@@ -44,3 +44,4 @@ payload_name: tests
 owners:
 - aos-master@redhat.com
 - openshift-technical-release-staff@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-agent-installer-api-server-container
@@ -20,7 +20,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: golang-1.20
   - member: openshift-enterprise-cli
   member: openshift-enterprise-base
 maintainer:
@@ -32,3 +32,4 @@ owners:
 - ocp-agent-team@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-agent-installer-csr-approver-container
@@ -20,7 +20,7 @@ for_payload: true
 from:
   builder:
   - member: openshift-enterprise-cli
-  - stream: golang
+  - stream: golang-1.20
   member: openshift-enterprise-base
 maintainer:
   component: Installer
@@ -29,3 +29,4 @@ name: openshift/ose-agent-installer-csr-approver
 payload_name: agent-installer-csr-approver
 owners:
 - ocp-agent-team@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -13,7 +13,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
         auto_label:
         - approved
         - lgtm
@@ -28,9 +28,10 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: golang
+  - stream: golang-1.20
   member: ose-aws-efs-utils
 name: openshift/ose-aws-efs-csi-driver-container-rhel8
 name_in_bundle: aws-efs-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-baremetal-installer-container
@@ -22,9 +22,10 @@ for_payload: true
 from:
   builder:
   - member: ose-installer-terraform-providers
-  - stream: golang
+  - stream: golang-1.20
   member: openshift-enterprise-base
 name: openshift/ose-baremetal-installer
 payload_name: baremetal-installer
 owners:
 - kni-devel-deployment@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-cli-artifacts-container
@@ -20,11 +20,12 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
-  - stream: rhel-9-golang
+  - stream: golang-1.20
+  - stream: rhel-9-golang-1.20
   member: openshift-enterprise-cli
 name: openshift/ose-cli-artifacts
 payload_name: cli-artifacts
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-csi-driver-shared-resource-mustgather.yml
+++ b/images/ose-csi-driver-shared-resource-mustgather.yml
@@ -18,3 +18,4 @@ from:
 name: openshift/ose-csi-driver-shared-resource-mustgather-rhel8
 owners:
 - openshift-build-jenkins-team@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-installer-artifacts-container
@@ -20,13 +20,14 @@ for_payload: true
 from:
   builder:
   - member: ose-installer-terraform-providers
-  - stream: golang
-  - stream: golang
-  - stream: golang
-  - stream: golang
-  - stream: golang
+  - stream: golang-1.20
+  - stream: golang-1.20
+  - stream: golang-1.20
+  - stream: golang-1.20
+  - stream: golang-1.20
   member: openshift-enterprise-base
 name: openshift/ose-installer-artifacts
 payload_name: installer-artifacts
 owners:
 - aos-install@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-installer-container
@@ -20,9 +20,10 @@ for_payload: true
 from:
   builder:
   - member: ose-installer-terraform-providers
-  - stream: golang
+  - stream: golang-1.20
   member: openshift-enterprise-base
 name: openshift/ose-installer
 payload_name: installer
 owners:
 - aos-install@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -25,3 +25,4 @@ non_shipping_repos:
 - rhel-8-appstream-rpms
 - rhel-8-baseos-rpms
 - rhel-8-server-ose-rpms-embargoed
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-must-gather-container
@@ -19,9 +19,10 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: golang-1.20
   member: openshift-enterprise-cli
 name: openshift/ose-must-gather
 payload_name: must-gather
 owners:
 - aos-master@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-network-tools-container
@@ -19,10 +19,11 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: golang-1.20
   - member: ose-ovn-kubernetes
   member: ose-tools
 name: openshift/ose-network-tools
 payload_name: network-tools
 owners:
 - aos-networking-staff@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-9-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ovn-kubernetes-container
@@ -32,8 +32,8 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-9-golang-1.20
+  - stream: golang-1.20
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+
@@ -48,3 +48,4 @@ owners:
 - aos-networking-staff@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-tools-container
@@ -32,3 +32,4 @@ payload_name: tools
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-9-golang-1.20-ci-build-root
 distgit:
   component: ovn-kubernetes-microshift-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
@@ -32,7 +32,7 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.20
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+
@@ -47,3 +47,4 @@ owners:
 - aos-networking-staff@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -14,7 +14,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ptp-operator-must-gather-container
@@ -24,8 +24,9 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: golang
+  - stream: golang-1.20
   member: ose-must-gather
 name: openshift/ose-ptp-operator-must-gather
 owners:
 - multus-dev@redhat.com
+canonical_builders_from_upstream: False # member image does not get resolved well


### PR DESCRIPTION
Since https://github.com/openshift-eng/art-tools/pull/246 merged and
config was merged to make use of it:
https://github.com/openshift-eng/ocp-build-data/pull/4080, there is a
circumstance that we did not account for.

Some base images are not synced by ART to their place in CI, but get
promoted there by CI builds themselves. A base image like `cli` does not
override their `"com.redhat.component"` label, so production builds
started to use the base image rather than the cli image with the newly
introduced logic.

This commit disables the "adhere to upstream" logic for images that have
a base image whose construction in CI is beyond ARTs control, pending a
real solution.