### PR TITLE
[4.17] baremetal-cluster-api-controllers not for payload

### DIFF
--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -16,7 +16,7 @@ distgit:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-for_payload: true
+for_payload: false
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
The image is not labelled for payload:
```
$ oc adm release info registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2024-07-08-042329  --image-for baremetal-cluster-api-controllers
error: no image tag "baremetal-cluster-api-controllers" exists in the release image registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2024-07-08-042329
```

PRs had been suggested to add the required label (e.g. [in 4.15](https://github.com/openshift/cluster-api-provider-metal3/pull/14)), but never got attention. Proposing to mark this image as not for payload, and evaluate deprecation.