### PR TITLE
[4.16] build enterprise-tests with  golang 1.21

### DIFF
--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-1.20-ci-build-root
+          stream: rhel-8-golang-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: openshift-enterprise-tests-container
@@ -30,7 +30,7 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: golang-1.20
+  - stream: golang
   member: ose-tools
 labels:
   License: GPLv2+


### PR DESCRIPTION
Needed after https://github.com/openshift/origin/pull/28587

Test build: [openshift-enterprise-tests-container-v4.16.0-202402161704.p0.g7812f3c.assembly.test.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2913929)
