### PR TITLE
Update CRO & VPA owners to pod autoscaling team

### DIFF
--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -25,7 +25,9 @@ from:
 name: openshift/ose-clusterresourceoverride-rhel9-operator
 name_in_bundle: clusterresourceoverride-rhel8-operator
 owners:
-- aos-node@redhat.com
+- jkyros@redhat.com
+- joesmith@redhat.com
+- macao@redhat.com
 update-csv:
   bundle-dir: stable/
   manifests-dir: manifests/

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -26,4 +26,6 @@ from:
 name: openshift/ose-clusterresourceoverride-rhel9
 name_in_bundle: clusterresourceoverride-rhel8
 owners:
-- aos-node@redhat.com
+- jkyros@redhat.com
+- joesmith@redhat.com
+- macao@redhat.com

--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -25,7 +25,9 @@ from:
 name: openshift/ose-vertical-pod-autoscaler-rhel9-operator
 name_in_bundle: vertical-pod-autoscaler-rhel8-operator
 owners:
+- jkyros@redhat.com
 - joesmith@redhat.com
+- macao@redhat.com
 update-csv:
   bundle-dir: stable/
   manifests-dir: manifests/

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -30,4 +30,6 @@ maintainer:
 name: openshift/ose-vertical-pod-autoscaler-rhel9
 name_in_bundle: vertical-pod-autoscaler-rhel8
 owners:
+- jkyros@redhat.com
 - joesmith@redhat.com
+- macao@redhat.com


### PR DESCRIPTION
VPA and CRO are no longer part of the AOS Node team, but are now overseen by the Pod Autoscaling team.