### PR TITLE
Disable canonical builders for ART images

### DIFF
--- a/images/openshift-base-nodejs.yml
+++ b/images/openshift-base-nodejs.yml
@@ -31,3 +31,4 @@ labels:
 name: openshift/base-nodejs
 owners:
 - aos-team-art@redhat.com
+canonical_builders_from_upstream: False

--- a/images/openshift-base-rhel8.yml
+++ b/images/openshift-base-rhel8.yml
@@ -35,3 +35,4 @@ from:
 name: openshift/base-rhel8
 owners:
 - aos-team-art@redhat.com
+canonical_builders_from_upstream: False

--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -38,3 +38,4 @@ from:
 name: openshift/base-rhel9
 owners:
 - aos-team-art@redhat.com
+canonical_builders_from_upstream: False


### PR DESCRIPTION
For these components, ocp4-scan uselessly tries to determine the "upstream" intended rhel version. This means useless operations (running `oc` against non-sense pullspecs) and ugly error messages that go like this: `error: source image must point to an image ID or image tag`, see for example [here](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4_scan/626428/consoleFull)

Let's just disable canonical builders for these images.