### PR TITLE
no openshift-clients

### DIFF
--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -1,3 +1,4 @@
+mode: wip
 content:
   source:
     git:


### PR DESCRIPTION
There is a weird build error for openshift-clients on golang-1.22. Disabling for now. 