### PR TITLE
[ART-9397] 4.16 golang bump

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -22,7 +22,7 @@
 golang:
   aliases:
   - rhel-8-golang-{GO_LATEST}
-  image: openshift/golang-builder:v1.21.7-202403061535.el8.g1ac3e39.el8
+  image: openshift/golang-builder:v1.21.9-202404181433.g1ac3e39.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -35,7 +35,7 @@ golang:
 rhel-9-golang:
   aliases:
   - rhel-9-golang-{GO_LATEST}
-  image: openshift/golang-builder:v1.21.7-202403061534.el9.gab74a9a.el9
+  image: openshift/golang-builder:v1.21.9-202404181431.gab74a9a.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -68,14 +68,14 @@ rhel-9-golang-1.22-ci-build-root:
 
 ibm-rhel-9-golang-1.21:
   # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.21.7-202403061534.el9.gab74a9a.el9
+  image: openshift/golang-builder:v1.21.9-202404181431.gab74a9a.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
 
 ibm-rhel-8-golang-1.21:
   # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.21.7-202403061535.el8.g1ac3e39.el8
+  image: openshift/golang-builder:v1.21.9-202404181433.g1ac3e39.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
Builds:

rhel8: [openshift-golang-builder-container-v1.21.9-202404181433.g1ac3e39.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3010854)
rhel9: [openshift-golang-builder-container-v1.21.9-202404181431.gab74a9a.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3010856)