### PR TITLE
Revert "Add rhel-9-golang stream for oc 4.15"

### DIFF
--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -21,7 +21,6 @@ for_payload: true
 from:
   builder:
   - stream: golang
-  - stream: rhel-9-golang
   member: openshift-enterprise-cli
 name: openshift/ose-cli-artifacts
 payload_name: cli-artifacts


### PR DESCRIPTION
Because of upstream mismatch https://github.com/openshift/oc/blob/release-4.15/images/cli-artifacts/Dockerfile.rhel