### PR TITLE
Add 4.15 z target release

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -11,6 +11,7 @@ bugzilla_config:
 
 target_release:
   - "4.15.0"
+  - "4.15.z"
 
 version:
   - "4.15"


### PR DESCRIPTION
Start looking at 4.15.z bugs too. It is available in jira - sometimes devs will use this target version
We don't want to miss these bugs iff they are fixed in GA