### PR TITLE
Nutanix CCM should use commit prefix

### DIFF
--- a/images/ose-nutanix-cloud-controller-manager.yml
+++ b/images/ose-nutanix-cloud-controller-manager.yml
@@ -10,6 +10,7 @@ content:
         target: release-{MAJOR}.{MINOR}
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
 distgit:


### PR DESCRIPTION
Our automation on this repository expects commits prefixed by `commit_prefix: "UPSTREAM: <carry>: "` as it is a fork of an upstream repo