### PR TITLE
Revert "disable ose-aws-efs-csi-driver-operator"

### DIFF
--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled
 arches:
 - x86_64
 - aarch64


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#5264.

[Changed](https://github.com/openshift/csi-operator/pull/261/files) `tools` to `ose-tools`, as requested [here](https://github.com/openshift/csi-operator/pull/252/files#r1719471717).

@Ximinhan is it possible to know if my changes fixed the build issue before merging this?