### PR TITLE
[fix] include ose-aws-efs-csi-driver-operator as dependency for ose-tools

### DIFF
--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -10,6 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
+dependents:
+- ose-aws-efs-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-tools-container


### PR DESCRIPTION
With https://github.com/openshift/csi-operator/commit/172f99bcfddd7c356ecf9cbe4b87557dc7d0d31a ose-tools was included as image-reference