### PR TITLE
ART-8632 4.15 - Bump golang 1.20 to 1.20.12

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -59,7 +59,7 @@ rhel-9-golang-1.21:
 #   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
 golang:
-  image: openshift/golang-builder:v1.20.10-202310161945.el8.gdc4b478
+  image: openshift/golang-builder:v1.20.12-202401111802.el8.g17c0aac
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -71,13 +71,13 @@ golang:
 
 ibm-rhel-8-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.20.10-202310161945.el8.gdc4b478
+  image: openshift/golang-builder:v1.20.12-202401111802.el8.g17c0aac
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
-  image: openshift/golang-builder:v1.20.10-202310161945.el9.gbbb66ea
+  image: openshift/golang-builder:v1.20.12-202401111603.el9.g0bebe58
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -89,7 +89,7 @@ rhel-9-golang:
 
 ibm-rhel-9-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.20.10-202310161945.el9.gbbb66ea
+  image: openshift/golang-builder:v1.20.12-202401111603.el9.g0bebe58
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-8632

[openshift-golang-builder-container-v1.20.12-202401111603.el9.g0bebe58](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2845926)

[openshift-golang-builder-container-v1.20.12-202401111802.el8.g17c0aac](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2846059)