### PR TITLE
Comment out cdn repos that don't exist

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -16,7 +16,7 @@ brew_tag_product_version_mapping:
   # rhaos-{MAJOR}.{MINOR}-ironic-rhel-9-hotfix: OSE-IRONIC-{MAJOR}.{MINOR}-RHEL-9
 
 cdn_repos:
-# These do not exist yet
+# These do not exist yet see: CLOUDDST-22780
 # - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-x86_64-rpms
 # - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-ppc64le-rpms
 # - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-s390x-rpms

--- a/erratatool.yml
+++ b/erratatool.yml
@@ -16,10 +16,11 @@ brew_tag_product_version_mapping:
   # rhaos-{MAJOR}.{MINOR}-ironic-rhel-9-hotfix: OSE-IRONIC-{MAJOR}.{MINOR}-RHEL-9
 
 cdn_repos:
-- rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-x86_64-rpms
-- rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-ppc64le-rpms
-- rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-s390x-rpms
-- rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-aarch64-rpms
+# These do not exist yet
+# - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-x86_64-rpms
+# - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-ppc64le-rpms
+# - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-s390x-rpms
+# - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-aarch64-rpms
 - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-9-x86_64-rpms
 - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-9-ppc64le-rpms
 - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-9-s390x-rpms


### PR DESCRIPTION
`find-builds --attach` fails because it tries to enable non existent cdn repos to advisory
Related: https://github.com/openshift-eng/art-tools/pull/634

Test:
```
curl -sSL --negotiate --user : "https://errata.devel.redhat.com/api/v1/cdn_repos?filter
\[name\]=rhocp-4_DOT_16-for-rhel-8-x86_64-rpms" | jq
```

Request to create https://issues.redhat.com/browse/CLOUDDST-22780