### PR TITLE
check_external_packages: change to greater_equal for conmon

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -80,9 +80,10 @@ check_external_packages:
   - name: cri-tools
     tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
     condition: match
+  # As of Mar 28, 2024, RHEL has a newer version of conmon
   - name: conmon
     tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
-    condition: match
+    condition: greater_equal
   - name: skopeo
     tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
     condition: match


### PR DESCRIPTION
As of Mar 28, 2024, RHEL has a newer version of conmon:

```
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR conmon-2.1.2-5.2.rhaos4.12.el8
      but found conmon-2.1.4-1.module+el8.6.0+21266+3e24c7b3 installed
    permitted: false
```