### PR TITLE
TRT-1515: Revert #4411 "[4.16] build enterprise-tests with  golang 1.21"

### DIFF
--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-8-golang-1.20-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: openshift-enterprise-tests-container
@@ -30,7 +30,7 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: golang-1.20
   member: ose-tools
 labels:
   License: GPLv2+


### PR DESCRIPTION

Reverts #4411 ; tracked by TRT-1515

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

The bump to golang 1.21 is causing significant OOM problems, we're rejecting payloads on it now

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Verify metal payload jobs pass
```

CC: @locriandev

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
