### PR TITLE
[ART-10298] pf-status-relay image add

### DIFF
--- a/images/pf-status-relay.yml
+++ b/images/pf-status-relay.yml
@@ -1,0 +1,26 @@
+content:
+  source:
+    dockerfile: Dockerfile.openshift
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/pf-status-relay.git
+      web: https://github.com/openshift/pf-status-relay
+    ci_alignment:
+      streams_prs:
+        ci_build_root:
+          stream: rhel-9-golang-ci-build-root
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: pf-status-relay-container
+enabled_repos:
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
+for_payload: false
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/pf-status-relay-rhel9
+owners:
+- marguerr@redhat.com


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/ART-10298

- [X] HB [MR](https://gitlab.cee.redhat.com/pipeline/products/-/merge_requests/2779) merged 
- [X] Test build [pf-status-relay-container-v4.17.0-202408131338.p0.g7b2473d.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3222961) green
- [X] FIPS scan passed
```
asdas@asdas-thinkpadp1gen3:/tmp/crap/check-payload$ sudo ./check-payload -V 4.17 scan image --spec registry-proxy.engineering.redhat.com/rh-osbs/openshift-pf-status-relay-rhel9@sha256:67ac6316a46367d5906d89055f08b1f887c6bc84d4c73940bf014684f0dd0dd9
---- Successful run
```

ref [thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1721917527586489) 

- [ ] Follow up [MR](https://gitlab.cee.redhat.com/pipeline/products/-/merge_requests/2784) raised to make the delivery repo `Beta` (almost equivalent to Dev Preview)