### PR TITLE
4.12: Disable abandoned dpu-operator

### DIFF
--- a/images/dpu-network-operator.yml
+++ b/images/dpu-network-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled # No action in https://issues.redhat.com/browse/OCPBUGS-32779?jql=labels%20%3D%20art-infra-label-bundles, disabling dpu operator
 arches:
 - x86_64
 - aarch64

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -13,7 +13,6 @@ content:
 dependents:
 - ptp-operator
 - cluster-nfd-operator
-- dpu-network-operator
 - ose-metallb-operator
 - local-storage-operator
 - ingress-node-firewall-operator


### PR DESCRIPTION
ART is not able to ship dpu-operator, as infra labels are not set. https://issues.redhat.com/browse/OCPBUGS-32779 has been unaddressed since quite a while. Proposing to stop to build and ship this operator.