### PR TITLE
CORS-3191: add etcd image dep to installer

### DIFF
--- a/images/ose-installer-etcd-artifacts.yaml
+++ b/images/ose-installer-etcd-artifacts.yaml
@@ -1,0 +1,62 @@
+base_only: true
+cachito:
+  packages:
+    gomod:
+    - path: .
+    - path: api
+    - path: client/pkg
+    - path: client/v2
+    - path: client/v3
+    - path: etcdctl
+    - path: etcdutl
+    - path: pkg
+    - path: raft
+    - path: server
+    - path: tests
+    - path: tools/mod
+content:
+  source:
+    dockerfile: Dockerfile.installer
+    git:
+      branch:
+        target: openshift-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/etcd.git
+      web: https://github.com/openshift/etcd
+    pkg_managers:
+    - gomod
+    ci_alignment:
+      streams_prs:
+        enabled: false
+        ci_build_root:
+          stream: rhel-9-golang-ci-build-root
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ose-installer-etcd-artifacts-container
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+for_payload: false
+for_release: false
+from:
+  builder:
+  # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
+  # approval to diverge from what kube apiserver uses for a given release.
+  - stream: etcd_rhel9_golang
+  - stream: etcd_rhel9_golang
+  - stream: etcd_rhel9_golang
+  - stream: etcd_rhel9_golang
+  member: openshift-enterprise-base-rhel9
+labels:
+  License: Apache 2.0
+  io.k8s.description: etcd is distributed key-value store which stores the persistent
+    master state for Kubernetes and OpenShift.
+  io.k8s.display-name: etcd server
+  io.openshift.tags: etcd
+name: openshift/installer-etcd-artifacts
+owners:
+- aos-install@redhat.com
+external_scanners:
+  sast_scanning:
+    jira_integration:
+      enabled: false
+


### PR DESCRIPTION
With the transition from terraform to CAPI, the Installer has now to run a controlplane on the host with etcd. This first step builds an intermediary container image from which the Installer will be able to extract binaries during build time.