### PR TITLE
Add rhel-9-golang stream for oc 4.15

### DIFF
--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -21,6 +21,7 @@ for_payload: true
 from:
   builder:
   - stream: golang
+  - stream: rhel-9-golang
   member: openshift-enterprise-cli
 name: openshift/ose-cli-artifacts
 payload_name: cli-artifacts


### PR DESCRIPTION
This PR adds `rhel-9-golang` stream in oc 4.15 just like we did it for 4.16 in https://github.com/openshift-eng/ocp-build-data/pull/4046