### PR TITLE
[ART-9189] alternative_upstream suggest move to rhel9

### DIFF
--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -9,18 +9,18 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-cluster-capacity-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+
   io.k8s.description: This is a component of OpenShift Container Platform and runs
@@ -30,7 +30,19 @@ labels:
   vendor: Red Hat
   summary: Framework that estimates a number of instances of a specified pod that
     would be scheduled in a cluster
-name: openshift/ose-cluster-capacity
+name: openshift/ose-cluster-capacity-rhel9
 owners:
 - jchaloup@redhat.com
 - aos-workloads@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-cluster-capacity

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -7,14 +7,14 @@ content:
       web: https://github.com/openshift/images
     path: egress/router
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-egress-router-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 from:
-  member: openshift-enterprise-base
+  member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+
   io.k8s.description: This is a component of OpenShift Container Platform and contains
@@ -22,6 +22,16 @@ labels:
   io.k8s.display-name: OpenShift Container Platform Egress Router
   io.openshift.tags: openshift,router,egress
   vendor: Red Hat
-name: openshift/ose-egress-router
+name: openshift/ose-egress-router-rhel9
 owners:
 - aos-network-edge@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    member: openshift-enterprise-base
+  name: openshift/ose-egress-router

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -9,23 +9,35 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-helm-operator-container
 enabled_repos:
-- rhel-8-appstream-rpms
-- rhel-8-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 maintainer:
   component: Operator SDK
-name: openshift/ose-helm-operator
+name: openshift/ose-helm-operator-rhel9
 owners:
 - aos-operator-sdk@redhat.com
 - jlanford@redhat.com
 - fabian@redhat.com
 - cmacedo@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-appstream-rpms
+  - rhel-8-baseos-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-helm-operator

--- a/images/openshift-enterprise-operator-sdk.yml
+++ b/images/openshift-enterprise-operator-sdk.yml
@@ -9,23 +9,35 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-operator-sdk-container
 enabled_repos:
-- rhel-8-appstream-rpms
-- rhel-8-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 maintainer:
   component: Operator SDK
-name: openshift/ose-operator-sdk
+name: openshift/ose-operator-sdk-rhel9
 owners:
 - aos-operator-sdk@redhat.com
 - jlanford@redhat.com
 - fabian@redhat.com
 - cmacedo@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-appstream-rpms
+  - rhel-8-baseos-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-operator-sdk

--- a/images/openstack-cluster-api-controllers.yml
+++ b/images/openstack-cluster-api-controllers.yml
@@ -9,19 +9,31 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openstack-cluster-api-controllers-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-openstack-cluster-api-controllers
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-openstack-cluster-api-controllers-rhel9
 payload_name: openstack-cluster-api-controllers
 owners:
 - shiftstack-team@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-openstack-cluster-api-controllers

--- a/images/ose-agent-installer-orchestrator.yml
+++ b/images/ose-agent-installer-orchestrator.yml
@@ -9,22 +9,34 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-orchestrator-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 maintainer:
   component: Installer
   subcomponent: Agent based installation
-name: openshift/ose-agent-installer-orchestrator
+name: openshift/ose-agent-installer-orchestrator-rhel9
 payload_name: agent-installer-orchestrator
 owners:
 - ocp-agent-team@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-agent-installer-orchestrator

--- a/images/ose-aws-efs-utils.yml
+++ b/images/ose-aws-efs-utils.yml
@@ -12,15 +12,25 @@ content:
       web: https://github.com/openshift/aws-efs-utils
     pkg_managers: [] # FIXME: Don't use pip package manager magic in Cachito
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-efs-utils-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 for_release: false
 from:
-  member: openshift-enterprise-base
-name: openshift/ose-aws-efs-utils-base
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-aws-efs-utils-base-rhel9
 owners:
 - aos-storage-staff@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    member: openshift-enterprise-base
+  name: openshift/ose-aws-efs-utils-base

--- a/images/ose-aws-efs-utils.yml
+++ b/images/ose-aws-efs-utils.yml
@@ -12,25 +12,15 @@ content:
       web: https://github.com/openshift/aws-efs-utils
     pkg_managers: [] # FIXME: Don't use pip package manager magic in Cachito
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-aws-efs-utils-container
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
 for_payload: false
 for_release: false
 from:
-  member: openshift-enterprise-base-rhel9
-name: openshift/ose-aws-efs-utils-base-rhel9
+  member: openshift-enterprise-base
+name: openshift/ose-aws-efs-utils-base
 owners:
 - aos-storage-staff@redhat.com
-alternative_upstream:
-- when: el8
-  distgit:
-    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
-  enabled_repos:
-  - rhel-8-baseos-rpms
-  - rhel-8-appstream-rpms
-  from:
-    member: openshift-enterprise-base
-  name: openshift/ose-aws-efs-utils-base

--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -12,19 +12,31 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-workload-identity-webhook-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-azure-workload-identity-webhook-rhel8
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-azure-workload-identity-webhook-rhel9
 payload_name: azure-workload-identity-webhook
 owners:
 - aos-hive@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-azure-workload-identity-webhook-rhel8

--- a/images/ose-cloud-credential-operator.yml
+++ b/images/ose-cloud-credential-operator.yml
@@ -8,19 +8,31 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cloud-credential-operator-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-cloud-credential-operator
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-cloud-credential-operator-rhel9
 payload_name: cloud-credential-operator
 owners:
 - aos-hive@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-cloud-credential-operator

--- a/images/ose-cloud-network-config-controller.yml
+++ b/images/ose-cloud-network-config-controller.yml
@@ -9,19 +9,31 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cloud-network-config-controller-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-cloud-network-config-controller
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-cloud-network-config-controller-rhel9
 payload_name: cloud-network-config-controller
 owners:
 - aos-networking-staff@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-cloud-network-config-controller

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -9,20 +9,32 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-olm-operator-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-cluster-olm-operator-rhel8
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-cluster-olm-operator-rhel9
 payload_name: cluster-olm-operator
 owners:
 - angoldst@redhat.com
 - aos-odin@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-cluster-olm-operator-rhel8

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -7,14 +7,14 @@ content:
       web: https://github.com/openshift/images
     path: egress/http-proxy
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-egress-http-proxy-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 from:
-  member: openshift-enterprise-base
+  member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+
   io.k8s.description: This is a component of OpenShift Container Platform and contains
@@ -22,6 +22,16 @@ labels:
   io.k8s.display-name: OpenShift Container Platform Egress Http Proxy
   io.openshift.tags: openshift,http-proxy,egress
   vendor: Red Hat
-name: openshift/ose-egress-http-proxy
+name: openshift/ose-egress-http-proxy-rhel9
 owners:
 - aos-network-edge@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    member: openshift-enterprise-base
+  name: openshift/ose-egress-http-proxy

--- a/images/ose-kube-metrics-server.yml
+++ b/images/ose-kube-metrics-server.yml
@@ -9,19 +9,31 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-kube-metrics-server-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/kube-metrics-server-rhel8
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/kube-metrics-server-rhel9
 payload_name: kube-metrics-server
 owners:
 - team-monitoring-incluster@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/kube-metrics-server-rhel8

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -9,21 +9,21 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
     pkg_managers:
     - gomod
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-kubevirt-csi-driver-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-kubevirt-csi-driver
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-kubevirt-csi-driver-rhel9
 payload_name: kubevirt-csi-driver
 owners:
 - ydayagi@redhat.com
@@ -31,3 +31,15 @@ owners:
 - rgolan@redhat.com
 - nargaman@redhat.com
 - dvossel@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-kubevirt-csi-driver

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -10,19 +10,31 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-catalogd-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-olm-catalogd-rhel8
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-olm-catalogd-rhel9
 payload_name: olm-catalogd
 owners:
 - aos-odin@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-olm-catalogd-rhel8

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -11,6 +11,8 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
+    pkg_managers:
+    - gomod
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-operator-controller-container

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -10,24 +10,37 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-operator-controller-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+
-  io.k8s.description: This is the central component of Operator Lifecycle Manager (OLM) v1
+  io.k8s.description: This is the central component of Operator Lifecycle Manager
+    (OLM) v1
   io.k8s.display-name: OpenShift Operator Framework Operator Controller
   vendor: Red Hat
-name: openshift/ose-olm-operator-controller-rhel8
+name: openshift/ose-olm-operator-controller-rhel9
 payload_name: olm-operator-controller
 owners:
 - aos-odin@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-olm-operator-controller-rhel8

--- a/images/ose-olm-rukpak.yml
+++ b/images/ose-olm-rukpak.yml
@@ -10,15 +10,15 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-rukpak-container
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 labels:
   io.k8s.display-name: OpenShift RukPak
   io.k8s.description: This is a component of OpenShift Container Platform and manages
@@ -27,7 +27,16 @@ labels:
   summary: This is a component of OpenShift Container Platform and manages the lifecycle
     of operators.
   License: Apache 2.0
-name: openshift/ose-olm-rukpak
+name: openshift/ose-olm-rukpak-rhel9
 payload_name: olm-rukpak
 owners:
 - aos-odin@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-olm-rukpak

--- a/images/ose-route-controller-manager.yml
+++ b/images/ose-route-controller-manager.yml
@@ -9,24 +9,37 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-route-controller-manager-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 labels:
   io.k8s.display-name: OpenShift Route Controller Manager Command
-  io.k8s.description: OpenShift is a platform for developing, building, and deploying containerized applications.
+  io.k8s.description: OpenShift is a platform for developing, building, and deploying
+    containerized applications.
   io.openshift.tags: openshift,route-controller-manager
-name: openshift/ose-route-controller-manager
+name: openshift/ose-route-controller-manager-rhel9
 payload_name: route-controller-manager
 owners:
 - jchaloup@redhat.com
 - fkrepins@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    member: openshift-enterprise-base
+  name: openshift/ose-route-controller-manager


### PR DESCRIPTION
Ref ticket: https://issues.redhat.com/browse/ART-9189

All images except ose-olm-operator-controller [succeeded](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/236/)

ose-olm-operator-controller issue fixed by https://github.com/openshift-eng/ocp-build-data/pull/4535, green build [here](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2966003).