### PR TITLE
[group.yml] remove operator index mode

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -28,7 +28,6 @@ multi_arch:
   enabled: true
 
 operator_image_ref_mode: manifest-list
-operator_index_mode: ga-plus
 
 signing_advisory: 97866
 


### PR DESCRIPTION
Alongside https://github.com/openshift-eng/art-tools/pull/296

Should be cherry-picked to lower versions 