### PR TITLE
OCPBUGS-26220: sriov-cni - Use rhel8 builder

### DIFF
--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -24,7 +24,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: golang
   member: openshift-enterprise-base-rhel9
 name: openshift/sriov-cni-rhel9
 name_in_bundle: sriov-cni


### PR DESCRIPTION
sriov-cni binaries must be able to run on RHEL8 systems.

@joepvd can you confirm these changes are enough to follow PR:
- https://github.com/openshift/sriov-cni/pull/96