### PR TITLE
olm: base image fixes

### DIFF
--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -9,19 +9,17 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-1.20-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: operator-lifecycle-manager-container
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-envs:
-  GO_COMPLIANCE_EXCLUDE: "build.*operator-lifecycle-manager/util/cpb"
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang-1.20
+  - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+
@@ -33,4 +31,3 @@ name: openshift/ose-operator-lifecycle-manager-rhel9
 payload_name: operator-lifecycle-manager
 owners:
 - aos-odin@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now


### PR DESCRIPTION
- remove `envs` because this is [set upstream](https://github.com/openshift/operator-framework-olm/blob/master/operator-lifecycle-manager.Dockerfile#L9)
- Remove "Don't listen to upstream" because 4.16 has rhel9 base images
- Use golang-1.21.