### PR TITLE
Add missing labels to baremetalc-luster-api-provider

### DIFF
--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -21,6 +21,9 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
+labels:
+  io.k8s.display-name: Cluster API Provider Metal3
+  io.k8s.description: Kubernetes-native declarative infrastructure for Metal3.
 name: openshift/ose-baremetal-cluster-api-controllers-rhel9
 payload_name: baremetal-cluster-api-controllers
 owners:


### PR DESCRIPTION
Found this issue while running gen-assembly:
```
ERROR Unable to find ose-baremetal-cluster-api-controllers in releases despite it being marked as is_payload in ART metadata; this may mean the image does not have the proper labeling for being in the payload. Choosing what was in the estimated basis event sweep
```
Adding name  and description labels should fix it