### PR TITLE
prep 4.16.0 GA assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,4 +1,19 @@
 releases:
+  4.16.0:
+    assembly:
+      type: standard
+      basis:
+        assembly: "rc.9"
+        reference_releases!: { }
+      group:
+        advisories:
+          extras: 125774
+          image: 125775
+          metadata: 125776
+          microshift: 125777
+          rpm: 125779
+        release_jira: ART-8573
+        upgrades: 4.15.18,4.16.0-ec.1,4.16.0-ec.2,4.16.0-ec.3,4.16.0-ec.4,4.16.0-ec.5,4.16.0-ec.6,4.16.0-rc.0,4.16.0-rc.1,4.16.0-rc.2,4.16.0-rc.3,4.16.0-rc.4,4.16.0-rc.5,4.16.0-rc.6
   rc.9:
     assembly:
       type: candidate


### PR DESCRIPTION
Edges `4.15.19`, and `4.16.0-rc.8` excluded