### PR TITLE
4.11 stream builds not on weekdays

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: false
+freeze_automation: weekdays
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
due to the last z-stream (for 4.11.z) produced: **4.11.58** 
we don't need anymore the 4.11.z build on weekdays 