### PR TITLE
[ART-10308] [4.18] Add mapping between honeybadger and ocp-build-data

### DIFF
--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -15,6 +15,9 @@ distgit:
   namespace: containers
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: atomic-openshift-cluster-autoscaler-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-autoscaler
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/aws-kms-encryption-provider.yml
+++ b/images/aws-kms-encryption-provider.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: aws-kms-encryption-provider-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: aws-kms-encryption-provider
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/azure-file-csi-driver-operator.yml
+++ b/images/azure-file-csi-driver-operator.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-file-csi-driver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-azure-file-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-file-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-azure-file-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/azure-kms-encryption-provider.yml
+++ b/images/azure-kms-encryption-provider.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: azure-kms-encryption-provider-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: azure-kms-encryption-provider
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: baremetal-machine-controller-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-baremetal-machine-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-runtimecfg-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-baremetal-runtimecfg
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -18,6 +18,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cloud-event-proxy-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cloud-event-proxy
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-etcd-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-etcd-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-monitoring-operator.yml
+++ b/images/cluster-monitoring-operator.yml
@@ -21,6 +21,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-monitoring-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-monitoring-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-network-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-network-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -14,6 +14,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   bundle_component: cluster-nfd-operator-metadata-container
   component: cluster-nfd-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-nfd-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-node-tuning-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-node-tuning-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-policy-controller.yml
+++ b/images/cluster-policy-controller.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-policy-controller-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-policy-controller
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-storage-operator.yml
+++ b/images/cluster-storage-operator.yml
@@ -15,6 +15,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-storage-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-storage-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -21,6 +21,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-version-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-version-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -14,6 +14,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   bundle_component: ose-clusterresourceoverride-operator-metadata-container
   component: ose-clusterresourceoverride-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-clusterresourceoverride-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -15,6 +15,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-clusterresourceoverride-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-clusterresourceoverride
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/configmap-reload.yml
+++ b/images/configmap-reload.yml
@@ -21,6 +21,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: configmap-reload-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-configmap-reloader
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/container-networking-plugins-microshift.yml
+++ b/images/container-networking-plugins-microshift.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: container-networking-plugins-microshift-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: container-networking-plugins-microshift
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: coredns-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-coredns
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-attacher-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-external-attacher
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-driver-manila-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-driver-manila-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-driver-manila-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-driver-manila
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-driver-nfs-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-driver-nfs
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -22,6 +22,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-livenessprobe-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-livenessprobe
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -22,6 +22,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-node-driver-registrar-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-node-driver-registrar
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -21,6 +21,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-provisioner-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-external-provisioner
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/csi-snapshot-validation-webhook.yml
+++ b/images/csi-snapshot-validation-webhook.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-snapshot-validation-webhook-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-snapshot-validation-webhook
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/dpu-cni.yml
+++ b/images/dpu-cni.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url:  git@github.com:openshift-priv/dpu-operator.git
+      url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:
       streams_prs:
@@ -15,6 +15,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: dpu-cni-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-dpu-cni
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/dpu-daemon.yml
+++ b/images/dpu-daemon.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url:  git@github.com:openshift-priv/dpu-operator.git
+      url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:
       streams_prs:
@@ -15,6 +15,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: dpu-daemon-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-dpu-daemon
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/dpu-operator.yml
+++ b/images/dpu-operator.yml
@@ -15,6 +15,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   bundle_component: dpu-operator-bundle-container
   component: dpu-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-dpu-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: driver-toolkit-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: driver-toolkit
 enabled_repos:
 - rhel-9-server-ose-rpms-embargoed
 - rhel-9-baseos-rpms

--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-egress-router-cni-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: egress-router-cni
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/golang-github-openshift-oauth-proxy.yml
+++ b/images/golang-github-openshift-oauth-proxy.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: golang-github-openshift-oauth-proxy-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-oauth-proxy
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: golang-github-prometheus-alertmanager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-prometheus-alertmanager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: golang-github-prometheus-node_exporter-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-prometheus-node-exporter
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: golang-github-prometheus-prometheus-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-prometheus
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-hypershift-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-hypershift
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -19,6 +19,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ib-sriov-cni-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-sriov-infiniband-cni
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ingress-node-firewall-daemon.yml
+++ b/images/ingress-node-firewall-daemon.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ingress-node-firewall-daemon-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ingress-node-firewall
 dependents:
 - ingress-node-firewall-operator
 enabled_repos:

--- a/images/ingress-node-firewall-operator.yml
+++ b/images/ingress-node-firewall-operator.yml
@@ -14,6 +14,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   bundle_component: ingress-node-firewall-operator-bundle-container
   component: ingress-node-firewall-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ingress-node-firewall-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -22,6 +22,9 @@ cachito:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ironic-agent-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ironic-agent
 for_payload: true
 from:
   member: openshift-base-rhel9

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ironic-rhcos-downloader-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ironic-machine-os-downloader
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ironic-static-ip-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ironic-static-ip-manager
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -22,6 +22,9 @@ cachito:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ironic-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ironic
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: kube-proxy-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-kube-proxy
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -25,6 +25,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: kube-rbac-proxy-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-kube-rbac-proxy
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -21,6 +21,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: kube-state-metrics-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-kube-state-metrics
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -19,6 +19,9 @@ dependents:
 distgit:
   component: ose-linuxptp-daemon-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ptp
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -18,6 +18,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: local-storage-diskmaker-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-local-storage-diskmaker
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/local-storage-mustgather.yml
+++ b/images/local-storage-mustgather.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-local-storage-mustgather-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-local-storage-mustgather
 dependents:
 - local-storage-operator
 enabled_repos:

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -17,6 +17,9 @@ distgit:
   bundle_component: local-storage-operator-metadata-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: local-storage-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-local-storage-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: marketplace-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-operator-marketplace
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -29,6 +29,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: monitoring-plugin-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-monitoring-plugin
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/multus-cni-container-microshift.yml
+++ b/images/multus-cni-container-microshift.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: multus-cni-container-microshift-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-multus-cni-microshift
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: multus-cni-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-multus-cni
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/multus-networkpolicy.yml
+++ b/images/multus-networkpolicy.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-networkpolicy-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-multus-networkpolicy
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -22,6 +22,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: networking-console-plugin-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-networking-console-plugin
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -26,6 +26,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: nmstate-console-plugin-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: nmstate-console-plugin
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -15,6 +15,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: node-feature-discovery-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-node-feature-discovery
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/oauth-server.yml
+++ b/images/oauth-server.yml
@@ -15,6 +15,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: oauth-server-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-oauth-server
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: oc-mirror-plugin-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: oc-mirror-plugin
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: openshift-enterprise-ansible-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ansible-operator
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-builder-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-docker-builder
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -14,6 +14,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-cli-container
   namespace: containers
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cli
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-cluster-capacity-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-capacity
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-console-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-console-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -24,6 +24,9 @@ cachito:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-console-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-console
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -10,6 +10,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-deployer-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-deployer
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -10,6 +10,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-egress-dns-proxy-container
   namespace: containers
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-egress-dns-proxy
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -9,6 +9,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-egress-router-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-egress-router
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -9,6 +9,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-haproxy-router-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-haproxy-router
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-helm-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-helm-operator
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -18,6 +18,9 @@ distgit:
   namespace: containers
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-hyperkube-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-hyperkube
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -11,6 +11,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-keepalived-ipfailover-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-keepalived-ipfailover
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-operator-sdk.yml
+++ b/images/openshift-enterprise-operator-sdk.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-operator-sdk-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-operator-sdk
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -15,6 +15,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-pod-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-pod
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-registry-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-docker-registry
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -14,6 +14,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-tests-container
   namespace: containers
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-tests
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -15,6 +15,9 @@ dependents:
 distgit:
   component: openshift-kubernetes-nmstate-handler-rhel-9-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-kubernetes-nmstate-handler
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -14,6 +14,9 @@ distgit:
   component: ose-kubernetes-nmstate-operator-container
   bundle_component: ose-kubernetes-nmstate-operator-bundle-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: kubernetes-nmstate-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-state-metrics.yml
+++ b/images/openshift-state-metrics.yml
@@ -21,6 +21,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-state-metrics-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-openshift-state-metrics
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openstack-cluster-api-controllers.yml
+++ b/images/openstack-cluster-api-controllers.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openstack-cluster-api-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-openstack-cluster-api-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: operator-lifecycle-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-operator-lifecycle-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: operator-registry-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-operator-registry
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-api-server-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-agent-installer-api-server
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-csr-approver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-agent-installer-csr-approver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-node-agent-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-agent-installer-node-agent
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-orchestrator.yml
+++ b/images/ose-agent-installer-orchestrator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-orchestrator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-agent-installer-orchestrator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-utils-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-agent-installer-utils
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-alibaba-cloud-controller-manager.yml
+++ b/images/ose-alibaba-cloud-controller-manager.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-alibaba-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-alibaba-cloud-controller-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-alibaba-machine-controllers.yml
+++ b/images/ose-alibaba-machine-controllers.yml
@@ -15,6 +15,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-alibaba-machine-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-alibaba-machine-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-apiserver-network-proxy-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-apiserver-network-proxy
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-aws-cloud-controller-manager.yml
+++ b/images/ose-aws-cloud-controller-manager.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-aws-cloud-controller-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-cluster-api-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-aws-cluster-api-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-ebs-csi-driver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-aws-ebs-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-ebs-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-aws-ebs-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -20,6 +20,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-efs-csi-driver-operator-container
   bundle_component: ose-aws-efs-csi-driver-operator-bundle-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-aws-efs-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -22,6 +22,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-efs-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-aws-efs-csi-driver-container
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-aws-pod-identity-webhook.yml
+++ b/images/ose-aws-pod-identity-webhook.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-pod-identity-webhook-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-aws-pod-identity-webhook
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-azure-cloud-controller-manager.yml
+++ b/images/ose-azure-cloud-controller-manager.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-azure-cloud-controller-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-azure-cloud-node-manager.yml
+++ b/images/ose-azure-cloud-node-manager.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-cloud-node-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-azure-cloud-node-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-cluster-api-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-azure-cluster-api-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-azure-disk-csi-driver-operator.yml
+++ b/images/ose-azure-disk-csi-driver-operator.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-disk-csi-driver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-azure-disk-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-disk-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-azure-disk-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-workload-identity-webhook-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-azure-workload-identity-webhook
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-cluster-api-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-baremetal-cluster-api-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-installer-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-baremetal-installer
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -14,6 +14,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-baremetal-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -14,6 +14,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cli-artifacts-container
   namespace: containers
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cli-artifacts
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-cloud-credential-operator.yml
+++ b/images/ose-cloud-credential-operator.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cloud-credential-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cloud-credential-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cloud-network-config-controller.yml
+++ b/images/ose-cloud-network-config-controller.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cloud-network-config-controller-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: cloud-network-config-controller
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -14,6 +14,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-api-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-api
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-authentication-operator.yml
+++ b/images/ose-cluster-authentication-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-authentication-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-authentication-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-autoscaler-operator.yml
+++ b/images/ose-cluster-autoscaler-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-autoscaler-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-autoscaler-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-baremetal-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-baremetal-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-bootstrap.yml
+++ b/images/ose-cluster-bootstrap.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-bootstrap-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-bootstrap
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-capi-operator.yml
+++ b/images/ose-cluster-capi-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-capi-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-capi-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-cloud-controller-manager-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-cloud-controller-manager-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-config-api.yml
+++ b/images/ose-cluster-config-api.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-config-api-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-config-api
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-config-operator.yml
+++ b/images/ose-cluster-config-operator.yml
@@ -14,6 +14,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-config-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-config-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-control-plane-machine-set-operator.yml
+++ b/images/ose-cluster-control-plane-machine-set-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-control-plane-machine-set-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-control-plane-machine-set-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-csi-snapshot-controller-operator.yml
+++ b/images/ose-cluster-csi-snapshot-controller-operator.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-csi-snapshot-controller-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-csi-snapshot-controller-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-dns-operator.yml
+++ b/images/ose-cluster-dns-operator.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-dns-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-dns-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-image-registry-operator.yml
+++ b/images/ose-cluster-image-registry-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-image-registry-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-image-registry-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-ingress-operator.yml
+++ b/images/ose-cluster-ingress-operator.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-ingress-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-ingress-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-kube-apiserver-operator.yml
+++ b/images/ose-cluster-kube-apiserver-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-apiserver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-kube-apiserver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-kube-cluster-api-operator.yml
+++ b/images/ose-cluster-kube-cluster-api-operator.yml
@@ -14,6 +14,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-cluster-api-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-kube-cluster-api-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-kube-controller-manager-operator.yml
+++ b/images/ose-cluster-kube-controller-manager-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-controller-manager-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-kube-controller-manager-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-scheduler-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-kube-scheduler-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-kube-storage-version-migrator-operator.yml
+++ b/images/ose-cluster-kube-storage-version-migrator-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-storage-version-migrator-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-kube-storage-version-migrator-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-machine-approver.yml
+++ b/images/ose-cluster-machine-approver.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-machine-approver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-machine-approver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-olm-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-olm-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-openshift-apiserver-operator.yml
+++ b/images/ose-cluster-openshift-apiserver-operator.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-openshift-apiserver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-openshift-apiserver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-openshift-controller-manager-operator.yml
+++ b/images/ose-cluster-openshift-controller-manager-operator.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-openshift-controller-manager-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-openshift-controller-manager-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-ovirt-csi-operator.yml
+++ b/images/ose-cluster-ovirt-csi-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-ovirt-csi-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ovirt-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-cluster-platform-operators-manager.yml
+++ b/images/ose-cluster-platform-operators-manager.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-platform-operators-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-platform-operators-manager
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-samples-operator.yml
+++ b/images/ose-cluster-samples-operator.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-samples-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-samples-operator
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-update-keys-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-update-keys
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-csi-driver-shared-resource-mustgather.yml
+++ b/images/ose-csi-driver-shared-resource-mustgather.yml
@@ -9,6 +9,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-driver-shared-resource-mustgather-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-driver-shared-resource-mustgather
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-csi-driver-shared-resource-operator.yml
+++ b/images/ose-csi-driver-shared-resource-operator.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-driver-shared-resource-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-driver-shared-resource-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-csi-driver-shared-resource-webhook.yml
+++ b/images/ose-csi-driver-shared-resource-webhook.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-driver-shared-resource-webhook-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-driver-shared-resource-webhook
 for_payload: true
 from:
   builder:

--- a/images/ose-csi-driver-shared-resource.yml
+++ b/images/ose-csi-driver-shared-resource.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-driver-shared-resource-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-driver-shared-resource
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-external-resizer-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-external-resizer
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-csi-external-snapshotter.yml
+++ b/images/ose-csi-external-snapshotter.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-external-snapshotter-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-external-snapshotter
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-csi-snapshot-controller.yml
+++ b/images/ose-csi-snapshot-controller.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-snapshot-controller-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-snapshot-controller
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -9,6 +9,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-egress-http-proxy-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-egress-http-proxy
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -33,6 +33,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-etcd-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-etcd
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -9,6 +9,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-frr-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: frr
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -18,6 +18,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-gcp-cloud-controller-manager
 name: openshift/ose-gcp-cloud-controller-manager-rhel9
 payload_name: gcp-cloud-controller-manager
 for_payload: true

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -18,6 +18,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-cluster-api-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-gcp-cluster-api-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-gcp-filestore-csi-driver-operator.yml
+++ b/images/ose-gcp-filestore-csi-driver-operator.yml
@@ -21,6 +21,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-filestore-csi-driver-operator-container
   bundle_component: ose-gcp-filestore-csi-driver-operator-bundle-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-gcp-filestore-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -21,6 +21,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-filestore-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-gcp-filestore-csi-driver
 dependents:
 - ose-gcp-filestore-csi-driver-operator
 enabled_repos:

--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-pd-csi-driver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-gcp-pd-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -21,6 +21,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-pd-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-gcp-pd-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -18,6 +18,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibm-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ibm-cloud-controller-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ibm-vpc-block-csi-driver-operator.yml
+++ b/images/ose-ibm-vpc-block-csi-driver-operator.yml
@@ -18,6 +18,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibm-vpc-block-csi-driver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ibm-vpc-block-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibm-vpc-block-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ibm-vpc-block-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -18,6 +18,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibmcloud-cluster-api-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ibmcloud-cluster-api-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -15,6 +15,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibmcloud-machine-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ibmcloud-machine-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -15,6 +15,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-image-customization-controller-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-image-customization-controller
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-insights-operator.yml
+++ b/images/ose-insights-operator.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-insights-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-insights-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-installer-altinfra.yml
+++ b/images/ose-installer-altinfra.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-installer-altinfra-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-installer-altinfra
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-installer-artifacts-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-installer-artifacts
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-installer-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-installer
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-kube-metrics-server.yml
+++ b/images/ose-kube-metrics-server.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-kube-metrics-server-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: kube-metrics-server
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-kube-storage-version-migrator.yml
+++ b/images/ose-kube-storage-version-migrator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-kube-storage-version-migrator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-kube-storage-version-migrator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-kubevirt-cloud-controller-manager.yml
+++ b/images/ose-kubevirt-cloud-controller-manager.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-kubevirt-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-kubevirt-cloud-controller-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-libvirt-machine-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-libvirt-machine-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-machine-api-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-aws-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-machine-api-provider-aws
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-azure-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-machine-api-provider-azure
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-gcp-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-machine-api-provider-gcp
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -14,6 +14,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-openstack-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-machine-api-provider-openstack
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-config-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-machine-config-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -12,6 +12,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-os-images-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-machine-os-images
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -14,6 +14,9 @@ distgit:
   bundle_component: ose-metallb-operator-bundle-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-metallb-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: metallb-operator
 name: openshift/metallb-rhel9-operator
 name_in_bundle: metallb-rhel9-operator # matches exactly the name in image-references
 for_payload: false

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-metallb-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: metallb
 dependents:
 - ose-metallb-operator
 for_payload: false

--- a/images/ose-multus-admission-controller.yml
+++ b/images/ose-multus-admission-controller.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-admission-controller-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-multus-admission-controller
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-route-override-cni-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-multus-route-override-cni
 for_payload: true
 from:
   builder:

--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-whereabouts-ipam-cni-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-multus-whereabouts-ipam-cni
 for_payload: true
 from:
   builder:

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-must-gather-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-must-gather
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -9,6 +9,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-network-interface-bond-cni-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-network-interface-bond-cni
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-network-metrics-daemon.yml
+++ b/images/ose-network-metrics-daemon.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-network-metrics-daemon-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-network-metrics-daemon
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-network-tools-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: network-tools
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-nutanix-cloud-controller-manager.yml
+++ b/images/ose-nutanix-cloud-controller-manager.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-nutanix-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-nutanix-cloud-controller-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -14,6 +14,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-nutanix-machine-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-nutanix-machine-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-oauth-apiserver.yml
+++ b/images/ose-oauth-apiserver.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-oauth-apiserver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-oauth-apiserver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -14,6 +14,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-catalogd-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-olm-catalogd
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -18,6 +18,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-operator-controller-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-olm-operator-controller
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-openshift-apiserver.yml
+++ b/images/ose-openshift-apiserver.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openshift-apiserver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-openshift-apiserver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-openshift-controller-manager.yml
+++ b/images/ose-openshift-controller-manager.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openshift-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-openshift-controller-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-openstack-cinder-csi-driver-operator.yml
+++ b/images/ose-openstack-cinder-csi-driver-operator.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cinder-csi-driver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-openstack-cinder-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cinder-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-openstack-cinder-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -14,6 +14,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-openstack-cloud-controller-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -14,6 +14,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-operator-framework-tools-container
   namespace: containers
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-operator-framework-tools
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ovirt-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ovirt-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ovirt-machine-controllers.yml
+++ b/images/ose-ovirt-machine-controllers.yml
@@ -14,6 +14,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ovirt-machine-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ovirt-machine-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -15,6 +15,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ovn-kubernetes-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ovn-kubernetes
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-block-csi-driver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-powervs-block-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-block-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-powervs-block-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-powervs-cloud-controller-manager.yml
+++ b/images/ose-powervs-cloud-controller-manager.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-powervs-cloud-controller-manager
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-machine-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-powervs-machine-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-prometheus-adapter.yml
+++ b/images/ose-prometheus-adapter.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-prometheus-adapter-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-k8s-prometheus-adapter
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -17,6 +17,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-secrets-store-csi-driver-operator-container
   bundle_component: ose-secrets-store-csi-driver-operator-bundle-container # name in brew
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-secrets-store-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -19,6 +19,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-secrets-store-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-secrets-store-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -15,6 +15,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-secrets-store-csi-mustgather-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-secrets-store-csi-mustgather
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-service-ca-operator.yml
+++ b/images/ose-service-ca-operator.yml
@@ -13,6 +13,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-service-ca-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-service-ca-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -17,6 +17,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-smb-csi-driver-operator-container
   bundle_component: ose-smb-csi-driver-operator-bundle-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-smb-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-smb-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-smb-csi-driver
 dependents:
 - ose-smb-csi-driver-operator
 enabled_repos:

--- a/images/ose-sriov-network-metrics-exporter.yml
+++ b/images/ose-sriov-network-metrics-exporter.yml
@@ -15,10 +15,13 @@ content:
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
 dependents:
-- sriov-network-operator          
+- sriov-network-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-sriov-network-metrics-exporter-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-sriov-network-metrics-exporter
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms
@@ -29,7 +32,7 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sriov-network-metrics-exporter-rhel9
 name_in_bundle: sriov-network-metrics-exporter
-owners: 
+owners:
 - bnemeth@redhat.com
 - apanatto@redhat.com
 - wizhao@redhat.com

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -19,6 +19,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-sriov-rdma-cni-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-sriov-rdma-cni
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -14,6 +14,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-tools-container
   namespace: containers
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-tools
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-vmware-vsphere-csi-driver-operator.yml
+++ b/images/ose-vmware-vsphere-csi-driver-operator.yml
@@ -18,6 +18,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vmware-vsphere-csi-driver-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-vsphere-csi-driver-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vmware-vsphere-csi-driver-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-vsphere-csi-driver
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vsphere-cloud-controller-manager-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-vsphere-cloud-controller-manager
 for_payload: true
 name: openshift/ose-vsphere-cloud-controller-manager-rhel9
 payload_name: vsphere-cloud-controller-manager

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -16,6 +16,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vsphere-cluster-api-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-vsphere-cluster-api-controllers
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -15,6 +15,9 @@ content:
 distgit:
   component: ovn-kubernetes-microshift-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ovn-kubernetes-microshift
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: prom-label-proxy-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-prom-label-proxy
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: prometheus-config-reloader-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-prometheus-config-reloader
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/prometheus-operator-admission-webhook.yml
+++ b/images/prometheus-operator-admission-webhook.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: prometheus-operator-admission-webhook-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-prometheus-operator-admission-webhook
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -21,6 +21,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: prometheus-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-prometheus-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ptp-operator-must-gather-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ptp-must-gather
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -17,6 +17,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-cni-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: sriov-cni
 dependents:
 - sriov-network-operator
 enabled_repos:

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -19,6 +19,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-dp-admission-controller-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-sriov-dp-admission-controller
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -19,6 +19,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-network-config-daemon-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-sriov-network-config-daemon
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -19,6 +19,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-network-device-plugin-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-sriov-network-device-plugin
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -18,6 +18,9 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   bundle_component: sriov-network-operator-metadata-container
   component: sriov-network-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-sriov-network-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -19,6 +19,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-network-webhook-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-sriov-network-webhook
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: telemeter-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-telemeter
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -20,6 +20,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-thanos-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-thanos
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -14,6 +14,9 @@ distgit:
   bundle_component: ose-vertical-pod-autoscaler-operator-metadata-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vertical-pod-autoscaler-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-vertical-pod-autoscaler-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -17,6 +17,9 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vertical-pod-autoscaler-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-vertical-pod-autoscaler
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/vmware-vsphere-syncer.yml
+++ b/images/vmware-vsphere-syncer.yml
@@ -19,6 +19,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: vmware-vsphere-syncer-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-vsphere-csi-driver-syncer
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/vsphere-problem-detector.yml
+++ b/images/vsphere-problem-detector.yml
@@ -18,6 +18,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vsphere-problem-detector-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-vsphere-problem-detector
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms


### PR DESCRIPTION
This PR adds a `repo_name` key to each component config in 4.18 - this corresponds directly to `repo_name` entry in HB

Only components with `for_release: false` or with inconsistent distgit names between HB and ocp-build-data (e.g. ptp-operator) are left unaffected.