### PR TITLE
4.15 - Permit outdated rhcos builds to unblock nightlies

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -119,6 +119,7 @@ releases:
       permits:
       - code: CONFLICTING_INHERITED_DEPENDENCY
         component: 'ose-agent-installer-api-server'
+        why: older rpm is in the image, but it is not a blocking issue
       type: standard
 
   4.15.25:
@@ -3608,7 +3609,7 @@ releases:
         component: '*'
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: 'rhcos'
-        why: Unblock nightlies due to known issue with rhcos builds, CWFCONF-10301. Remove this when there is a new rhcos build
+        # why: Unblock nightlies due to known issue with rhcos builds, CWFCONF-10301. Remove this when there is a new rhcos build
       members:
         images:
         - distgit_key: '*'

--- a/releases.yml
+++ b/releases.yml
@@ -3608,7 +3608,7 @@ releases:
         component: '*'
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: 'rhcos'
-        # why: Unblock nightlies due to known issue with rhcos builds, CWFCONF-10301. Remove this when there is a new rhcos build
+        why: Unblock nightlies due to known issue with rhcos builds, CWFCONF-10301. Remove this when there is a new rhcos build
       members:
         images:
         - distgit_key: '*'

--- a/releases.yml
+++ b/releases.yml
@@ -87,10 +87,12 @@ releases:
           metadata:
             is:
               nvr: openshift-enterprise-builder-container-v4.15.0-202408010909.p0.gb98fb65.assembly.stream.el8
+          why: Pinning build that contains the same rpms as RHCOS
         - distgit_key: ose-agent-installer-api-server
           metadata:
             is:
               nvr: ose-agent-installer-api-server-container-v4.15.0-202408010711.p0.g833fd90.assembly.stream.el8
+          why: Pinning build that contains the same rpms as RHCOS
         rpms:
         - distgit_key: microshift
           why: Pin microshift to assembly
@@ -119,7 +121,7 @@ releases:
       permits:
       - code: CONFLICTING_INHERITED_DEPENDENCY
         component: 'ose-agent-installer-api-server'
-        why: older rpm is in the image, but it is not a blocking issue
+        # why: older rpm is in the image, but it is not a blocking issue
       type: standard
 
   4.15.25:

--- a/releases.yml
+++ b/releases.yml
@@ -3606,6 +3606,9 @@ releases:
       permits:
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'
+      - code: CONFLICTING_GROUP_RPM_INSTALLED
+        component: 'rhcos'
+        # why: Unblock nightlies due to known issue with rhcos builds, CWFCONF-10301. Remove this when there is a new rhcos build
       members:
         images:
         - distgit_key: '*'


### PR DESCRIPTION
slack ref: https://redhat-internal.slack.com/archives/C04668B0XK2/p1723209068463649?thread_ts=1723026260.728109&cid=C04668B0XK2