### PR TITLE
4.16 golang bump v1.21.9

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -22,7 +22,7 @@
 golang:
   aliases:
   - rhel-8-golang-{GO_LATEST}
-  image: openshift/golang-builder:v1.21.9-202404181433.g1ac3e39.el8
+  image: openshift/golang-builder:v1.21.9-202404231038.g1ac3e39.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -75,7 +75,7 @@ ibm-rhel-9-golang-1.21:
 
 ibm-rhel-8-golang-1.21:
   # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.21.9-202404181433.g1ac3e39.el8
+  image: openshift/golang-builder:v1.21.9-202404231038.g1ac3e39.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
Looks like the earlier one didn't have the correct module build

Builder: [openshift-golang-builder-container-v1.21.9-202404231038.g1ac3e39.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3019534)