### PR TITLE
OCPBUGS-19685: Use RHEL 9 builder image for ose-agent-installer-utils

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -297,6 +297,26 @@ repos:
     reposync:
       enabled: false
 
+  rhel-9-codeready-builder-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/ppc64le/codeready-builder/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/s390x/codeready-builder/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/x86_64/codeready-builder/os/
+      ci_alignment:
+        profiles:
+        - el9
+        localdev:
+          enabled: true
+    content_set:
+      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_2
+      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_2
+      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_2
+      s390x:   codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_2
+    reposync:
+      enabled: false
+
   rhel-9-appstream-rpms:
     conf:
       extra_options:

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -22,13 +22,12 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
+maintainer:
+  component: Installer
+  subcomponent: Agent based installation
 name: openshift/ose-agent-installer-utils
 owners:
-- afasano@redhat.com
-- zbitter@redhat.com
-- bfournie@redhat.com
-- ppinjark@redhat.com
-- rwsu@redhat.com
+- ocp-agent-team@redhat.com
 non_shipping_repos:
 - rhel-9-codeready-builder-rpms
 - rhel-9-server-ose-rpms-embargoed

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -9,16 +9,19 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 enabled_repos:
-- rhel-8-appstream-rpms
-- rhel-8-baseos-rpms
-- rhel-8-server-ose-rpms-embargoed
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-codeready-builder-rpms
+- rhel-9-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 name: openshift/ose-agent-installer-utils
 owners:
 - afasano@redhat.com
@@ -26,3 +29,6 @@ owners:
 - bfournie@redhat.com
 - ppinjark@redhat.com
 - rwsu@redhat.com
+non_shipping_repos:
+- rhel-9-codeready-builder-rpms
+- rhel-9-server-ose-rpms-embargoed


### PR DESCRIPTION
Test build: [ose-agent-installer-utils-container-v4.14.0-202312191513.p0.gad85376.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2827703)