### PR TITLE
[sast] exclude ovs and ovn

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -538,3 +538,26 @@ external_scanners:
       - kernel
       - kernel-rt
       - systemd
+      - openvswitch2.13
+      - openvswitch2.15
+      - openvswitch2.16
+      - openvswitch2.17
+      - openvswitch3.0
+      - openvswitch3.1
+      - ovn-2021
+      - ovn2.12
+      - ovn2.13
+      - ovn21.09
+      - ovn21.12
+      - ovn22.03
+      - ovn22.06
+      - ovn22.09
+      - ovn22.12
+      - ovn23.03
+      - ovn23.06
+      - ovn23.09
+      - ovn23.12
+      - ovn24.03
+      - ovn24.06
+      - ovn24.09
+      - ovn24.12


### PR DESCRIPTION
Excluded ovs and ovn components for SAST scanning until the ticket solved: https://issues.redhat.com/browse/ART-8525