### PR TITLE
[ART-9397] 4.13 golang bump

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 ####################################################################################################
 
 golang:
-  image: openshift/golang-builder:v1.19.13-202403221045.el8.gfa00de2.el8
+  image: openshift/golang-builder:v1.19.13-202404160928.gfa00de2.el8
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -30,7 +30,7 @@ golang:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
-  image: openshift/golang-builder:v1.19.13-202403221142.el9.g3172d57.el9
+  image: openshift/golang-builder:v1.19.13-202404160932.g3172d57.el9
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -54,7 +54,7 @@ rhel-9-golang-ci-build-root:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 etcd_rhel9_golang:
-  image: openshift/golang-builder:v1.19.13-202403221142.el9.g3172d57.el9
+  image: openshift/golang-builder:v1.19.13-202404160932.g3172d57.el9
   mirror: false
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
Builds:

rhel8: [openshift-golang-builder-container-v1.19.13-202404160928.gfa00de2.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3005887)
rhel9: [openshift-golang-builder-container-v1.19.13-202404160932.g3172d57.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3005938)