### PR TITLE
Revert "ART-9931 Move 4.12 RHEL 8.6 to E4S"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -202,20 +202,20 @@ repos:
   rhel-8-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel8/8.6/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel8/8.6/ppc64le/baseos/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/e4s/rhel8/8.6/s390x/baseos/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/e4s/rhel8/8.6/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/baseos/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/baseos/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-baseos-e4s-rpms__8_DOT_6
-      aarch64: rhel-8-for-aarch64-baseos-e4s-rpms__8_DOT_6
-      ppc64le: rhel-8-for-ppc64le-baseos-e4s-rpms__8_DOT_6
-      s390x: rhel-8-for-s390x-baseos-e4s-rpms__8_DOT_6
+      default: rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
+      aarch64: rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_6
+      ppc64le: rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_6
+      s390x: rhel-8-for-s390x-baseos-eus-rpms__8_DOT_6
     reposync:
       enabled: false
 
@@ -260,10 +260,10 @@ repos:
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel8/8.6/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel8/8.6/ppc64le/appstream/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/e4s/rhel8/8.6/s390x/appstream/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/e4s/rhel8/8.6/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/appstream/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/appstream/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el8
@@ -272,10 +272,10 @@ repos:
       extra_options:
         excludepkgs: containernetworking-plugins
     content_set:
-      default: rhel-8-for-x86_64-appstream-e4s-rpms__8_DOT_6
-      aarch64: rhel-8-for-aarch64-appstream-e4s-rpms__8_DOT_6
-      ppc64le: rhel-8-for-ppc64le-appstream-e4s-rpms__8_DOT_6
-      s390x: rhel-8-for-s390x-appstream-e4s-rpms__8_DOT_6
+      default: rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
+      aarch64: rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
+      ppc64le: rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
+      s390x: rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
     reposync:
       enabled: false
 


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#4974

Possibly due to [RHELCOUNCL-91](https://issues.redhat.com/browse/RHELCOUNCL-91) not being fully implemented, this change has broken [openshift-base-rhel8 builds](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=62042563) because
```
Comparison mismatch for component libnghttp2:
aarch64: libnghttp2-1.33.0-4.el8_6.1 (199e2f91fd431d51)
ppc64le: libnghttp2-1.33.0-4.el8_6.2 (199e2f91fd431d51)
s390x: libnghttp2-1.33.0-4.el8_6.1 (199e2f91fd431d51)
x86_64: libnghttp2-1.33.0-4.el8_6.2 (199e2f91fd431d51)
```

Looking at https://pub.devel.redhat.com/pub/task/769592/log/stdout.log, there is no mention to s390x or aarch64 builds being pushed. Reverting for now as `4.12.60` is due to be prepared on June 20.