### PR TITLE
Revert "Revert "Move extra storage images to rhel9""

### DIFF
--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -10,7 +10,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
@@ -19,24 +19,36 @@ dependents:
 - ose-gcp-filestore-csi-driver-operator
 - ose-secrets-store-csi-driver-operator
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-livenessprobe-container
 enabled_repos:
-- rhel-8-appstream-rpms
-- rhel-8-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 labels:
   License: ASL 2.0
   io.k8s.description: Liveness probe for CSI drivers
   io.k8s.display-name: Liveness probe for CSI drivers
   io.openshift.tags: csi,storage,probe
   vendor: Red Hat
-name: openshift/ose-csi-livenessprobe
+name: openshift/ose-csi-livenessprobe-rhel9
 name_in_bundle: csi-livenessprobe
 payload_name: csi-livenessprobe
 owners:
 - aos-storage-staff@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}-{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-appstream-rpms
+  - rhel-8-baseos-rpms
+  from:
+    builder:
+    - golang
+    member: openshift-enterprise-base
+  name: openshift/ose-csi-livenessprobe

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -10,7 +10,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
@@ -19,18 +19,30 @@ dependents:
 - ose-gcp-filestore-csi-driver-operator
 - ose-secrets-store-csi-driver-operator
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-node-driver-registrar-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-csi-node-driver-registrar
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-csi-node-driver-registrar-rhel9
 name_in_bundle: csi-node-driver-registrar
 payload_name: csi-node-driver-registrar
 owners:
 - aos-storage-staff@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-csi-node-driver-registrar

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -10,7 +10,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
@@ -18,24 +18,36 @@ dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-provisioner-container
 enabled_repos:
-- rhel-8-appstream-rpms
-- rhel-8-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 labels:
   License: ASL 2.0
   io.k8s.description: External provisioner for CSI volumes
   io.k8s.display-name: External provisioner for CSI volumes
   io.openshift.tags: csi,storage,provisioner
   vendor: Red Hat
-name: openshift/ose-csi-external-provisioner
+name: openshift/ose-csi-external-provisioner-rhel9
 payload_name: csi-external-provisioner
 name_in_bundle: csi-external-provisioner
 owners:
 - aos-storage-staff@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-appstream-rpms
+  - rhel-8-baseos-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-csi-external-provisioner

--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -10,25 +10,37 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-external-resizer-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 dependents:
 - ose-gcp-filestore-csi-driver-operator
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-csi-external-resizer
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-csi-external-resizer-rhel9
 payload_name: csi-external-resizer
 name_in_bundle: csi-external-resizer
 owners:
 - aos-storage-staff@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-csi-external-resizer

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -14,24 +14,38 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
         auto_label:
         - approved
         - lgtm
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-filestore-csi-driver-container
 dependents:
 - ose-gcp-filestore-csi-driver-operator
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-gcp-filestore-csi-driver-rhel8
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-gcp-filestore-csi-driver-rhel9
 name_in_bundle: gcp-filestore-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  dependents:
+  - ose-gcp-filestore-csi-driver-operator
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-gcp-filestore-csi-driver-rhel8


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#4449

Looks like it's working: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/42024/consoleFull has `viable: true`