### PR TITLE
STOR-1856: remove cachito legacy manifest dir for aws efs

### DIFF
--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -1,10 +1,6 @@
 arches:
 - x86_64
 - aarch64
-cachito:
-  packages:
-    gomod:
-      - path: legacy/aws-efs-csi-driver-operator
 content:
   source:
     dockerfile: Dockerfile.aws-efs
@@ -38,7 +34,7 @@ owners:
 - aos-storage-staff@redhat.com
 update-csv:
   bundle-dir: stable/
-  manifests-dir: legacy/aws-efs-csi-driver-operator/config/manifests
+  manifests-dir: config/aws-efs/manifests
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container
     Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
Must merge after https://github.com/openshift/csi-operator/pull/237