### PR TITLE
Revert "[4.17] baremetal-cluster-api-controllers not for payload"

### DIFF
--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -16,7 +16,7 @@ distgit:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-for_payload: false
+for_payload: true
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
This reverts commit 5543e1deda506b033549466993a2426e8922e04a.

Operator label added: https://github.com/openshift/cluster-api-provider-metal3/pull/19