### PR TITLE
CORS-3250: installer: add etcd/kas to altinfra image.

### DIFF
--- a/images/ose-installer-altinfra.yml
+++ b/images/ose-installer-altinfra.yml
@@ -1,6 +1,10 @@
 content:
   source:
     dockerfile: images/installer-altinfra/Dockerfile.ci
+    modifications:
+      - action: replace
+        match: 'ARG OPENSHIFT_INSTALL_CLUSTER_API=""'
+        replacement: 'ARG OPENSHIFT_INSTALL_CLUSTER_API="y"'
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -9,19 +13,21 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-installer-altinfra-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
-name: openshift/ose-installer-altinfra-rhel8
+  - member: ose-etcd
+  - member: openshift-enterprise-hyperkube
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-installer-altinfra-rhel9
 payload_name: installer-altinfra
 owners:
 - aos-install@redhat.com


### PR DESCRIPTION
This is needed to enable capi providers in the release.

Depends on https://github.com/openshift/installer/pull/8309