### PR TITLE
installer-terraform-providers: Leave promotion in CI to CI

### DIFF
--- a/images/ose-installer-terraform-providers.yml
+++ b/images/ose-installer-terraform-providers.yml
@@ -10,11 +10,8 @@ content:
     ci_alignment:
       streams_prs:
         enabled: false
-      mirror: true
-      transform: rhel-8/base-repos
-      upstream_image_base: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:installer-terraform-providers.art
-      upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:installer-terraform-providers
-
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-installer-terraform-providers-container


### PR DESCRIPTION
...as promotion is handled by CI here: https://github.com/openshift/release/blob/2b1755b8cc5f722487506cc2755005c73040559c/ci-operator/config/openshift/installer/openshift-installer-master__terraform.yaml#L21-L26