### PR TITLE
Revert "[openshift-4.16] [ART-9923] set dockerfile_fallback"

### DIFF
--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -8,8 +8,7 @@ content:
       url: git@github.com:openshift-priv/azure-workload-identity.git
       branch:
         target: release-{MAJOR}.{MINOR}
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#5035

Fallback not needed, since we are aiming only for 4.17 now