### PR TITLE
pin go tools with previous version to match golang version

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile.previous
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile.previous
@@ -1,0 +1,69 @@
+FROM replaced_by_doozer
+
+# Used by builds scripts to detect whether they are running in the context
+# of OpenShift CI or elsewhere (e.g. brew).
+ENV OPENSHIFT_CI="true"
+
+ENV GO_COMPLIANCE_POLICY=exempt_all
+
+# Install, matching upstream k8s, protobuf-3.x, see:
+# https://github.com/kubernetes/kubernetes/blob/master/hack/lib/protoc.sh
+# and etcd, see:
+# https://github.com/kubernetes/kubernetes/blob/master/hack/lib/etcd.sh
+# for CI only testing.
+ENV PATH=/opt/google/protobuf/bin:$PATH
+
+# Note that GHPROXY requests will only pass certificate checks in brew if
+# SSL_CERT_FILE=/tmp/tls-ca-bundle.pem (the CA injected by brew which
+# trusts the RH certificate used by ocp-artifacts)
+ENV GHPROXY_PREFIX="https://ocp-artifacts.engineering.redhat.com/github"
+
+ADD ci_images/install_protoc.sh /tmp
+ADD ci_images/install_etcd.sh /tmp
+
+RUN set -euxo pipefail && \
+    chmod +x /tmp/*.sh && \
+    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    /tmp/install_protoc.sh "23.4" && \
+    /tmp/install_etcd.sh "3.5.10"
+
+RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
+    dnf install -y $INSTALL_PKGS && \
+    dnf clean all && \
+    touch /os-build-image && \
+    git config --system user.name origin-release-container && \
+    git config --system user.email origin-release@redhat.com
+
+# Notes:
+# - brew will not be able to access go modules outside RH, setting GOPROXY allows them to be sourced from ocp-artifacts
+# - brew will not be able to connect to https://sum.golang.org/ . GOSUMDB='off' disables this check.
+# - brew temporarily injects a trust store at /tmp/tls-ca-bundle.pem. Setting SSL_CERT_FILE allows go install to use it.
+#   this is important because the system trust store does not trust Red Hat IT certificates.
+RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
+    export GOSUMDB='off' && \
+    export GOFLAGS='' && export GO111MODULE=on && \
+    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
+    go install github.com/tools/godep@latest && \
+    go install golang.org/x/lint/golint@latest && \
+    go install gotest.tools/gotestsum@latest && \
+    go install github.com/openshift/release/tools/gotest2junit@latest && \
+    go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
+    mv $GOPATH/bin/* /usr/bin/ && \
+    rm -rf $GOPATH/* $GOPATH/.cache && \
+    mkdir $GOPATH/bin && \
+    mkdir -p /go/src/github.com/openshift/origin && \
+    ln -s /usr/bin/imagebuilder $GOPATH/bin/imagebuilder && \
+    ln -s /usr/bin/goimports $GOPATH/bin/goimports && \
+    curl --fail -L -k $GHPROXY_PREFIX/golang/dep/releases/download/v0.5.4/dep-linux-amd64 > /usr/bin/dep && \
+    chmod +x /usr/bin/dep
+
+# make go related directories writeable since builds in CI will run as non-root. go install
+# may have created new directories.
+RUN mkdir -p $GOPATH && \
+    chmod g+xw -R $GOPATH && \
+    chmod g+xw -R $(go env GOROOT)
+
+# Some image building tools don't create a missing WORKDIR
+RUN mkdir -p /go/src/github.com/openshift/origin
+WORKDIR /go/src/github.com/openshift/origin

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile.previous
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile.previous
@@ -1,0 +1,69 @@
+FROM replaced_by_doozer
+
+# Used by builds scripts to detect whether they are running in the context
+# of OpenShift CI or elsewhere (e.g. brew).
+ENV OPENSHIFT_CI="true"
+
+ENV GO_COMPLIANCE_POLICY=exempt_all
+
+# Install, matching upstream k8s, protobuf-3.x, see:
+# https://github.com/kubernetes/kubernetes/blob/master/hack/lib/protoc.sh
+# and etcd, see:
+# https://github.com/kubernetes/kubernetes/blob/master/hack/lib/etcd.sh
+# for CI only testing.
+ENV PATH=/opt/google/protobuf/bin:$PATH
+
+# Note that GHPROXY requests will only pass certificate checks in brew if
+# SSL_CERT_FILE=/tmp/tls-ca-bundle.pem (the CA injected by brew which
+# trusts the RH certificate used by ocp-artifacts)
+ENV GHPROXY_PREFIX="https://ocp-artifacts.engineering.redhat.com/github"
+
+ADD ci_images/install_protoc.sh /tmp
+ADD ci_images/install_etcd.sh /tmp
+
+RUN set -euxo pipefail && \
+    chmod +x /tmp/*.sh && \
+    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    /tmp/install_protoc.sh "23.4" && \
+    /tmp/install_etcd.sh "3.5.10"
+
+RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build rpmdevtools selinux-policy-devel" && \
+    dnf install -y $INSTALL_PKGS && \
+    dnf clean all && \
+    touch /os-build-image && \
+    git config --system user.name origin-release-container && \
+    git config --system user.email origin-release@redhat.com
+
+# Notes:
+# - brew will not be able to access go modules outside RH, setting GOPROXY allows them to be sourced from ocp-artifacts
+# - brew will not be able to connect to https://sum.golang.org/ . GOSUMDB='off' disables this check.
+# - brew temporarily injects a trust store at /tmp/tls-ca-bundle.pem. Setting SSL_CERT_FILE allows go install to use it.
+#   this is important because the system trust store does not trust Red Hat IT certificates.
+RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
+    export GOSUMDB='off' && \
+    export GOFLAGS='' && export GO111MODULE=on && \
+    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
+    go install github.com/tools/godep@latest && \
+    go install golang.org/x/lint/golint@latest && \
+    go install gotest.tools/gotestsum@latest && \
+    go install github.com/openshift/release/tools/gotest2junit@latest && \
+    go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
+    mv $GOPATH/bin/* /usr/bin/ && \
+    rm -rf $GOPATH/* $GOPATH/.cache && \
+    mkdir $GOPATH/bin && \
+    mkdir -p /go/src/github.com/openshift/origin && \
+    ln -s /usr/bin/imagebuilder $GOPATH/bin/imagebuilder && \
+    ln -s /usr/bin/goimports $GOPATH/bin/goimports && \
+    curl --fail -L -k $GHPROXY_PREFIX/golang/dep/releases/download/v0.5.4/dep-linux-amd64 > /usr/bin/dep && \
+    chmod +x /usr/bin/dep
+
+# make go related directories writeable since builds in CI will run as non-root. go install
+# may have created new directories.
+RUN mkdir -p $GOPATH && \
+    chmod g+xw -R $GOPATH && \
+    chmod g+xw -R $(go env GOROOT)
+
+# Some image building tools don't create a missing WORKDIR
+RUN mkdir -p /go/src/github.com/openshift/origin
+WORKDIR /go/src/github.com/openshift/origin

--- a/images/ci-openshift-build-root-previous.rhel8.yml
+++ b/images/ci-openshift-build-root-previous.rhel8.yml
@@ -2,7 +2,7 @@ content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true
   source:
-    dockerfile: ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+    dockerfile: ci_images/rhel-8/ci-openshift-build-root/Dockerfile.previous
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}

--- a/images/ci-openshift-build-root-previous.rhel9.yml
+++ b/images/ci-openshift-build-root-previous.rhel9.yml
@@ -2,7 +2,7 @@ content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true
   source:
-    dockerfile: ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+    dockerfile: ci_images/rhel-9/ci-openshift-build-root/Dockerfile.previous
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
current ci image failed to build because latest go/tools update its deps to go 1.22

add `Dockerfile.previous` to align with `ci-openshift-build-root-previous-container` image usage, also good for cherry pick
the `Dockerfile.previous` changed two parts from Dockerfile
- pin go/tools v0.24.0 vetsion since v0.25.0 requires at least go 1.22 but current previous image is on go 1.21
- remove go/tools/cmd/cover due to its deprecated in go/tools

test build 
https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=64195448
https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=64195449
