### PR TITLE
[ART-8355] monitoring-plugin use openshift-base-nodejs instead

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -28,7 +28,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: nodejs
+  - member: openshift-base-nodejs
   member: openshift-enterprise-base
 name: openshift/ose-monitoring-plugin-rhel8
 payload_name: monitoring-plugin


### PR DESCRIPTION
Green [build](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2963459)

Similar to https://github.com/openshift-eng/ocp-build-data/pull/4496