### PR TITLE
Define 4.16 rc.9 assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,4 +1,29 @@
 releases:
+  rc.9:
+    assembly:
+      type: candidate
+      basis:
+        assembly: "rc.8"
+        reference_releases!: {}
+      group:
+        advisories:
+          extras: 125774
+          image: 125775
+          metadata: 125776
+          microshift: 125777
+          rpm: 125779
+        release_jira: ART-8573
+        upgrades: 4.15.18,4.15.19,4.16.0-ec.1,4.16.0-ec.2,4.16.0-ec.3,4.16.0-ec.4,4.16.0-ec.5,4.16.0-ec.6,4.16.0-rc.0,4.16.0-rc.1,4.16.0-rc.2,4.16.0-rc.3,4.16.0-rc.4,4.16.0-rc.5,4.16.0-rc.6,4.16.0-rc.8
+      issues:
+        include:
+        - id: OCPBUGS-35992
+      members:
+        images:
+        - distgit_key: ose-machine-config-operator
+          why: Fix for OCPBUGS-35992
+          metadata:
+            is:
+              nvr: ose-machine-config-operator-container-v4.16.0-202406241749.p0.g9e4a1f5.assembly.stream.el9
   rc.8:
     assembly:
       type: candidate


### PR DESCRIPTION
Pin fix for https://issues.redhat.com/browse/OCPBUGS-35992
https://github.com/openshift/machine-config-operator/pull/4427
[ose-machine-config-operator-container-v4.16.0-202406241749.p0.g9e4a1f5.assembly.stream.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3130897)