### PR TITLE
Revert "4.12 - Temporarily freeze automation to delay mass rebuild"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: true
+freeze_automation: false
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#4188

Merge when 4.15 and 4.14 mass rebuilds have completed 
https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/