### PR TITLE
Fix build failures 2025-01-25

### DIFF
--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -29,3 +29,5 @@ name: openshift/ose-ibm-cloud-controller-manager-rhel9
 payload_name: ibm-cloud-controller-manager
 owners:
 - aos-cloud@redhat.com
+cachito:
+  enabled: false  # disabling cachito processing awaiting STONEBLD-1973

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -34,3 +34,4 @@ owners:
 - pkrupa@redhat.com
 cachito:
   enabled: false  # disabling cachito processing awaiting STONEBLD-1973
+canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -48,3 +48,4 @@ owners:
 - aos-networking-staff@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
+canonical_builders_from_upstream: False # member image does not get resolved well


### PR DESCRIPTION
- Base image of ovn does not get resolved well
- libvirt-machine-controllers did not yet merge rhel9 pr
- disable cachito processing for ibm-cloud-controller-manager