### PR TITLE
<temp> freeze 4.18 automation

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,7 +4,7 @@
 #   - weekdays: always allow manual builds; forbid scheduled builds from Monday to Friday
 #   - no|false: always allow builds
 # Note that ocp4 builds are always permitted  for non-stream assemblies
-freeze_automation: false
+freeze_automation: scheduled
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
To allow manual testing of 4.18 ocp4-scan. Must be reverted.