### PR TITLE
ART-9329: added ose-sriov-network-metrics-exporter

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -806,6 +806,8 @@ bug_mapping:
       issue_component: Storage
     ose-smb-csi-driver-operator-container:
       issue_component: Storage
+    ose-sriov-network-metrics-exporter:
+      issue_component: Networking / SR-IOV
     ose-thanos-container:
       issue_component: Monitoring
     ose-tools-container:


### PR DESCRIPTION
should be merged together with: https://github.com/openshift-eng/ocp-build-data/pull/4916