### PR TITLE
[4.16] Define alternative_upstream configs

### DIFF
--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -25,4 +25,4 @@ name: openshift/ose-operator-marketplace-rhel9
 payload_name: operator-marketplace
 owners:
 - aos-marketplace@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now
+canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression

--- a/images/oauth-server.yml
+++ b/images/oauth-server.yml
@@ -27,4 +27,4 @@ name: openshift/ose-oauth-server-rhel9
 payload_name: oauth-server
 owners:
 - mfojtik@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now
+canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -27,4 +27,4 @@ name: openshift/ose-keepalived-ipfailover-rhel9
 payload_name: keepalived-ipfailover
 owners:
 - aos-network-edge@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now
+canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression

--- a/images/ose-cluster-config-operator.yml
+++ b/images/ose-cluster-config-operator.yml
@@ -27,4 +27,4 @@ payload_name: cluster-config-operator
 owners:
 - aos-master@redhat.com
 - tnozicka@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now
+canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression

--- a/images/ose-cluster-openshift-controller-manager-operator.yml
+++ b/images/ose-cluster-openshift-controller-manager-operator.yml
@@ -24,4 +24,4 @@ name: openshift/ose-cluster-openshift-controller-manager-rhel9-operator
 payload_name: cluster-openshift-controller-manager-operator
 owners:
 - openshift-build-api@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now
+canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression

--- a/images/ose-kubevirt-cloud-controller-manager.yml
+++ b/images/ose-kubevirt-cloud-controller-manager.yml
@@ -30,4 +30,4 @@ payload_name: kubevirt-cloud-controller-manager
 owners:
 - dvossel@redhat.com
 - nargaman@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now
+canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression

--- a/images/ose-openshift-controller-manager.yml
+++ b/images/ose-openshift-controller-manager.yml
@@ -25,4 +25,4 @@ name: openshift/ose-openshift-controller-manager-rhel9
 payload_name: openshift-controller-manager
 owners:
 - openshift-build-api@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now
+canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression

--- a/images/ose-service-ca-operator.yml
+++ b/images/ose-service-ca-operator.yml
@@ -25,4 +25,4 @@ name: openshift/ose-service-ca-rhel9-operator
 payload_name: service-ca-operator
 owners:
 - aos-apiserver@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now
+canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression

--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -25,4 +25,4 @@ name: openshift/ose-telemeter-rhel9
 payload_name: telemeter
 owners:
 - team-monitoring@redhat.com
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now
+canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression


### PR DESCRIPTION
For those images that haven't made the move to rhel9 yet, we are currently disabling canonical_builders unless we define an `alternative_upstream` config stanza that accounts for the el version switch. Adding these stanzas for all images (except one that is disabled) and enabling canonical builders yet