### PR TITLE
[4.16.0-ec.6] pin NVRs for components that did not exist at nightly time

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -21,6 +21,41 @@ releases:
         upgrades: 4.15.5,4.15.6,4.15.7,4.15.8,4.15.9,4.15.10,4.15.11,4.16.0-ec.1,4.16.0-ec.2,4.16.0-ec.3,4.16.0-ec.4,4.16.0-ec.5
       members:
         images:
+        - distgit_key: ose-smb-csi-driver
+          metadata:
+            is:
+              nvr: ose-smb-csi-driver-container-v4.16.0-202404231239.p0.g48072ba.assembly.stream.el9
+          why: Component did not exist at nightly cut cut-off
+        - distgit_key: ose-smb-csi-driver-operator
+          metadata:
+            is:
+              nvr: ose-smb-csi-driver-operator-container-v4.16.0-202404231239.p0.g097858b.assembly.stream.el9
+          why: Component did not exist at nightly cut cut-off
+        - distgit_key: dpu-cni
+          metadata:
+            is:
+              nvr: dpu-cni-container-v4.16.0-202404231239.p0.gce3aeb8.assembly.stream.el9
+          why: Component did not exist at nightly cut cut-off
+        - distgit_key: dpu-daemon
+          metadata:
+            is:
+              nvr: dpu-daemon-container-v4.16.0-202404221036.p0.gc8d787e.assembly.test.el9
+          why: Component did not exist at nightly cut cut-off
+        - distgit_key: dpu-operator
+          metadata:
+            is:
+              nvr: dpu-operator-container-v4.16.0-202404231909.p0.gf1158b5.assembly.stream.el9
+          why: Component did not exist at nightly cut cut-off
+        - distgit_key: container-networking-plugins-microshift
+          metadata:
+            is:
+              nvr: container-networking-plugins-microshift-container-v4.16.0-202404251943.p0.gf503997.assembly.stream.el9
+          why: Component did not exist at nightly cut cut-off
+        - distgit_key: multus-cni-container-microshift
+          metadata:
+            is:
+              nvr: multus-cni-container-microshift-container-v4.16.0-202404251943.p0.gbd8686f.assembly.stream.el9
+          why: Component did not exist at nightly cut cut-off
         - distgit_key: ose-installer-artifacts
           metadata:
             is:


### PR DESCRIPTION
Tested with:
```
elliott --data-path=/home/dpaolell/develop/github.com/openshift/ocp-build-data --group=openshift-4.16 --assembly ec.6 find-builds --kind=image --payload
```
and
```
elliott --data-path=/home/dpaolell/develop/github.com/openshift/ocp-build-data --group=openshift-4.16 --assembly ec.6 find-builds --kind=image --non-payload
```