### PR TITLE
4.15 - Set prerelease advisory release back to rhose async auto

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -142,7 +142,6 @@ boilerplates:
       https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.15/html/release_notes/index
   prerelease:
     synopsis: OpenShift Container Platform 4.15 OLM Operators pre-release
-    release: "RHOSE ASYNC"
     topic: |
       This advisory will be used to pre-release OCP 4.15 operator bundles and the
       container image builds on which they depend.


### PR DESCRIPTION
We want prerelease advisories to be automatically pushed once they are set to `push_ready` by QEs
Only "advance" operator advisory need to be pushed in 2 stages (1 week before ga and at ga)
in coordination with SP, so keep it to "rhose async"

ref: https://art-docs.engineering.redhat.com/release/4.y-ga/#update-advisory-release-type-and-remove-dependencies