### PR TITLE
Fix 4.15 rc.5 prerelease

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -8,12 +8,13 @@ releases:
       group:
         advisories:
           prerelease: 127442
-          advance: 127352
+#          advance: 127352
           extras: 123982
           image: 123983
           metadata: 123984
           microshift: 123985
           rpm: 123986
+        operator_index_mode: pre-release
         release_jira: ART-8258
         upgrades: 4.14.9,4.14.10,4.14.11,4.15.0-ec.0,4.15.0-ec.1,4.15.0-ec.2,4.15.0-ec.3,4.15.0-rc.0,4.15.0-rc.1,4.15.0-rc.2,4.15.0-rc.3,4.15.0-rc.4
       members:


### PR DESCRIPTION
Since `operator_index_mode: pre-release` was missing in assembly config bundles were rebuilt without the prerelease tag