### PR TITLE
[scan-osh] activate for 4.16

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -540,7 +540,7 @@ external_scanners:
       # Enable feature to raise OCPBUGS Jira tickets if SAST scan issues are found
       # This flag enables for this OCP version, but it also has to be enabled specifically in the image config
       # as well
-      enabled: false  # Until 4.16.0 target version exists
+      enabled: true
 
       exclude_components:
       # Built by CPAAS


### PR DESCRIPTION
Now that `4.16.0` target version exists, activating for 4.16