### PR TITLE
OSASINFRA-3609: Move OpenStack Cinder CSI Driver Operator to csi-operator repo

### DIFF
--- a/images/ose-openstack-cinder-csi-driver-operator.yml
+++ b/images/ose-openstack-cinder-csi-driver-operator.yml
@@ -1,11 +1,15 @@
+cachito:
+  packages:
+    gomod:
+    - path: legacy/openstack-cinder-csi-driver-operator
 content:
   source:
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.openstack-cinder
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/openstack-cinder-csi-driver-operator.git
-      web: https://github.com/openshift/openstack-cinder-csi-driver-operator
+      url: git@github.com:openshift-priv/csi-operator.git
+      web: https://github.com/openshift/csi-operator
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
We have moved the contents of the old `openstack-cinder-csi-driver-operator` repo into the `csi-operator` repo ([1]) and have migrated our jobs accordingly ([2]). We are also in the process of marking the old repo as deprecated ([3]). This is the final step in the process.

By way of prior art, this is what was previously done for the Azure disk operator in #4148.

[1]: https://github.com/openshift/csi-operator/pull/278
[2]: https://github.com/openshift/release/pull/56812
[3]: https://github.com/openshift/openstack-cinder-csi-driver-operator/pull/180
