### PR TITLE
remove rhel8 golang in ose-ovn-kubernetes

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -33,7 +33,6 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+


### PR DESCRIPTION
align with https://github.com/openshift/ovn-kubernetes/commit/2f51c186ff5adcdf4fe4f94486469af6b67b598d