### PR TITLE
ART-9185 4.14 - Bump builders to latest 1.20.12

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -31,7 +31,7 @@ golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 golang:
-  image: openshift/golang-builder:v1.20.12-202401111802.el8.g17c0aac
+  image: openshift/golang-builder:v1.20.12-202403212140.el8.g2983c24.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -53,7 +53,7 @@ rhel-9-golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
-  image: openshift/golang-builder:v1.20.12-202401111603.el9.g0bebe58
+  image: openshift/golang-builder:v1.20.12-202403212137.el9.g144a3f8.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
Same as 4.15 bump: https://github.com/openshift-eng/ocp-build-data/pull/4539