### PR TITLE
[4.16] Bump egress-dns-proxy to rhel9

### DIFF
--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -7,23 +7,23 @@ content:
       web: https://github.com/openshift/images
     path: egress/dns-proxy
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-egress-dns-proxy-container
   namespace: containers
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms-embargoed
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
 for_payload: false
 from:
-  member: openshift-enterprise-base
+  member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+
   io.k8s.description: This is the egress router L4 DNS proxy for OpenShift Origin.
   io.k8s.display-name: OpenShift Container Platform Egress DNS Proxy
   io.openshift.tags: openshift,egress,dns,proxy
   vendor: Red Hat
-name: openshift/ose-egress-dns-proxy
+name: openshift/ose-egress-dns-proxy-rhel9
 owners:
 - aos-network-edge@redhat.com
 non_shipping_repos:


### PR DESCRIPTION
Upstream moved to rhel9: https://github.com/openshift/images/commit/3d1e257555d26747af503ebb88b6381a7a8846a8