### PR TITLE
Migrate ocp-build-data-validator to art-tools

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install validator
-        run: pip3 install https://github.com/openshift-eng/ocp-build-data-validator/archive/master.zip
+        run: git clone https://github.com/openshift-eng/art-tools && cd art-tools/ocp-build-data-validator && pip install .
 
       - name: Get all relevant files that have changed
         id: changed-files


### PR DESCRIPTION
Sample [run](https://github.com/openshift-eng/ocp-build-data/actions/runs/7631535191/job/20789690813?pr=4236)

Need to be cherry picked to all `openshift-4.*` branches