### PR TITLE
Stop pinning git in ci images

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -27,9 +27,7 @@ RUN set -euxo pipefail && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
-RUN CI_PINNED_GIT_VERSION="git-2.31.1" && \
-    echo "Uninstalling any pre-existing git to ensure that we install ${CI_PINNED_GIT_VERSION}" && dnf remove --noautoremove -y git || true && \
-    INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc ${CI_PINNED_GIT_VERSION} glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
+RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
     dnf install -y $INSTALL_PKGS && \
     dnf clean all && \
     touch /os-build-image && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -27,9 +27,7 @@ RUN set -euxo pipefail && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
-RUN CI_PINNED_GIT_VERSION="git-2.31.1" && \
-    echo "Uninstalling any pre-existing git to ensure that we install ${CI_PINNED_GIT_VERSION}" && dnf remove --noautoremove -y git || true && \
-    INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc ${CI_PINNED_GIT_VERSION} glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
+RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
     dnf install -y $INSTALL_PKGS && \
     dnf clean all && \
     touch /os-build-image && \

--- a/ci_transforms/rhel-8/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-8/ci-build-root/Dockerfile
@@ -35,9 +35,7 @@ RUN set -euxo pipefail && \
 # to permit non-root users from interacting with git in
 # CI workload pods: https://github.com/openshift/ci-tools/blob/acad25edd747d5a21c839c60d480aaf7902961ec/pkg/steps/pod.go#L241
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    CI_PINNED_GIT_VERSION="git-2.31.1" && \
-    echo "Uninstalling any pre-existing git to ensure that we install ${CI_PINNED_GIT_VERSION}" && yum remove -y git || true && \
-    INSTALL_PKGS="bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc ${CI_PINNED_GIT_VERSION} glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel libvirt-devel lsof make mercurial nmap-ncat openssl rsync socat systemd-devel tar tito tree wget which xfsprogs zip goversioninfo gettext python3 iproute" && \
+    INSTALL_PKGS="bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel libvirt-devel lsof make mercurial nmap-ncat openssl rsync socat systemd-devel tar tito tree wget which xfsprogs zip goversioninfo gettext python3 iproute" && \
     yum install -y $INSTALL_PKGS && \
     alternatives --set python /usr/bin/python3 && \
     yum clean all && \

--- a/ci_transforms/rhel-9/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-9/ci-build-root/Dockerfile
@@ -35,9 +35,7 @@ RUN set -euxo pipefail && \
 # to permit non-root users from interacting with git in
 # CI workload pods: https://github.com/openshift/ci-tools/blob/acad25edd747d5a21c839c60d480aaf7902961ec/pkg/steps/pod.go#L241
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    CI_PINNED_GIT_VERSION="git-2.31.1" && \
-    echo "Uninstalling any pre-existing git to ensure that we install ${CI_PINNED_GIT_VERSION}" && yum remove -y git || true && \
-    INSTALL_PKGS="bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc ${CI_PINNED_GIT_VERSION} glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
+    INSTALL_PKGS="bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
     yum install -y $INSTALL_PKGS && \
     yum clean all && \
     touch /os-build-image && \


### PR DESCRIPTION
[RHEL-22852](https://issues.redhat.com//browse/RHEL-22852) got resolved, CI builds should not fail with errors like these anymore:

```
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```