### PR TITLE
ART-7860: Use GOAMD64=v2 on rhel9 1.22 golang builder containers

### DIFF
--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -6,6 +6,7 @@ ENV SUMMARY="RHEL9 based Go builder image for OpenShift ART" \
     GOFLAGS='-mod=vendor' \
     GOPATH=${GOPATH:-/go} \
     GOMAXPROCS=8 \
+    GOAMD64=v2 \
     VERSION="1.22" \
     GO_VERSION="${__doozer_version:-$VERSION}" \
     GODEBUG="disablethp=1"


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-7860