### PR TITLE
Mirror haproxy-router-base to CI

### DIFF
--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -8,6 +8,9 @@ content:
       url: git@github.com:openshift-priv/router.git
       web: https://github.com/openshift/router
     ci_alignment:
+      mirror: true
+      upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:haproxy-router-base
+      upstream_image_base: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:haproxy-router-base.art
       streams_prs:
         ci_build_root:
           stream: rhel-9-golang-ci-build-root


### PR DESCRIPTION
This will let us rebase `haproxy-router` when trying to match upstream