### PR TITLE
[4.16] re-enable canonical builders for machine-config-operator

### DIFF
--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -55,8 +55,13 @@ alternative_upstream:
   name: openshift/ose-machine-config-operator
   content:
     source:
+      dockerfile: Dockerfile.rhel7
+      git:
+        branch:
+          target: release-{MAJOR}.{MINOR}
+        url: git@github.com:openshift-priv/machine-config-operator.git
+        web: https://github.com/openshift/machine-config-operator
       ci_alignment:
         streams_prs:
           ci_build_root:
             stream: rhel-8-golang-ci-build-root
-canonical_builders_from_upstream: False # errors during rebase to be investigated


### PR DESCRIPTION
Follows https://github.com/openshift-eng/ocp-build-data/pull/4324