### PR TITLE
PODAUTO-225: Fix bundle and manifest directories for vertical-pod-autoscaler-operator

### DIFF
--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -32,7 +32,7 @@ owners:
 - joesmith@redhat.com
 - macao@redhat.com
 update-csv:
-  bundle-dir: stable/
-  manifests-dir: manifests/
+  bundle-dir: manifests/
+  manifests-dir: bundle/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
This is needed as a result of this PR that was merged to migrate the repo to operator-sdk 1.35: https://github.com/openshift/vertical-pod-autoscaler-operator/pull/169

All the ART stuff should be here now: https://github.com/openshift/vertical-pod-autoscaler-operator/tree/master/bundle