### PR TITLE
Revert "[4.14] dockerfile_fallback for azure-workload"

### DIFF
--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -8,8 +8,7 @@ content:
       url: git@github.com:openshift-priv/azure-workload-identity.git
       branch:
         target: release-{MAJOR}.{MINOR}
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#5037

Fallback not needed, since we are aiming for 4.17 only for now