### PR TITLE
WIP: Introduce centos 9.4 content to nightlies

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -12,7 +12,7 @@ vars:
   IMPACT: Low
   CVES: None
   RHCOS_EL_MAJOR: 9
-  RHCOS_EL_MINOR: 2
+  RHCOS_EL_MINOR: 4
 
 compliance:
   rpm_shim:
@@ -118,7 +118,7 @@ urls:
   brew_image_namespace: rh-osbs
   cgit: https://pkgs.devel.redhat.com/cgit
   rhcos_release_base:
-    multi: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/4.16-9.2/builds
+    multi: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/4.16-9.4/builds
 dist_git_ignore:
   - gating.yaml
 

--- a/releases.yml
+++ b/releases.yml
@@ -93,6 +93,11 @@ releases:
   stream:
     assembly:
       type: stream
+      group:
+        arches!:
+        - x86_64
+        rhcos:
+          allow_missing_brew_rpms: true
       permits:
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'
@@ -100,6 +105,16 @@ releases:
         component: rhcos
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: openshift-clients
+
+
+      - code: FAILED_CROSS_RPM_VERSIONS_REQUIREMENT
+        # While using centos as the RHCOS base, kernel and kernel-rt
+        # may not match.
+        component: '*'
+      - code: FAILED_CONSISTENCY_REQUIREMENT
+        # While using centos as the RHCOS base, don't fail to assemble
+        # if DTK doesn't match a centos kernel.
+        component: '*'
       members:
         images:
         - distgit_key: '*'


### PR DESCRIPTION
4.16 will be based on RHEL 9.4. However, at this time, 9.4 has not branched and we will not be able to publish 9.4 content publicly until RHEL 9.4 is at least in public beta.
The following changes force doozer to update the ART 4.16 nightly (and CI) image streams with floating tag references. These tags will be kept up to date with RHCOS builds with centos 9.4 content.
- When floating tags are in use, the imagestream tags should be configured to do periodic imports (this will cause the OCP imagestream controller to periodically poll the floating and update itself with any new sha at the floating tag location).
- These floating tags should never be permitted for non-stream assemblies.