### PR TITLE
ART-8476 Move ose-libvirt-machine-controllers to rhel9

### DIFF
--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -15,19 +15,20 @@ content:
         - bugzilla/valid-bug
         - cherry-pick-approved
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-libvirt-machine-controllers-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-codeready-builder-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-libvirt-machine-controllers
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-libvirt-machine-controllers-rhel9
 payload_name: libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com


### PR DESCRIPTION
Test build: [ose-libvirt-machine-controllers-container-v4.15.0-202401081251.p0.g1e096cd.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2840698)