### PR TITLE
Bump ovn-kubernetes to golang-1.21

### DIFF
--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -32,7 +32,7 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang-1.20
+  - stream: golang
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+


### PR DESCRIPTION
`ovn` started using golang-1.21 with https://github.com/openshift/ovn-kubernetes/pull/2027/, and this confuses our bot that wants to downgrade it to 1.20

Test build: [ovn-kubernetes-microshift-container-v4.16.0-202401291455.p0.ge8f87e8.assembly.test](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2875855)