### PR TITLE
[ART-10455] add rhel9 base and appstream repo to sync list

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -158,6 +158,26 @@ repos:
       default: rhel-8-for-x86_64-appstream-rpms
       ppc64le: rhel-8-for-ppc64le-appstream-rpms
       s390x: rhel-8-for-s390x-appstream-rpms
+  rhel-9-baseos-rpms:
+    conf:
+      baseurl:
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/
+    content_set:
+      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4
+      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_4
+      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_4
+  rhel-9-appstream-rpms:
+    conf:
+      baseurl:
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/
+    content_set:
+      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4
+      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4
+      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4
   rhel-server-ose-3.11-rpms:
     conf:
       baseurl:


### PR DESCRIPTION
add rhel-9-base and rhel-9-appstream repo to support sync rhel9 repos to mirror/enterprise/ci-deps