### PR TITLE
ose-baremetal-installer does not depend on terraform-providers

### DIFF
--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -21,7 +21,6 @@ for_payload: true
 # needs to bump to account for the new tarball suffix
 from:
   builder:
-  - member: ose-installer-terraform-providers
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-baremetal-installer


### PR DESCRIPTION
This is the only installer image that is dynamically built, so it needs to build the terraform providers as well since the terraform-providers image contains statically linked binaries.

/hold
for https://github.com/openshift/installer/pull/8215