### PR TITLE
bump ose-azure-disk-csi-driver-operator to rhel-9 images

### DIFF
--- a/images/ose-azure-disk-csi-driver-operator.yml
+++ b/images/ose-azure-disk-csi-driver-operator.yml
@@ -16,22 +16,22 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-disk-csi-driver-operator-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-azure-disk-csi-driver-operator
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-azure-disk-csi-driver-rhel9-operator
 payload_name: azure-disk-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com


### PR DESCRIPTION
The ART bot is fighting with itself to reconcile .ci-operator.yaml in the csi-operator repo:

https://github.com/openshift/csi-operator/pull/114
https://github.com/openshift/csi-operator/pull/115

This is because aws-ebs-csi-driver-operator uses rhel-9 while azure-disk-csi-driver-operator uses rhel-8. This PR bumps azure-disk-csi-driver-operator to rhel-9 so they'll be consistent.

/cc @openshift/storage
