### PR TITLE
4.17 - Explicitly set cachito configs

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: Dockerfile.rhel

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: Dockerfile.rhel9

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: Dockerfile.art

--- a/images/oauth-server.yml
+++ b/images/oauth-server.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: images/Dockerfile.rhel

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: openshift/operator-controller.Dockerfile

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: Dockerfile

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: true
 content:
   source:
     dockerfile: Dockerfile.microshift


### PR DESCRIPTION
Set `cachito.enabled = True` for all images that have a non-empty `content.source.pkg_managers`. This was implicitly being set but will require explicit setting once https://github.com/openshift-eng/art-tools/pull/659 merges
