### PR TITLE
ART-9391 [4.15] Update to ubi8 repos and base images

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -206,40 +206,40 @@ repos:
   rhel-8-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/baseos/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/baseos/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
-      aarch64: rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_6
-      ppc64le: rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_6
-      s390x: rhel-8-for-s390x-baseos-eus-rpms__8_DOT_6
+      default: rhel-8-for-x86_64-baseos-rpms__8
+      aarch64: rhel-8-for-aarch64-baseos-rpms__8
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms__8
+      s390x:   rhel-8-for-s390x-baseos-rpms__8
     reposync:
       enabled: false
 
   rhel-8-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/codeready-builder/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/codeready-builder/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/codeready-builder/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/codeready-builder/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/codeready-builder/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: codeready-builder-for-rhel-8-x86_64-eus-rpms__8_DOT_6
-      aarch64: codeready-builder-for-rhel-8-aarch64-eus-rpms__8_DOT_6
-      ppc64le: codeready-builder-for-rhel-8-ppc64le-eus-rpms__8_DOT_6
-      s390x:   codeready-builder-for-rhel-8-s390x-eus-rpms__8_DOT_6
+      default: codeready-builder-for-rhel-8-x86_64-rpms__8
+      aarch64: codeready-builder-for-rhel-8-aarch64-rpms__8
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms__8
+      s390x:   codeready-builder-for-rhel-8-s390x-rpms__8
     reposync:
       enabled: false
 
@@ -266,10 +266,10 @@ repos:
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/appstream/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/appstream/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el8
@@ -278,10 +278,10 @@ repos:
       extra_options:
         excludepkgs: containernetworking-plugins
     content_set:
-      default: rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
-      aarch64: rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
-      ppc64le: rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
-      s390x: rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
+      default: rhel-8-for-x86_64-appstream-rpms__8
+      aarch64: rhel-8-for-aarch64-appstream-rpms__8
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms__8
+      s390x:   rhel-8-for-s390x-appstream-rpms__8
     reposync:
       enabled: false
 

--- a/streams.yml
+++ b/streams.yml
@@ -113,8 +113,8 @@ etcd_rhel9_golang:
 rhel8:
   # the most recent release at present. since we yum update this, it does not need to float.
   # it is important that we not build from unreleased builds and publish them.
-  # rhel-els-container-8.6-921
-  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:ae88d68c3ba828bfac144a6561f9300af68fc5d6f332785e10e845cc2a48b2a3
+  # ubi8-container-8.10-901.1717584420
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8@sha256:143123d85045df426c5bbafc6863659880ebe276eb02c77ee868b88d08dbd05d
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
- use `ubi8` base image instead of `ELS`
- use standard rhel8 repos instead of `EUS`