### PR TITLE
[ART-9397] 4.14 golang bump

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -31,7 +31,7 @@ golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 golang:
-  image: openshift/golang-builder:v1.20.12-202403212140.el8.g2983c24.el8
+  image: openshift/golang-builder:v1.20.12-202404151507.g92d4921.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -53,7 +53,7 @@ rhel-9-golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
-  image: openshift/golang-builder:v1.20.12-202403212137.el9.g144a3f8.el9
+  image: openshift/golang-builder:v1.20.12-202404151445.g5488123.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
Builds:
rhel8: [openshift-golang-builder-container-v1.20.12-202404151507.g92d4921.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3004037)
rhel9: [openshift-golang-builder-container-v1.20.12-202404151445.g5488123.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3003949)