### PR TITLE
[4.7] disable cachito for machine-config-operator

### DIFF
--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -1,3 +1,5 @@
+cachito:
+  enabled: false
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
Test build: [ose-machine-config-operator-container-v4.7.0-202408281348.p0.g9bbeff5.assembly.test.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3254191)