### PR TITLE
4.14 - Bump golang 1.20 to 1.20.12

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -31,7 +31,7 @@ golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 golang:
-  image: openshift/golang-builder:v1.20.10-202310161945.el8.gdc4b478
+  image: openshift/golang-builder:v1.20.12-202401111802.el8.g17c0aac
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -53,7 +53,7 @@ rhel-9-golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
-  image: openshift/golang-builder:v1.20.10-202310161945.el9.gbbb66ea
+  image: openshift/golang-builder:v1.20.12-202401111603.el9.g0bebe58
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
[openshift-golang-builder-container-v1.20.12-202401111603.el9.g0bebe58](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2845926)

[openshift-golang-builder-container-v1.20.12-202401111802.el8.g17c0aac](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2846059)