### PR TITLE
disable ose-aws-efs-csi-driver-operator

### DIFF
--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - x86_64
 - aarch64


### PR DESCRIPTION
disable ose-aws-efs-csi-driver-operator to unblock pipeline until [OCPBUGS-38578](https://issues.redhat.com/browse/OCPBUGS-38578) resolved