### PR TITLE
Disable helm and operator-sdk images

### DIFF
--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: release/helm/Dockerfile

--- a/images/openshift-enterprise-operator-sdk.yml
+++ b/images/openshift-enterprise-operator-sdk.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: release/sdk/Dockerfile


### PR DESCRIPTION
Dockerfiles disappeared with https://github.com/openshift/ocp-release-operator-sdk/commit/2e2ec82b15ed43e46804e6b3d21a782c7a26c2c3, disabling while we figure out what there is to do.