### PR TITLE
Make rteval available to tests image

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -487,12 +487,10 @@ repos:
     conf:
       extra_options:
         module_hotfixes: 1
-        includepkgs: "kernel-rt*"
       baseurl:
         # RT doesn't do EUS, and TUS isn't around yet. get from dist
         x86_64: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/"
         # Kernel RT is x86 only, so use same repo as a dummy for other arches.
-        # The driver-toolkit Dockerfile only installs the kernel-rt for x86_64.
         aarch64: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/"
         ppc64le: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/"
         s390x: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/"


### PR DESCRIPTION
Reinstating https://github.com/openshift-eng/ocp-build-data/pull/4711 after https://github.com/openshift-eng/ocp-build-data/pull/5052