### PR TITLE
Enable secrets-store-csi-driver and operator and move to rhel9

### DIFF
--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -17,7 +17,7 @@ content:
 dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator
-# - ose-secrets-store-csi-driver-operator
+- ose-secrets-store-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: csi-livenessprobe-container

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -17,7 +17,7 @@ content:
 dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator
-# - ose-secrets-store-csi-driver-operator
+- ose-secrets-store-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: csi-node-driver-registrar-container

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled  # XXX: is not yet set up in brew and related places, disabling image for now
 content:
   source:
     dockerfile: Dockerfile.openshift
@@ -10,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-1.20-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
@@ -24,7 +23,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang-1.20
+  - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-secrets-store-csi-driver-rhel9-operator
 name_in_bundle: secrets-store-csi-driver-operator # name in image reference
@@ -35,4 +34,3 @@ update-csv:
   manifests-dir: config/manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
-canonical_builders_from_upstream: False # rhel version of upstream and us does not seem to match. Excluding for now

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -26,7 +26,7 @@ for_payload: false
 from:
   builder:
   - stream: rhel-9-golang
-  member: openshift-enterprise-base
+  member: openshift-enterprise-base-rhel9
 name: openshift/ose-secrets-store-csi-driver-rhel9
 name_in_bundle: secrets-store-csi-driver-container
 owners:

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -1,4 +1,3 @@
-mode: disabled # operator does not yet have rhel9 bits set up
 content:
   source:
     dockerfile: Dockerfile.openshift
@@ -11,24 +10,24 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
 dependents:
 - ose-secrets-store-csi-driver-operator
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-secrets-store-csi-driver-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang
+  - stream: rhel-9-golang
   member: openshift-enterprise-base
-name: openshift/ose-secrets-store-csi-driver-rhel
-name_in_bundle: secrets-store-csi-driver-container-rhel8
+name: openshift/ose-secrets-store-csi-driver-rhel9
+name_in_bundle: secrets-store-csi-driver-container
 owners:
 - aos-storage-staff@redhat.com

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -1,4 +1,3 @@
-mode: disabled # brew and related config is not set up for rhel9, disabling for now
 content:
   source:
     dockerfile: Dockerfile.mustgather
@@ -27,4 +26,3 @@ from:
 name: openshift/ose-secrets-store-csi-mustgather-rhel9
 owners:
 - aos-storage-staff@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well


### PR DESCRIPTION
The secrets-store image builds were disabled in https://github.com/openshift-eng/ocp-build-data/pull/4071 and this PR attempts to move all 3 images to rhel9 and re-enable the builds for 4.16.

/hold
Depends on:
https://github.com/openshift/secrets-store-csi-driver/pull/14
https://github.com/openshift/secrets-store-csi-driver-operator/pull/45

/cc @openshift/storage @joepvd
