### PR TITLE
4.12: Stop building ingress-node-firewall-operator

### DIFF
--- a/images/ingress-node-firewall-daemon.yml
+++ b/images/ingress-node-firewall-daemon.yml
@@ -1,3 +1,4 @@
+mode: disabled # No backports needed according to upstream
 content:
   source:
     dockerfile: Dockerfile.daemon.openshift

--- a/images/ingress-node-firewall-operator.yml
+++ b/images/ingress-node-firewall-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled # No backports needed according to upstream
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -16,7 +16,6 @@ dependents:
 - dpu-network-operator
 - ose-metallb-operator
 - local-storage-operator
-- ingress-node-firewall-operator
 - ose-gcp-filestore-csi-driver-operator
 - ose-aws-efs-csi-driver-operator
 enabled_repos:


### PR DESCRIPTION
ART is currently not able to ship ingress-node-firewall. Upstream has indicated that backports will not be done: https://issues.redhat.com/browse/OCPBUGS-32780