### PR TITLE
Revert "[4.15] dockerfile_fallback for azure-workload"

### DIFF
--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -8,8 +8,7 @@ content:
       url: git@github.com:openshift-priv/azure-workload-identity.git
       branch:
         target: release-{MAJOR}.{MINOR}
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: ose-azure-workload-identity-webhook-container


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#5036

Fallback not needed, since we are aiming for 4.17 only for now