### PR TITLE
ose-console migrate to rhel9

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -22,17 +22,17 @@ cachito:
     yarn:
     - path: frontend
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-console-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  - member: openshift-base-nodejs
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  - member: openshift-base-nodejs.rhel9
+  member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+
   io.k8s.description: This is a component of OpenShift Container Platform and provides
@@ -40,7 +40,7 @@ labels:
   io.k8s.display-name: OpenShift Console
   io.openshift.tags: openshift,console
   vendor: Red Hat
-name: openshift/ose-console
+name: openshift/ose-console-rhel9
 payload_name: console
 owners:
 - spadgett@redhat.com

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -44,3 +44,16 @@ name: openshift/ose-console-rhel9
 payload_name: console
 owners:
 - spadgett@redhat.com
+alternative_upstream:
+- when: el8
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  enabled_repos:
+  - rhel-8-baseos-rpms
+  - rhel-8-appstream-rpms
+  from:
+    builder:
+    - stream: golang
+    - member: openshift-base-nodejs
+    member: openshift-enterprise-base
+  name: openshift/ose-console


### PR DESCRIPTION
Green [build](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2968315) 

Splitting out from https://github.com/openshift-eng/ocp-build-data/pull/4545