### PR TITLE
4.15 v1.19.13 golang bump

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -148,7 +148,7 @@ etcd_golang-1.16:
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.
 etcd_golang:
-  image: openshift/golang-builder:v1.19.13-202403221045.el8.gfa00de2.el8
+  image: openshift/golang-builder:v1.19.13-202404160928.gfa00de2.el8
   mirror: true
   # No transform required as etcd does not yum install any packages.
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -159,7 +159,7 @@ etcd_golang:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-etcd-golang-1.19
 
 etcd_rhel9_golang:
-  image: openshift/golang-builder:v1.19.13-202403221142.el9.g3172d57.el9
+  image: openshift/golang-builder:v1.19.13-202404160932.g3172d57.el9
   mirror: true
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
Follows https://github.com/openshift-eng/ocp-build-data/pull/4671

rhel8: [openshift-golang-builder-container-v1.19.13-202404160928.gfa00de2.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3005887)
rhel9: [openshift-golang-builder-container-v1.19.13-202404160932.g3172d57.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3005938)