### PR TITLE
Add krb5-devel to RHEL9 golang 1.21 image

### DIFF
--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -27,6 +27,7 @@ RUN dnf update -y && \
         gpgme \
         gpgme-devel \
         hostname \
+        krb5-devel \
         libassuan-devel \
         libtool \
         lsof \


### PR DESCRIPTION
krb5-devel library required to build oc