### PR TITLE
Silence RHEL8 builders in CI

### DIFF
--- a/ci_transforms/rhel-8/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-8/ci-build-root/Dockerfile
@@ -10,6 +10,11 @@ FROM replaced-by-buildconfig
 # trouble than it is worth and should not be need to catch actual FIPS issues.
 ENV GO_COMPLIANCE_POLICY=exempt_all
 
+# Turn off information for CI environment. This is usually just noise for upstream
+# engineers and can complicate debug. When issues arise, have repos export
+# GO_COMPLIANCE_INFO=1 or GO_COMPLIANCE_DEBUG=1 before running go.
+ENV GO_COMPLIANCE_INFO=0
+
 # Install, matching upstream k8s, protobuf-3.x, see:
 # https://github.com/kubernetes/kubernetes/blob/master/hack/lib/protoc.sh
 # and etcd, see:

--- a/ci_transforms/rhel-8/golang/Dockerfile
+++ b/ci_transforms/rhel-8/golang/Dockerfile
@@ -2,6 +2,11 @@ FROM replaced-by-buildconfig
 # Layers CI appropriate yum repository configurations on top of the ART builder images.
 # Used as a template for 'images:streams gen-buildconfigs'
 
+# Turn off information for CI environment. This is usually just noise for upstream
+# engineers and can complicate debug. When issues arise, have repos export
+# GO_COMPLIANCE_INFO=1 or GO_COMPLIANCE_DEBUG=1 before running go.
+ENV GO_COMPLIANCE_INFO=0
+
 ENV GOARM=5 \
     LOGNAME=deadbeef \
     GOCACHE=/go/.cache \


### PR DESCRIPTION
This was already done in https://issues.redhat.com/browse/ART-7963 for RHEL9.