### PR TITLE
Bump to 1.21

### DIFF
--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-1.20-ci-build-root
+          stream: rhel-8-golang-1.21-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-must-gather-container
@@ -19,7 +19,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang-1.20
+  - stream: golang-1.21
   member: openshift-enterprise-cli
 name: openshift/ose-must-gather
 payload_name: must-gather


### PR DESCRIPTION
Upstream has moved to 1.21 https://github.com/openshift/must-gather/blob/release-4.16/Dockerfile.rhel7