### PR TITLE
prepare prerelease for ec.1

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -15,7 +15,7 @@ releases:
           image: 125775
           metadata: 125776
           microshift: 125777
-          prerelease: 125778
+          prerelease: -1
           rpm: 125779
         upgrades: 4.15.0-ec.0,4.15.0-ec.1,4.15.0-ec.2,4.15.0-ec.3,4.15.0-rc.0,4.15.0-rc.1,4.16.0-ec.0
         operator_index_mode: pre-release


### PR DESCRIPTION
Prepare new prerelease advisory for `ec.1`

Need to rerun prepare release after merge.