### PR TITLE
4.15 - Exclude LCA operator jira component

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -77,6 +77,7 @@ filters:
     - "Cloud Native Events / Hardware Event Proxy"
     - "descheduler"
     - "secondary-scheduler-operator"
+    - "LCA operator"
   security:
     - "AWS Load Balancer Operator"
     - "Quay"
@@ -114,3 +115,4 @@ filters:
     - "Cloud Native Events / Hardware Event Proxy"
     - "descheduler"
     - "secondary-scheduler-operator"
+    - "LCA operator"


### PR DESCRIPTION
LCA operator is built in CPaaS, so exclude it from ART operations.
example bug: https://issues.redhat.com/browse/OCPBUGS-31374
ref: https://redhat-internal.slack.com/archives/CB95J6R4N/p1712846278042069?thread_ts=1712844263.382109&cid=CB95J6R4N