### PR TITLE
Enable cachito for all 4.17 images

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -64,7 +64,7 @@ assemblies:
   enabled: true
 
 cachito:
-  enabled: false # Cachito does not work with go 1.22 https://issues.redhat.com/browse/STONEBLD-2206
+  enabled: true
 
 rhcos:
   payload_tags:

--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -1,5 +1,3 @@
-cachito:
-  enabled: false # Cachito does not work with go 1.22 https://issues.redhat.com/browse/STONEBLD-2206
 content:
   source:
     dockerfile: Dockerfile.rhel

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -3,8 +3,8 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/baremetal-runtimecfg.git
+        target: dcb68b39e65f8b0ea803caf8e2e9297374605353
+      url: git@github.com:thegreyd/baremetal-runtimecfg.git
       web: https://github.com/openshift/baremetal-runtimecfg
     ci_alignment:
       streams_prs:

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -1,5 +1,3 @@
-cachito:
-  enabled: false # Cachito does not work with go 1.22 https://issues.redhat.com/browse/STONEBLD-2206
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -1,5 +1,3 @@
-cachito:
-  enabled: false # Cachito does not work with go 1.22 https://issues.redhat.com/browse/STONEBLD-2206
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -1,5 +1,5 @@
 cachito:
-  enabled: true  # Cachito does not work with go 1.22 https://issues.redhat.com/browse/STONEBLD-2206, explicitly enabling for nodejs
+  enabled: true
 content:
   source:
     dockerfile: Dockerfile.art

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -7,7 +7,7 @@ content:
       url: git@github.com:openshift-priv/console.git
       web: https://github.com/openshift/console
     pkg_managers:
-    #- gomod Take out go.mod processing because of STONEBLD-2479 not being supported
+    - gomod
     - yarn
     artifacts:
       from_urls:

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -3,8 +3,8 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/baremetal-operator.git
+        target: e257b27fbfd89a4658803c805b8219120a23b5bd
+      url: git@github.com:thegreyd/baremetal-operator.git
       web: https://github.com/openshift/baremetal-operator
     ci_alignment:
       streams_prs:

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -10,7 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
-    pkg_managers: []  # STONEBLD-2302: Cachito is on 1.21.0, and cannot deal with 1.21.6 in go.mod's toolchain directive
+    pkg_managers:
+    - gomod
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-operator-container

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -1,5 +1,3 @@
-cachito:
-  enabled: false # Cachito does not work with go 1.22 https://issues.redhat.com/browse/STONEBLD-2206
 content:
   source:
     dockerfile: openshift/operator-controller.Dockerfile


### PR DESCRIPTION
Partial support for go1.22 is complete https://issues.redhat.com/browse/STONEBLD-2479 
so we can test and enable for eligible images.

Test builds: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/7285/console

Successful builds
- [ose-olm-operator-controller-container-v4.17.0-202408201757.p0.g8d16b39.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3236924)
- [cluster-etcd-operator-container-v4.17.0-202408201757.p0.g37ac49d.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3236926)
- [baremetal-machine-controller-container-v4.17.0-202408201757.p0.g2549061.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3236923)
- [openshift-enterprise-console-container-v4.17.0-202408201757.p0.gf3bab80.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3236931)

Failed images: ose-baremetal-operator, baremetal-runtimecfg. PRs to adjust go.mod
- https://github.com/openshift/baremetal-operator/pull/370
- https://github.com/openshift/baremetal-runtimecfg/pull/331