### PR TITLE
OSDOCS-11155: updates solution text to 4.16 for MicroShift

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -131,7 +131,7 @@ boilerplates:
 
       This advisory contains the RPM packages for Red Hat build of MicroShift 4.16.z. Read the following advisory for the container images for this release:
 
-      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHSA-2023:1234
+      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHSA-2024:1234
 
       All of the bug fixes may not be documented in this advisory. Read the following release notes documentation for details about these changes:
 
@@ -140,9 +140,9 @@ boilerplates:
 
       All Red Hat build of MicroShift 4.16 users are advised to use these updated packages and images when they are available in the RPM repository.
     solution: |
-      For MicroShift 4.15, read the following documentation, which will be updated shortly for this release, for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
+      For MicroShift 4.16, read the following documentation, which will be updated soon after this release, for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
 
-      https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.15/html/release_notes/index
+      https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.16/html/release_notes/index
   prerelease:
     synopsis: OpenShift Container Platform 4.16 OLM Operators pre-release
     topic: |


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-11155](https://issues.redhat.com/browse/OSDOCS-11155)

Details: The solution text for the 4.16.z Errata did not update. This PR updates the version to 4.16 in the solution field for MicroShift.