### PR TITLE
[4.16] re-enable canonical builders for telemeter

### DIFF
--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -25,4 +25,3 @@ name: openshift/ose-telemeter-rhel9
 payload_name: telemeter
 owners:
 - team-monitoring@redhat.com
-canonical_builders_from_upstream: False # upstream is on rhel8, so disabling to prevent regression


### PR DESCRIPTION
Upstream moved to rhel9, canonical builders can be re-enabled without regressions