### PR TITLE
Fix aws-efs-utils-base name

### DIFF
--- a/images/ose-aws-efs-utils.yml
+++ b/images/ose-aws-efs-utils.yml
@@ -21,7 +21,7 @@ for_payload: false
 for_release: false
 from:
   member: openshift-enterprise-base-rhel9
-name: openshift/ose-aws-efs-utils-base-rhel9
+name: openshift/ose-aws-efs-utils-base
 owners:
 - aos-storage-staff@redhat.com
 canonical_builders_from_upstream: false


### PR DESCRIPTION
Currently, 4.16 build-sync is complaining because
```
image "registry.ci.openshift.org/ocp/4.16:aws-efs-utils-base-rhel9" not found: manifest unknown: manifest unknown
```
In fact, 
```
$ oc get istag | grep 4.16:aws-efs-utils-base | cut -d " " -f 1 | sort --unique
4.16:aws-efs-utils-base
```
so that imagestream tag never existed. This happened because:

1. [this change](https://github.com/openshift-eng/ocp-build-data/pull/4544/files#diff-5d61cb477dc5f256d5d951c468df930e26ae239fc8be9e17f4eef18120801854R36) added the `alternative_upstream` config, where the image was named `openshift/ose-aws-efs-utils-base` (just like it is in all other branches. In the main config, it started having the `-rhel9` suffix
2. [this change](https://github.com/openshift-eng/ocp-build-data/commit/fcf3db9a94bd157b734f10f0007fe3f94755c59e#diff-5d61cb477dc5f256d5d951c468df930e26ae239fc8be9e17f4eef18120801854L27) in turn removed the `alternative_upstream` config and disabled canonical builders. So the image started being referenced to with the `-rhel9` suffix
3. an [alignment PR](https://github.com/openshift/aws-efs-csi-driver/commit/2c5584584f43e8717723ccbd141424d32cf841fa#diff-f20a7cf8ba7e8b20f3bd1963e18191e6ba4474bb0bf92bdd745bb62841e4a6c3R7) was merged upstream, updating the `FROM` clause to reference the non-existing imagestream tag

Finally, when our automation looks at upstream intended rhel version for `aws-efs-csi-driver`, it now tries to look into a non-existing image, hence the error message on build-sync.

Note that this is not breaking anything, it's just polluting our logs with an error that shouldn't be there.