### PR TITLE
Make /go writeable in ci-build-root

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -61,6 +61,12 @@ RUN export GOPROXY="https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com:9443" &
     curl --fail -L -k $GHPROXY_PREFIX/golang/dep/releases/download/v0.5.4/dep-linux-amd64 > /usr/bin/dep && \
     chmod +x /usr/bin/dep
 
+# make go related directories writeable since builds in CI will run as non-root. go install
+# may have created new directories.
+RUN mkdir -p $GOPATH && \
+    chmod g+xw -R $GOPATH && \
+    chmod g+xw -R $(go env GOROOT)
+
 # Some image building tools don't create a missing WORKDIR
 RUN mkdir -p /go/src/github.com/openshift/origin
 WORKDIR /go/src/github.com/openshift/origin

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -61,6 +61,12 @@ RUN export GOPROXY="https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com:9443" &
     curl --fail -L -k $GHPROXY_PREFIX/golang/dep/releases/download/v0.5.4/dep-linux-amd64 > /usr/bin/dep && \
     chmod +x /usr/bin/dep
 
+# make go related directories writeable since builds in CI will run as non-root. go install
+# may have created new directories.
+RUN mkdir -p $GOPATH && \
+    chmod g+xw -R $GOPATH && \
+    chmod g+xw -R $(go env GOROOT)
+
 # Some image building tools don't create a missing WORKDIR
 RUN mkdir -p /go/src/github.com/openshift/origin
 WORKDIR /go/src/github.com/openshift/origin


### PR DESCRIPTION
go install was creating /go/bin in the build root image. This was directory was only writeable by root. CI builds install tools as well, running as non-root, so it is necessary for them to be able to write to this directory structure.