### PR TITLE
Move kube-proxy back to rhel8, to match ose-sdn

### DIFF
--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -9,19 +9,19 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-8-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: kube-proxy-container
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
-  member: openshift-enterprise-base-rhel9
-name: openshift/ose-kube-proxy-rhel9
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-kube-proxy
 payload_name: kube-proxy
 owners:
 - aos-networking-staff@redhat.com


### PR DESCRIPTION
I think this will make automated bugs like https://github.com/openshift/sdn/pull/605 go away