### PR TITLE
4.17 to golang 1.22

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -64,7 +64,7 @@ assemblies:
   enabled: true
 
 cachito:
-  enabled: true
+  enabled: false
 
 rhcos:
   payload_tags:

--- a/group.yml
+++ b/group.yml
@@ -23,9 +23,9 @@ vars:
   #               aliases:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
-  GO_LATEST: "1.21"
-  GO_PREVIOUS: "1.20"
-  GO_EXTRA: "1.21"  # There is no extra version at this time, so just duplicate latest.
+  GO_LATEST: "1.22"
+  GO_PREVIOUS: "1.21"
+  GO_EXTRA: "1.22"  # There is no extra version at this time, so just duplicate latest.
 
 
 compliance:

--- a/images/dpu-network-operator.yml
+++ b/images/dpu-network-operator.yml
@@ -24,7 +24,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base
 name: openshift/dpu-network-rhel8-operator
 name_in_bundle: dpu-network-operator

--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -19,7 +19,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-egress-router-cni-rhel9
 payload_name: egress-router-cni

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -25,7 +25,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: golang
+  - stream: rhel-8-golang
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sriov-infiniband-cni-rhel9

--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: Dockerfile.art

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -23,7 +23,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 labels:
   io.k8s.description: This is a component of OpenShift Container Platform and provides

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: Dockerfile.art

--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -19,7 +19,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: rhel-8-golang
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-oc-mirror-rhel9

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -21,7 +21,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base
 maintainer:
   component: Operator SDK

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -20,7 +20,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: rhel-8-golang
   - stream: rhel-9-golang
   member: openshift-enterprise-cli
 name: openshift/ose-cli-artifacts-rhel9

--- a/images/ose-cloud-credential-operator.yml
+++ b/images/ose-cloud-credential-operator.yml
@@ -19,7 +19,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cloud-credential-operator-rhel9
 payload_name: cloud-credential-operator

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -23,8 +23,8 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang
-  - stream: golang
+  - stream: rhel-8-golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-container-networking-plugins-rhel9
 payload_name: container-networking-plugins

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -1,4 +1,5 @@
 cachito:
+  enabled: true
   packages:
     gomod:
     - path: .
@@ -26,7 +27,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-9-golang-1.21-ci-build-root
     okd_alignment:
       dockerfile: Dockerfile.rhel
 distgit:
@@ -38,7 +39,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.21
   member: openshift-enterprise-base-rhel9
 labels:
   License: Apache 2.0

--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -1,5 +1,6 @@
 base_only: true
 cachito:
+  enabled: true
   packages:
     gomod:
     - path: .
@@ -28,7 +29,7 @@ content:
       streams_prs:
         enabled: false
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-9-golang-1.21-ci-build-root
     okd_alignment:
       dockerfile: Dockerfile.installer
 distgit:
@@ -43,11 +44,11 @@ from:
   builder:
   # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
   # approval to diverge from what kube apiserver uses for a given release.
-  - stream: etcd_rhel9_golang
-  - stream: etcd_rhel9_golang
-  - stream: etcd_rhel9_golang
-  - stream: etcd_rhel9_golang
-  - stream: etcd_rhel9_golang
+  - stream: rhel-9-golang-1.21
+  - stream: rhel-9-golang-1.21
+  - stream: rhel-9-golang-1.21
+  - stream: rhel-9-golang-1.21
+  - stream: rhel-9-golang-1.21
   member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -30,7 +30,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-machine-config-operator-rhel9
 payload_name: machine-config-operator

--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -20,7 +20,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-base-rhel9
 name: openshift/ose-multus-route-override-cni-rhel9
 payload_name: multus-route-override-cni

--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -21,7 +21,7 @@ from:
   builder:
   # Binaries must be compiled for the RHCOS version of RHEL
   - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-base-rhel9
 name: openshift/ose-multus-whereabouts-ipam-cni-rhel9
 payload_name: multus-whereabouts-ipam-cni

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -17,7 +17,7 @@ from:
   builder:
   # Binaries must be compiled for the RHCOS version of RHEL
   - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-network-interface-bond-cni-rhel9
 payload_name: network-interface-bond-cni

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -35,7 +35,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-8-golang
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -22,7 +22,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sdn-rhel9
 payload_name: sdn

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -24,7 +24,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-ptp-rhel9-operator
 name_in_bundle: ptp-operator

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -25,7 +25,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: golang
+  - stream: rhel-8-golang
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/sriov-cni-rhel9

--- a/streams.yml
+++ b/streams.yml
@@ -20,8 +20,6 @@
 ####################################################################################################
 
 rhel-8-golang-1.21:
-  aliases:
-  - rhel-8-golang-{GO_PREVIOUS}
   image: openshift/golang-builder:v1.21.7-202403061535.el8.g1ac3e39.el8
   mirror: true
   transform: rhel-8/golang
@@ -33,8 +31,6 @@ rhel-8-golang-1.21:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.21:
-  aliases:
-  - rhel-9-golang-{GO_PREVIOUS}
   image: openshift/golang-builder:v1.21.7-202403061534.el9.gab74a9a.el9
   mirror: true
   transform: rhel-9/golang
@@ -84,6 +80,20 @@ ibm-rhel-8-golang-1.21:
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
+
+ibm-rhel-9-golang-1.22:
+  # Mirror non-embargoed golang builders for IBM
+  image: openshift/golang-builder:v1.22.1-202404151500.g8dc5a64.el9
+  mirror: true
+  mirror_manifest_list: true
+  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}
+
+ibm-rhel-8-golang-1.22:
+  # Mirror non-embargoed golang builders for IBM
+  image: openshift/golang-builder:v1.22.2-202405221448.gd58751c.el8
+  mirror: true
+  mirror_manifest_list: true
+  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}
 
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on

--- a/streams.yml
+++ b/streams.yml
@@ -19,9 +19,9 @@
 #
 ####################################################################################################
 
-golang:
+rhel-8-golang-1.21:
   aliases:
-  - rhel-8-golang-{GO_LATEST}
+  - rhel-8-golang-{GO_PREVIOUS}
   image: openshift/golang-builder:v1.21.7-202403061535.el8.g1ac3e39.el8
   mirror: true
   transform: rhel-8/golang
@@ -32,9 +32,9 @@ golang:
   upstream_image_mirror:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang:
+rhel-9-golang-1.21:
   aliases:
-  - rhel-9-golang-{GO_LATEST}
+  - rhel-9-golang-{GO_PREVIOUS}
   image: openshift/golang-builder:v1.21.7-202403061534.el9.gab74a9a.el9
   mirror: true
   transform: rhel-9/golang
@@ -45,7 +45,9 @@ rhel-9-golang:
   upstream_image_mirror:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang-1.22:
+rhel-9-golang:
+  aliases:
+  - rhel-9-golang-{GO_LATEST}
   image: openshift/golang-builder:v1.22.1-202404151500.g8dc5a64.el9
   mirror: true
   transform: rhel-9/golang
@@ -56,7 +58,9 @@ rhel-9-golang-1.22:
   upstream_image_mirror:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}
 
-rhel-8-golang-1.22:
+rhel-8-golang:
+  aliases:
+  - rhel-8-golang-{GO_LATEST}
   image: openshift/golang-builder:v1.22.2-202405221448.gd58751c.el8
   mirror: true
   transform: rhel-8/golang
@@ -81,59 +85,10 @@ ibm-rhel-8-golang-1.21:
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-golang-1.20:
-  aliases:
-  - rhel-8-golang-{GO_PREVIOUS}
-  image: openshift/golang-builder:v1.20.12-202403212140.el8.g2983c24.el8
-  mirror: true
-  transform: rhel-8/golang
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}.art
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
-  upstream_image_mirror:
-  - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
-
-ibm-rhel-8-golang-1.20:
-  # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.20.12-202403212140.el8.g2983c24.el8
-  mirror: true
-  mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
-
-rhel-9-golang-1.20:
-  aliases:
-  - rhel-9-golang-{GO_PREVIOUS}
-  image: openshift/golang-builder:v1.20.12-202403212137.el9.g144a3f8.el9
-  mirror: true
-  transform: rhel-9/golang
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}.art
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
-  upstream_image_mirror:
-  - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
-
-ibm-rhel-9-golang-1.20:
-  # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.20.12-202403212137.el9.g144a3f8.el9
-  mirror: true
-  mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
-
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-1.20-ci-build-root:
-  image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
-  transform: rhel-8/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-{MAJOR}.{MINOR}
-
-# This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
-# Our transform is designed to create a buildconfig atop a specific golang version, layering on
-# packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-ci-build-root:
+rhel-8-golang-1.21-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
@@ -142,33 +97,29 @@ rhel-8-golang-ci-build-root:
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-9-golang-ci-build-root:
+rhel-8-golang-ci-build-root:
   image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
-  transform: rhel-9/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-{MAJOR}.{MINOR}
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}
+  transform: rhel-8/ci-build-root
+  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-{MAJOR}.{MINOR}
 
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-9-golang-1.20-ci-build-root:
+rhel-9-golang-ci-build-root:
   image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}
   transform: rhel-9/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-{MAJOR}.{MINOR}
+  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-{MAJOR}.{MINOR}
 
-# IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
-# approval to diverge from what kube apiserver uses for a given release.
-etcd_golang-1.16:
-  image: openshift/golang-builder:v1.16.12-202306121749.el8.g74bd633
-  mirror: true
-  # No transform required as etcd does not yum install any packages.
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.16
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.16
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
-  upstream_image_mirror:
-  - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-etcd-golang-1.16
+# This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
+# Our transform is designed to create a buildconfig atop a specific golang version, layering on
+# packages that upstream has traditionally had present in its build_roots.
+rhel-9-golang-1.21-ci-build-root:
+  image: not_applicable
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
+  transform: rhel-9/ci-build-root
+  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-{MAJOR}.{MINOR}
 
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.


### PR DESCRIPTION
This commit proposes to change the default golang to 1.22. The rhel8
golangs have been given a new name to include their rhel version.


Disable cachito because cachito does not do 1.22

Until https://issues.redhat.com/browse/STONEBLD-2206 is resolved,
cachito will not work for repositories with `1.22` in `go.mod`. As part
of the move to 1.22:
- disabling cachito processing globally
- enabling it for images that use REMOTE_SOURCES in their Dockerfile
- do not suggest to move to 1.22 for images that have their golang deps not
  vendored