### PR TITLE
Revert "Move cvo to rhel-9-golang-1.21"

### DIFF
--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -27,7 +27,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang-1.21
+  - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-version-rhel9-operator
 payload_name: cluster-version-operator


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#4966

This is ineffective. As long as `canonical_builders_from_upstream: True` is set in `group.yml`, we'll listen for the desired golang version of upstream. https://github.com/openshift/cluster-version-operator/pull/1055 made the actual switch back. 