### PR TITLE
[WIP] [ART-8357] Migrate ptp-operator, related images to rhel9

### DIFF
--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -9,19 +9,19 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-cli-container
   namespace: containers
 enabled_repos:
-- rhel-8-appstream-rpms
-- rhel-8-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+
   io.k8s.description: OpenShift is a platform for developing, building, and deploying
@@ -29,7 +29,19 @@ labels:
   io.k8s.display-name: OpenShift Client
   io.openshift.tags: openshift,cli
   vendor: Red Hat
-name: openshift/ose-cli
+name: openshift/ose-cli-rhel9
 payload_name: cli
 owners:
 - aos-master@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+      - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-cli

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -8,11 +8,11 @@ content:
       web: https://github.com/openshift/oc
     path: images/deployer
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-deployer-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   member: openshift-enterprise-cli
@@ -24,8 +24,17 @@ labels:
   io.k8s.display-name: OpenShift Container Platform Deployer
   io.openshift.tags: openshift,deployer
   vendor: Red Hat
-name: openshift/ose-deployer
+name: openshift/ose-deployer-rhel9
 payload_name: deployer
 owners:
 - aos-master@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    member: openshift-enterprise-cli
+  name: openshift/ose-deployer

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -9,27 +9,42 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-1.20-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-api-server-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms-embargoed
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
+- rhel-9-codeready-builder-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang-1.20
+  - stream: rhel-9-golang
   - member: openshift-enterprise-cli
-  member: openshift-enterprise-base
+  member: openshift-enterprise-base-rhel9
 maintainer:
   component: Installer
   subcomponent: Agent based installation
-name: openshift/ose-agent-installer-api-server
+name: openshift/ose-agent-installer-api-server-rhel9
 payload_name: agent-installer-api-server
 owners:
 - ocp-agent-team@redhat.com
 non_shipping_repos:
-- rhel-8-server-ose-rpms-embargoed
-canonical_builders_from_upstream: False # member image does not get resolved well
+- rhel-9-server-ose-rpms-embargoed
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+    - rhel-8-server-ose-rpms-embargoed
+    - rhel-8-codeready-builder-rpms
+  from:
+    builder:
+      - stream: golang-1.20
+      - member: openshift-enterprise-cli
+    member: openshift-enterprise-base
+  name: openshift/ose-agent-installer-api-server

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -9,24 +9,36 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-1.20-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-csr-approver-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
   - member: openshift-enterprise-cli
-  - stream: golang-1.20
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 maintainer:
   component: Installer
   subcomponent: Agent based installation
-name: openshift/ose-agent-installer-csr-approver
+name: openshift/ose-agent-installer-csr-approver-rhel9
 payload_name: agent-installer-csr-approver
 owners:
 - ocp-agent-team@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+      - member: openshift-enterprise-cli
+      - stream: golang-1.20
+    member: openshift-enterprise-base
+  name: openshift/ose-agent-installer-csr-approver

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -9,23 +9,35 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-1.20-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cli-artifacts-container
   namespace: containers
 enabled_repos:
-- rhel-8-appstream-rpms
-- rhel-8-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang-1.20
+  - stream: rhel-9-golang
   - stream: rhel-9-golang-1.20
   member: openshift-enterprise-cli
-name: openshift/ose-cli-artifacts
+name: openshift/ose-cli-artifacts-rhel9
 payload_name: cli-artifacts
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-appstream-rpms
+    - rhel-8-baseos-rpms
+  from:
+    builder:
+      - stream: golang-1.20
+      - stream: rhel-9-golang-1.20
+    member: openshift-enterprise-cli
+  name: openshift/ose-cli-artifacts

--- a/images/ose-csi-driver-shared-resource-mustgather.yml
+++ b/images/ose-csi-driver-shared-resource-mustgather.yml
@@ -7,15 +7,24 @@ content:
       url: git@github.com:openshift-priv/csi-driver-shared-resource.git
       web: https://github.com/openshift/csi-driver-shared-resource
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-driver-shared-resource-mustgather-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 from:
-  member: ose-must-gather
-name: openshift/ose-csi-driver-shared-resource-mustgather-rhel8
+  member: ose-must-gather-rhel9
+name: openshift/ose-csi-driver-shared-resource-mustgather-rhel9
 owners:
 - openshift-build-jenkins-team@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-appstream-rpms
+    - rhel-8-baseos-rpms
+  from:
+    member: ose-must-gather
+  name: openshift/ose-csi-driver-shared-resource-mustgather-rhel8

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -9,20 +9,31 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-1.20-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-must-gather-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang-1.20
+  - stream: rhel-9-golang
   member: openshift-enterprise-cli
-name: openshift/ose-must-gather
+name: openshift/ose-must-gather-rhel9
 payload_name: must-gather
 owners:
 - aos-master@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+      - stream: golang-1.20
+    member: openshift-enterprise-cli
+  name: openshift/ose-must-gather

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -14,19 +14,30 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-1.20-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ptp-operator-must-gather-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang-1.20
-  member: ose-must-gather
-name: openshift/ose-ptp-operator-must-gather
+  - stream: rhel-9-golang
+  member: ose-must-gather-rhel9
+name: openshift/ptp-must-gather-rhel9
 owners:
 - multus-dev@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+    - rhel-8-baseos-rpms
+    - rhel-8-appstream-rpms
+  from:
+    builder:
+      - stream: golang-1.20
+    member: ose-must-gather
+  name: openshift/ose-ptp-operator-must-gather


### PR DESCRIPTION
Migrate to rhel9:
- openshift-enterprise-cli
- openshift-enterprise-deployer
- ose-agent-installer-api-server
- ose-agent-installer-csr-approver
- ose-cli-artifacts
- ose-csi-driver-shared-resource-mustgather
- ose-must-gather
- ptp-operator-must-gather