### PR TITLE
Fix component for openstack-cluster-api-controllers-container

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -407,7 +407,7 @@ bug_mapping:
     openshift-state-metrics-container:
       issue_component: Monitoring
     openstack-cluster-api-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / OpenStack Provider
     openstack-ironic:
       issue_component: Bare Metal Hardware Provisioning / ironic
     openstack-ironic-inspector:


### PR DESCRIPTION
This should go to the more specific `Cloud Compute / OpenStack Provider` component rather than `Cloud Compute / Other Provider`.