### PR TITLE
Remove temporary 4.17 streams from 4.16

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -45,27 +45,6 @@ rhel-9-golang:
   upstream_image_mirror:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-# Note: 4.16 will not use golang1.22, this is temporarily to enable 4.17 golang1.22
-rhel-9-golang-1.22:
-  image: openshift/golang-builder:v1.22.1-202404151500.g8dc5a64.el9
-  mirror: true
-  transform: rhel-9/golang
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17.art
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
-  upstream_image_mirror:
-  - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.22-openshift-4.17
-
-# This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
-# Our transform is designed to create a buildconfig atop a specific golang version, layering on
-# packages that upstream has traditionally had present in its build_roots.
-rhel-9-golang-1.22-ci-build-root:
-  image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17
-  transform: rhel-9/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17
-
 ibm-rhel-9-golang-1.21:
   # Mirror non-embargoed golang builders for IBM
   image: openshift/golang-builder:v1.21.9-202404181431.gab74a9a.el9


### PR DESCRIPTION
Both of these are being sync'd via the 4.17 branch now