### PR TITLE
smb-csi-driver-operator: fix valid-subscription-label

### DIFF
--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -33,4 +33,4 @@ update-csv:
   bundle-dir: preview
   manifests-dir: config/samba/manifests/
   registry: image-registry.openshift-imageregistry.svc:5000
-  valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+  valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
[operator-valid-subscriptions-bundle-image](http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-smb-csi-driver-operator-bundle-container-v4.16.0.202404231239.p0.g097858b.assembly.stream.el9-8/58bb1ba2-d3dd-48d0-b6a7-06f5ab0dd44d/operator-valid-subscriptions-bundle-image-output.txt) failed with:

```
[INVALID] 'openshift4/ose-smb-csi-driver-operator-bundle' subscription type: OCP and up
 -> The annotation must contain: 'OpenShift Container Platform', 'OpenShift Platform Plus', but not contain: 'OpenShift Kubernetes Engine'
```

/cc @ashwindasr @mpatlasov @joepvd
/cherrypick openshift-4.17
