### PR TITLE
TRT-1523: Revert #4413 "Switch azure-file to csi-operator"

### DIFF
--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -1,18 +1,14 @@
 arches:
 - x86_64
 - aarch64
-cachito:
-  packages:
-    gomod:
-    - path: legacy/azure-file-csi-driver-operator
 content:
   source:
-    dockerfile: Dockerfile.azure-file
+    dockerfile: Dockerfile.openshift
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/csi-operator.git
-      web: https://github.com/openshift/csi-operator
+      url: git@github.com:openshift-priv/azure-file-csi-driver.git
+      web: https://github.com/openshift/azure-file-csi-driver
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
@@ -21,8 +17,7 @@ content:
         auto_label:
         - approved
         - lgtm
-    pkg_managers:
-    - gomod
+    pkg_managers: [] # disabling cachito processing awaiting STONEBLD-1973
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-file-csi-driver-container


### PR DESCRIPTION

Reverts #4413 ; tracked by [TRT-1523](https://issues.redhat.com//browse/TRT-1523)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

All azure jobs broke after this merged

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Verify azure payload jobs succeed
```

CC: @locriandev

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
