### PR TITLE
[4.16] Fix alternative config payload name for machine-config-operator

### DIFF
--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -32,8 +32,8 @@ from:
   - stream: golang
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
-name: openshift/ose-machine-config-operator
-payload_name: machine-config-operator-rhel9
+name: openshift/ose-machine-config-operator-rhel9
+payload_name: machine-config-operator
 owners:
 - jerzhang@redhat.com
 - jkyros@redhat.com


### PR DESCRIPTION
Follows https://github.com/openshift-eng/ocp-build-data/pull/4276/files#diff-64c70eca940106602f26735a4ad5b1f427ba8b1faa66dbaf06516fabcddccf00