### PR TITLE
[ART-8358][4.16] alignment for multi-builder migration to rhel9

### DIFF
--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -9,18 +9,31 @@ content:
     ci_alignment:
       enabled: false
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-egress-router-cni-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
   - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-egress-router-cni
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-egress-router-cni-rhel9
 payload_name: egress-router-cni
 owners:
 - aos-networking-staff@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: rhel-9-golang
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-egress-router-cni

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -14,24 +14,37 @@ content:
         - lgtm
       enabled: false
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: multus-cni-container
 enabled_repos:
-- rhel-8-appstream-rpms
-- rhel-8-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
   - stream: golang
-  member: openshift-enterprise-base
+  member: openshift-enterprise-base-rhel9
 labels:
   io.k8s.description: This is a component of OpenShift Container Platform and provides
     a meta CNI plugin.
   io.k8s.display-name: Multus CNI
   io.openshift.tags: openshift
   vendor: Red Hat
-name: openshift/ose-multus-cni
+name: openshift/ose-multus-cni-rhel9
 payload_name: multus-cni
 owners:
 - multus-dev@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: rhel-9-golang
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-multus-cni

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -14,19 +14,19 @@ content:
         - lgtm
       enabled: false
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-containernetworking-plugins-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
   - stream: golang
   - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-container-networking-plugins
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-container-networking-plugins-rhel9
 payload_name: container-networking-plugins
 owners:
 - nfvpe-container@redhat.com
@@ -34,3 +34,17 @@ owners:
 - fpan@redhat.com
 - tohayash@redhat.com
 - dcbw@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: rhel-9-golang
+    - stream: golang
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-container-networking-plugins

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -9,14 +9,14 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-config-operator-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms-embargoed
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
 # Generally doozer scan-sources will detect all possible change factors automatically and trigger rebuilds.
 # However, certain images may consume RPMs in unexpected way that make it programmatically impossible to
 # detect they were used.
@@ -31,11 +31,31 @@ from:
   builder:
   - stream: golang
   - stream: rhel-9-golang
-  member: openshift-enterprise-base
+  member: openshift-enterprise-base-rhel9
 name: openshift/ose-machine-config-operator
-payload_name: machine-config-operator
+payload_name: machine-config-operator-rhel9
 owners:
 - jerzhang@redhat.com
 - jkyros@redhat.com
 - skumari@redhat.com
 - zzlotnik@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  - rhel-8-server-ose-rpms-embargoed
+  from:
+    builder:
+    - stream: golang
+    - stream: rhel-9-golang
+    member: openshift-enterprise-base
+  name: openshift/ose-machine-config-operator
+  content:
+    source:
+      ci_alignment:
+        streams_prs:
+          ci_build_root:
+            stream: rhel-8-golang-ci-build-root

--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -14,15 +14,28 @@ content:
         - lgtm
       enabled: false
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-route-override-cni-container
 for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
   - stream: golang
-  member: openshift-base-rhel8
-name: openshift/ose-multus-route-override-cni
+  member: openshift-base-rhel9
+name: openshift/ose-multus-route-override-cni-rhel9
 payload_name: multus-route-override-cni
 owners:
 - multus-dev@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: rhel-9-golang
+    - stream: golang
+    member: openshift-base-rhel8
+  name: openshift/ose-multus-route-override-cni

--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -14,7 +14,7 @@ content:
         - lgtm
       enabled: false
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-whereabouts-ipam-cni-container
 for_payload: true
 from:
@@ -22,8 +22,21 @@ from:
   # Binaries must be compiled for the RHCOS version of RHEL
   - stream: rhel-9-golang
   - stream: golang
-  member: openshift-base-rhel8
-name: openshift/ose-multus-whereabouts-ipam-cni
+  member: openshift-base-rhel9
+name: openshift/ose-multus-whereabouts-ipam-cni-rhel9
 payload_name: multus-whereabouts-ipam-cni
 owners:
 - multus-dev@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: rhel-9-golang
+    - stream: golang
+    member: openshift-base-rhel8
+  name: openshift/ose-multus-whereabouts-ipam-cni

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -7,19 +7,32 @@ content:
       url: git@github.com:openshift-priv/bond-cni.git
       web: https://github.com/openshift/bond-cni
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-network-interface-bond-cni-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
   # Binaries must be compiled for the RHCOS version of RHEL
   - stream: rhel-9-golang
   - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-network-interface-bond-cni
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-network-interface-bond-cni-rhel9
 payload_name: network-interface-bond-cni
 owners:
 - carlosg@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: rhel-9-golang
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-network-interface-bond-cni


### PR DESCRIPTION
for rhel8 builds that build with el8 and el9 golang, migrate them to rhel9 but leave rhel8 config in place to match upstream until they get the PR and make the move. (like https://github.com/openshift-eng/ocp-build-data/pull/4237/)

can merge on lgtm