### PR TITLE
4.15.5 pin rpms

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -39,6 +39,14 @@ releases:
           s390x: 4.15.0-0.nightly-s390x-2024-03-20-032213
           x86_64: 4.15.0-0.nightly-2024-03-20-032212
       group:
+        dependencies:
+          rpms:
+          - el8: cri-o-1.28.4-5.rhaos4.15.git159b3c8.el8
+            why: "pin what's in rhcos"
+            non_gc_tag: "Build will be shipped via advisory and therefore will not be gc'd"
+          - el9: cri-o-1.28.4-5.rhaos4.15.git159b3c8.el9
+            why: "pin what's in rhcos"
+            non_gc_tag: "Build will be shipped via advisory and therefore will not be gc'd"
         advisories:
           extras: 129356
           image: 129357


### PR DESCRIPTION
This is to satisfy assembly issue:

```
assembly_issues:
  rhcos:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected cri-o-1.28.4-7.rhaos4.15.git14784b2.el9 to be installed in RHCOS
      build 415.92.202403191241-0 (x86_64) but found cri-o-1.28.4-5.rhaos4.15.git159b3c8.el9
    permitted: false
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected cri-o-1.28.4-7.rhaos4.15.git14784b2.el9 to be installed in RHCOS
      build 415.92.202403191241-0 (ppc64le) but found cri-o-1.28.4-5.rhaos4.15.git159b3c8.el9
    permitted: false
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected cri-o-1.28.4-7.rhaos4.15.git14784b2.el9 to be installed in RHCOS
      build 415.92.202403191241-0 (s390x) but found cri-o-1.28.4-5.rhaos4.15.git159b3c8.el9
    permitted: false
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected cri-o-1.28.4-7.rhaos4.15.git14784b2.el9 to be installed in RHCOS
      build 415.92.202403191241-0 (aarch64) but found cri-o-1.28.4-5.rhaos4.15.git159b3c8.el9
    permitted: false
```
Before: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/192/console

After: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/196/console