### PR TITLE
remove fallbacks

### DIFF
--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -1,7 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.openshift.rhel7
+    dockerfile: Dockerfile.openshift.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -1,7 +1,6 @@
 content:
   source:
     dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.openshift.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -1,7 +1,6 @@
 content:
   source:
     dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.openshift.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -1,7 +1,6 @@
 content:
   source:
     dockerfile: release/ansible/Dockerfile.ocp
-    dockerfile_fallback: release/ansible/Dockerfile.rhel8
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -1,7 +1,6 @@
 content:
   source:
     dockerfile: images/cluster-capacity/Dockerfile.ocp
-    dockerfile_fallback: images/cluster-capacity/Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -1,7 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -1,7 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-aws-pod-identity-webhook.yml
+++ b/images/ose-aws-pod-identity-webhook.yml
@@ -4,7 +4,6 @@ arches:
 content:
   source:
     dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-cluster-config-api.yml
+++ b/images/ose-cluster-config-api.yml
@@ -1,7 +1,6 @@
 content:
   source:
     dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel8
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-cluster-config-operator.yml
+++ b/images/ose-cluster-config-operator.yml
@@ -1,7 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-cluster-csi-snapshot-controller-operator.yml
+++ b/images/ose-cluster-csi-snapshot-controller-operator.yml
@@ -1,7 +1,6 @@
 content:
   source:
     dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-cluster-kube-apiserver-operator.yml
+++ b/images/ose-cluster-kube-apiserver-operator.yml
@@ -1,7 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-cluster-kube-controller-manager-operator.yml
+++ b/images/ose-cluster-kube-controller-manager-operator.yml
@@ -1,7 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -1,7 +1,6 @@
 content:
   source:
     dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -1,7 +1,6 @@
 content:
   source:
     dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-oauth-apiserver.yml
+++ b/images/ose-oauth-apiserver.yml
@@ -1,7 +1,6 @@
 content:
   source:
-    dockerfile: images/Dockerfile.ocp
-    dockerfile_fallback: images/Dockerfile.rhel7
+    dockerfile: images/Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -5,7 +5,6 @@ arches:
 content:
   source:
     dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -5,7 +5,6 @@ arches:
 content:
   source:
     dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -4,8 +4,7 @@ arches:
 - ppc64le
 content:
   source:
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -4,8 +4,7 @@ arches:
 - ppc64le
 content:
   source:
-    dockerfile: Dockerfile.sriov-network-config-daemon.ocp
-    dockerfile_fallback: Dockerfile.sriov-network-config-daemon.rhel7
+    dockerfile: Dockerfile.sriov-network-config-daemon.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -4,8 +4,7 @@ arches:
 - ppc64le
 content:
   source:
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -4,8 +4,7 @@ arches:
 - ppc64le
 content:
   source:
-    dockerfile: Dockerfile.ocp
-    dockerfile_fallback: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -4,8 +4,7 @@ arches:
 - ppc64le
 content:
   source:
-    dockerfile: Dockerfile.webhook.ocp
-    dockerfile_fallback: Dockerfile.webhook.rhel7
+    dockerfile: Dockerfile.webhook.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
For components that have migrated, remove fallbacks (ref https://github.com/openshift-eng/ocp-build-data/pull/5039), else keep back the original name. So that we can solve issues with the sync-ci pipeline