### PR TITLE
Fix stream definition

### DIFF
--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -49,6 +49,6 @@ alternative_upstream:
   - rhel-8-baseos-rpms
   from:
     builder:
-    - golang
+    - stream: golang
     member: openshift-enterprise-base
   name: openshift/ose-csi-livenessprobe


### PR DESCRIPTION
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4/art-tools/doozer/doozerlib/image.py", line 494, in <setcomp>
    referred_streams = {builder.get("stream") for builder in builders if builder.get("stream")}
AttributeError: 'str' object has no attribute 'get'
2024-02-29 18:18:33,744 ERROR [containers/csi-livenessprobe] 'str' object has no attribute 'get'