### PR TITLE
4.14 v1.19.13 golang bump

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 ####################################################################################################
 
 golang-1.19:
-  image: openshift/golang-builder:v1.19.13-202403221045.el8.gfa00de2.el8
+  image: openshift/golang-builder:v1.19.13-202404160928.gfa00de2.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -42,7 +42,7 @@ golang:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.19:
-  image: openshift/golang-builder:v1.19.13-202403221142.el9.g3172d57.el9
+  image: openshift/golang-builder:v1.19.13-202404160932.g3172d57.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -115,7 +115,7 @@ etcd_golang:
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.
 etcd_golang-1.19:
-  image: openshift/golang-builder:v1.19.13-202403221045.el8.gfa00de2.el8
+  image: openshift/golang-builder:v1.19.13-202404160928.gfa00de2.el8
   mirror: false
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -126,7 +126,7 @@ etcd_golang-1.19:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-etcd-golang-1.19
 
 etcd_rhel9_golang:
-  image: openshift/golang-builder:v1.19.13-202403221142.el9.g3172d57.el9
+  image: openshift/golang-builder:v1.19.13-202404160932.g3172d57.el9
   mirror: false
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
Follows https://github.com/openshift-eng/ocp-build-data/pull/4671

rhel8: [openshift-golang-builder-container-v1.19.13-202404160928.gfa00de2.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3005887)
rhel9: [openshift-golang-builder-container-v1.19.13-202404160932.g3172d57.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3005938)