### PR TITLE
WIP: terraform-providers: Change base image

### DIFF
--- a/images/ose-installer-terraform-providers.yml
+++ b/images/ose-installer-terraform-providers.yml
@@ -26,7 +26,7 @@ from:
   - stream: golang
   - stream: golang
   - stream: golang
-  member: openshift-enterprise-base
+  member: openshift-base-rhel8
 labels:
   License: GPLv2+
   io.k8s.description: This is the base image from which all OCP installer images inherit.


### PR DESCRIPTION
we have witnessed the installer-terraform-providers image time out twice while a mass rebuild for 4.16 is running. This is a resource hungry image build, and it seems to suffer when it is not able to consume more memory or compute or disk pipe resources.

This PR proposes to change the last layer from
openshift-enterprise-base to openshift-base-rhel8. The former depends on the latter, and are functionally equivalent for the purposes of a layer from which to pluck binaries. The effect of this change will be that this image will start to build ahead of the pack, which may be helpful to complete in time more often.