### PR TITLE
STOR-1856: move AWS EFS operator to csi-operator repo

### DIFF
--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -1,14 +1,18 @@
 arches:
 - x86_64
 - aarch64
+cachito:
+  packages:
+    gomod:
+      - path: legacy/aws-efs-csi-driver-operator
 content:
   source:
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.aws-efs
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/aws-efs-csi-driver-operator.git
-      web: https://github.com/openshift/aws-efs-csi-driver-operator
+      url: git@github.com:openshift-priv/csi-operator.git
+      web: https://github.com/openshift/csi-operator
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -34,7 +38,7 @@ owners:
 - aos-storage-staff@redhat.com
 update-csv:
   bundle-dir: stable/
-  manifests-dir: config/manifests
+  manifests-dir: legacy/aws-efs-csi-driver-operator/config/manifests
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container
     Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
Needs to be merged along with: https://github.com/openshift/release/pull/52706