### PR TITLE
[4.16] disable cachito processing for ibm-cloud-controller-manager

### DIFF
--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -14,6 +14,7 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
+    pkg_managers: []
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibm-cloud-controller-manager-container


### PR DESCRIPTION
The component is again failing to build using cachito: [logs](https://download.eng.bos.redhat.com/brewroot/work/tasks/7279/59167279/osbs-build.log)