### PR TITLE
Fix ci-build-root build failures

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -28,10 +28,10 @@ RUN set -euxo pipefail && \
     /tmp/install_etcd.sh "3.5.10"
 
 RUN CI_PINNED_GIT_VERSION="git-2.31.1" && \
-    echo "Uninstalling any pre-existing git to ensure that we install ${CI_PINNED_GIT_VERSION}" && yum remove -y git || true && \
+    echo "Uninstalling any pre-existing git to ensure that we install ${CI_PINNED_GIT_VERSION}" && dnf remove --noautoremove -y git || true && \
     INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc ${CI_PINNED_GIT_VERSION} glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
-    yum install -y $INSTALL_PKGS && \
-    yum clean all && \
+    dnf install -y $INSTALL_PKGS && \
+    dnf clean all && \
     touch /os-build-image && \
     git config --system user.name origin-release-container && \
     git config --system user.email origin-release@redhat.com

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -28,10 +28,10 @@ RUN set -euxo pipefail && \
     /tmp/install_etcd.sh "3.5.10"
 
 RUN CI_PINNED_GIT_VERSION="git-2.31.1" && \
-    echo "Uninstalling any pre-existing git to ensure that we install ${CI_PINNED_GIT_VERSION}" && yum remove -y git || true && \
+    echo "Uninstalling any pre-existing git to ensure that we install ${CI_PINNED_GIT_VERSION}" && dnf remove --noautoremove -y git || true && \
     INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc ${CI_PINNED_GIT_VERSION} glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
-    yum install -y $INSTALL_PKGS && \
-    yum clean all && \
+    dnf install -y $INSTALL_PKGS && \
+    dnf clean all && \
     touch /os-build-image && \
     git config --system user.name origin-release-container && \
     git config --system user.email origin-release@redhat.com


### PR DESCRIPTION
Brew builds of ci-build-root rhel8 images are failing the content set check of brew, as the package less is different between the arches. This is because less gets removed from some of the arches when git gets installed. Reinstalling git pulls in the current less on arches where it was removed, whereas it remains the old one where there was no removal.

This change instructs dnf to not be smart and remove perceived dependencies.