### PR TITLE
disabled ose-smb-csi-driver-operator for ec.6

### DIFF
--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled # for ec.6
 content:
   source:
     dockerfile: Dockerfile.samba


### PR DESCRIPTION
gen-assembly for ec.6 failed because this image couldn't be found