### PR TITLE
Have route-override image use standard enterprise base

### DIFF
--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -21,7 +21,7 @@ from:
   builder:
   - stream: rhel-9-golang
   - stream: rhel-8-golang
-  member: openshift-base-rhel9
+  member: openshift-enterprise-base-rhel9
 name: openshift/ose-multus-route-override-cni-rhel9
 payload_name: multus-route-override-cni
 owners:


### PR DESCRIPTION
For OKD builds, this is necessary to ensure uuidgen is available.