### PR TITLE
OSASINFRA-3610: OpenStack: ship manila CSI operator from csi-operator

### DIFF
--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -1,14 +1,18 @@
+cachito:
+  packages:
+    gomod:
+    - path: legacy/csi-driver-manila-operator
 arches:
 - x86_64
 - ppc64le
 content:
   source:
-    dockerfile: build/Dockerfile.openshift
+    dockerfile: Dockerfile.openstack-manila
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/csi-driver-manila-operator.git
-      web: https://github.com/openshift/csi-driver-manila-operator
+      url: git@github.com:openshift-priv/csi-operator.git
+      web: https://github.com/openshift/csi-operator
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
We have [moved the content of csi-driver-manila-operator repo to csi-operator repo](https://github.com/openshift/csi-operator/pull/280) and are in the progress [of migrating our jobs](https://github.com/openshift/release/pull/56882). This is the final step of the process.

Here is the similar process that was done for cinder csi https://github.com/openshift-eng/ocp-build-data/pull/5402