### PR TITLE
Revert "Stop 4.12 automation"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: true
+freeze_automation: false
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#5076

[RHELWF-11439](https://issues.redhat.com/browse/RHELWF-11439) claims packages got reshipped. 