### PR TITLE
CFE-1111: [openshift-4.17] Update Dockerfile and repo location for ansible-operator-plugins

### DIFF
--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -1,11 +1,11 @@
 content:
   source:
-    dockerfile: release/ansible/Dockerfile.ocp
+    dockerfile: openshift/Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/ocp-release-operator-sdk.git
-      web: https://github.com/openshift/ocp-release-operator-sdk
+      url: git@github.com:openshift-priv/ansible-operator-plugins.git
+      web: https://github.com/openshift/ansible-operator-plugins.git
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -30,5 +30,8 @@ owners:
 - aos-operator-sdk@redhat.com
 - jlanford@redhat.com
 - fabian@redhat.com
+- tgeer@redhat.com
+- ckyal@redhat.com
+- arsen@redhat.com
 non_shipping_repos:
 - rhel-8-server-ose-rpms-embargoed


### PR DESCRIPTION
Update Dockerfile path and repo location for ansible-operator-plugins

Switch the building of the `openshift-enterprise-ansible-operator` from [https://github.com/openshift/ocp-release-operator-sdk](https://github.com/openshift/ocp-release-operator-sdk/blob/d147fd3b63cf4a6bc4c1d9168f5388f2da102505/release/ansible/Dockerfile.ocp#L1) to [https://github.com/openshift/ansible-operator-plugins](https://github.com/openshift/ansible-operator-plugins/blob/f30dff62ceda41de7bfe69ce82cb6fb08c2feefe/openshift/Dockerfile#L1)

https://issues.redhat.com//browse/CFE-1111