### PR TITLE
[4.16] use member base image for nmstate-console-plugin

### DIFF
--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -30,7 +30,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: nodejs
+  - member: openshift-base-nodejs
   member: openshift-enterprise-base
 name: openshift/nmstate-console-plugin-rhel8
 name_in_bundle: nmstate-console-plugin-rhel8


### PR DESCRIPTION
`nmstate-console-plugin` is using the bare `nodejs` stream; it should use the `openshift-base-nodejs` member base image just like the console does.

Test build: [nmstate-console-plugin-container-v4.16.0-202403111057.p0.gd607541.assembly.test.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2950177)