### PR TITLE
Update machine-api provider IBM component mapping

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -521,7 +521,7 @@ bug_mapping:
     ose-cluster-authentication-operator-container:
       issue_component: apiserver-auth
     ose-cluster-autoscaler-operator-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / Cluster Autoscaler
     ose-cluster-baremetal-operator-container:
       issue_component: Bare Metal Hardware Provisioning / cluster-baremetal-operator
     ose-cluster-bootstrap-container:
@@ -653,7 +653,7 @@ bug_mapping:
     ose-ibmcloud-cluster-api-controllers-container:
       issue_component: Cloud Compute / IBM Provider
     ose-ibmcloud-machine-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / IBM Provider
     ose-image-customization-controller-container:
       issue_component: Bare Metal Hardware Provisioning / OS Image Provider
     ose-insights-operator-container:
@@ -783,7 +783,7 @@ bug_mapping:
     ose-powervs-cloud-controller-manager-container:
       issue_component: Multi-Arch / IBM P and Z
     ose-powervs-machine-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / IBM Provider
     ose-prometheus-adapter-container:
       issue_component: Monitoring
     ose-ptp-operator-container:


### PR DESCRIPTION
We created a component for IBM providers. The machine provider is still using the global one.