### PR TITLE
CORS-3191: installer: add kas/etcd deps to images

### DIFF
--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -22,6 +22,8 @@ for_payload: true
 # needs to bump to account for the new tarball suffix
 from:
   builder:
+  - member: ose-etcd
+  - member: openshift-enterprise-hyperkube
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-baremetal-installer-rhel9

--- a/images/ose-installer-altinfra.yml
+++ b/images/ose-installer-altinfra.yml
@@ -23,8 +23,8 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - member: ose-etcd
-  - member: openshift-enterprise-hyperkube
+  - member: ose-installer-kube-apiserver-artifacts
+  - member: ose-installer-etcd-artifacts
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-installer-altinfra-rhel9

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -20,6 +20,8 @@ for_payload: true
 from:
   builder:
   - member: ose-installer-terraform-providers
+  - member: ose-installer-kube-apiserver-artifacts
+  - member: ose-installer-etcd-artifacts
   - stream: rhel-9-golang
   - stream: rhel-9-golang
   - stream: rhel-9-golang

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -21,6 +21,8 @@ for_payload: true
 from:
   builder:
   - member: ose-installer-terraform-providers
+  - member: ose-installer-kube-apiserver-artifacts
+  - member: ose-installer-etcd-artifacts
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-installer-rhel9


### PR DESCRIPTION
This is the last step needed before we can enable capi and capi providers in the release image.