### PR TITLE
Bump hypershift golang to 1.21

### DIFF
--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -19,7 +19,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.21
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-hypershift-rhel9
 payload_name: hypershift


### PR DESCRIPTION
Fixes
```
go.mod file indicates go 1.21, but maximum version supported by tidy is 1.20
```