### PR TITLE
OPRUN-3454 : Removing rukpak from main branch

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -754,8 +754,6 @@ bug_mapping:
       issue_component: OLM / Registry
     ose-olm-operator-controller-container:
       issue_component: OLM
-    ose-olm-rukpak-container:
-      issue_component: OLM
     ose-openshift-apiserver-container:
       issue_component: openshift-apiserver
     ose-openshift-controller-manager-container:


### PR DESCRIPTION
As we do not intend to support it in OLM V1 going forward. It is also getting removed from the release payload and all the required places.