### PR TITLE
[4.16] Re-enable canonical builders for unresolved member images

### DIFF
--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -28,4 +28,3 @@ name: openshift/ose-deployer
 payload_name: deployer
 owners:
 - aos-master@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -31,4 +31,3 @@ owners:
 - aos-network-edge@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -44,4 +44,3 @@ payload_name: tests
 owners:
 - aos-master@redhat.com
 - openshift-technical-release-staff@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -32,4 +32,3 @@ owners:
 - ocp-agent-team@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -29,4 +29,3 @@ name: openshift/ose-agent-installer-csr-approver
 payload_name: agent-installer-csr-approver
 owners:
 - ocp-agent-team@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -34,4 +34,3 @@ name: openshift/ose-aws-efs-csi-driver-container-rhel8
 name_in_bundle: aws-efs-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -28,4 +28,3 @@ name: openshift/ose-baremetal-installer
 payload_name: baremetal-installer
 owners:
 - kni-devel-deployment@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -28,4 +28,3 @@ payload_name: cli-artifacts
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-csi-driver-shared-resource-mustgather.yml
+++ b/images/ose-csi-driver-shared-resource-mustgather.yml
@@ -18,4 +18,3 @@ from:
 name: openshift/ose-csi-driver-shared-resource-mustgather-rhel8
 owners:
 - openshift-build-jenkins-team@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -30,4 +30,3 @@ name: openshift/ose-installer-artifacts
 payload_name: installer-artifacts
 owners:
 - aos-install@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -26,4 +26,3 @@ name: openshift/ose-installer
 payload_name: installer
 owners:
 - aos-install@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -25,4 +25,3 @@ non_shipping_repos:
 - rhel-8-appstream-rpms
 - rhel-8-baseos-rpms
 - rhel-8-server-ose-rpms-embargoed
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -25,4 +25,3 @@ name: openshift/ose-must-gather
 payload_name: must-gather
 owners:
 - aos-master@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -26,4 +26,3 @@ name: openshift/ose-network-tools
 payload_name: network-tools
 owners:
 - aos-networking-staff@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -48,4 +48,3 @@ owners:
 - aos-networking-staff@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -27,4 +27,3 @@ from:
 name: openshift/ose-secrets-store-csi-mustgather-rhel9
 owners:
 - aos-storage-staff@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -32,4 +32,3 @@ payload_name: tools
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -47,4 +47,3 @@ owners:
 - aos-networking-staff@redhat.com
 non_shipping_repos:
 - rhel-9-server-ose-rpms-embargoed
-canonical_builders_from_upstream: False # member image does not get resolved well

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -30,4 +30,3 @@ from:
 name: openshift/ose-ptp-operator-must-gather
 owners:
 - multus-dev@redhat.com
-canonical_builders_from_upstream: False # member image does not get resolved well


### PR DESCRIPTION
Test build: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/52402/