### PR TITLE
[4.17] use must-gather as base for LSO and secrets-store-csi mustgather

### DIFF
--- a/images/local-storage-mustgather.yml
+++ b/images/local-storage-mustgather.yml
@@ -24,7 +24,7 @@ enabled_repos:
 - rhel-9-server-ose-rpms-embargoed
 for_payload: false
 from:
-  member: openshift-enterprise-base-rhel9
+  member: ose-must-gather
 name: openshift/ose-local-storage-mustgather-rhel9
 name_in_bundle: local-storage-mustgather
 owners:

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -22,7 +22,7 @@ enabled_repos:
 for_payload: false
 name_in_bundle: secrets-store-csi-mustgather
 from:
-  member: openshift-enterprise-base-rhel9
+  member: ose-must-gather
 name: openshift/ose-secrets-store-csi-mustgather-rhel9
 owners:
 - aos-storage-staff@redhat.com


### PR DESCRIPTION
Upstream wants to use `mustgather` as base image instead of `openshift-enterprise-base`. This change will prevent our bot to open alignment PRs like [this](https://github.com/openshift/local-storage-operator/pull/482/files#diff-1a46cd98e1dd1e1eb02deaa992828147cd6f22d2c5d8b8cf43a4d3be71c32f33R1) and [this](https://github.com/openshift/secrets-store-csi-driver-operator/pull/57/files#diff-1a46cd98e1dd1e1eb02deaa992828147cd6f22d2c5d8b8cf43a4d3be71c32f33R1)

Test builds:
- [ose-secrets-store-csi-mustgather-container-v4.17.0-202407040928.p0.g84bd1d4.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3153514)
- [ose-local-storage-mustgather-container-v4.17.0-202407040928.p0.g7f342da.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3153512)