### PR TITLE
Fix rhel layers oc-mirror-plugin

### DIFF
--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -9,20 +9,20 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: oc-mirror-plugin-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
   - stream: golang
   - stream: rhel-9-golang
-  member: openshift-enterprise-base
-name: openshift/ose-oc-mirror
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-oc-mirror-rhel9
 payload_name: oc-mirror
 owners:
 - jpower@redhat.com


### PR DESCRIPTION
After https://github.com/openshift/oc-mirror/pull/804 got in, production
build configuration followed up with https://github.com/openshift-eng/ocp-build-data/pull/4475.

This was incomplete, as the change to the final layer was not reflected
in this configuration update.

This PR sets rhel layers as upstream expects, and ensures ENTRYPOINT
does not run into a linking error.