### PR TITLE
[4.17] disable cachito for images using 1.22

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: false # Cachito does not work with go 1.22 https://issues.redhat.com/browse/STONEBLD-2206
 content:
   source:
     dockerfile: Dockerfile.rhel

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: false # Cachito does not work with go 1.22 https://issues.redhat.com/browse/STONEBLD-2206
 content:
   source:
     dockerfile: openshift/operator-controller.Dockerfile


### PR DESCRIPTION
Upstream bumped to golang 1.22 and this is breaking cachito