### PR TITLE
[4.16] bump rhel9 repos to 9.4

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -247,20 +247,20 @@ repos:
   rhel-9-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/ppc64le/codeready-builder/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/s390x/codeready-builder/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/x86_64/codeready-builder/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/codeready-builder/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/codeready-builder/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/codeready-builder/os/
       ci_alignment:
         profiles:
         - el9
         localdev:
           enabled: true
     content_set:
-      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_2
-      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_2
-      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_2
-      s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_2
+      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_4
+      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_4
+      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_4
+      s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_4
     reposync:
       enabled: false
 
@@ -358,20 +358,20 @@ repos:
       extra_options:
         module_hotfixes: 1
       baseurl:
-        aarch64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/aarch64/baseos/os/"
-        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/ppc64le/baseos/os/"
-        s390x: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/s390x/baseos/os/"
-        x86_64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/x86_64/baseos/os/"
+        aarch64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/"
+        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/baseos/os/"
+        s390x: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/"
+        x86_64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/"
       ci_alignment:
         profiles:
         - el9
         localdev:
           enabled: true
     content_set:
-      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_2
-      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_2
-      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_2
-      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_2
+      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4
+      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_4
+      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_4
+      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_4
     reposync:
       enabled: false
 
@@ -380,20 +380,20 @@ repos:
       extra_options:
         module_hotfixes: 1
       baseurl:
-        aarch64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/aarch64/appstream/os/"
-        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/ppc64le/appstream/os/"
-        s390x: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/s390x/appstream/os/"
-        x86_64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/x86_64/appstream/os/"
+        aarch64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/"
+        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/appstream/os/"
+        s390x: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/"
+        x86_64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/"
       ci_alignment:
         profiles:
         - el9
         localdev:
           enabled: true
     content_set:
-      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
-      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_2
-      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2
-      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
+      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4
+      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4
+      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4
+      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4
     reposync:
       enabled: false
 
@@ -489,15 +489,15 @@ repos:
         module_hotfixes: 1
       baseurl:
         # RT doesn't do EUS, and TUS isn't around yet. get from dist
-        x86_64: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.2/x86_64/rt/os/"
+        x86_64: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/"
         # Kernel RT is x86 only, so use same repo as a dummy for other arches.
         # The driver-toolkit Dockerfile only installs the kernel-rt for x86_64.
-        aarch64: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.2/x86_64/rt/os/"
-        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.2/x86_64/rt/os/"
-        s390x: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.2/x86_64/rt/os/"
+        aarch64: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/"
+        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/"
+        s390x: "https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/"
 
     content_set:
-      default: rhel-9-for-x86_64-rt-rpms__9_DOT_2
+      default: rhel-9-for-x86_64-rt-rpms__9_DOT_4
       # don't have content set for other arches since they don't exist
       optional: true
     reposync:
@@ -515,63 +515,6 @@ repos:
     content_set:
       default: rhel-8-for-x86_64-rt-rpms__8_DOT_6
       # don't have content set for other arches since they don't exist
-      optional: true
-    reposync:
-      enabled: false
-
-  # CENTOS repos have been added temporarily to allow us to build Centos 9.4 based DTK images before
-  # RHEL's 9.4 beta makes it possible to use RHEL 9.4 publicly. CentOS content has been made available
-  # by proxying through Nginx configuration on ocp-artifacts. Once 9.4 is ready, we should restore
-  # the previous config as defined at https://github.com/openshift-eng/art-config/blob/main/ansible-playbooks/roles/ocp-artifacts-http
-  rhel-94-baseos-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1
-        includepkgs: "kernel*"
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/
-    content_set:
-      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4
-      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_4
-      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_4
-      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_4
-    reposync:
-      enabled: false
-  rhel-94-appstream-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1
-        includepkgs: "kernel*"
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/
-    content_set:
-      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4
-      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4
-      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4
-      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4
-    reposync:
-      enabled: false
-  rhel-94-rt-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1
-        includepkgs: "kernel-rt*"
-      baseurl:
-        # Kernel RT is x86 only, so fake repos for other arches. The driver-toolkit Dockerfile only installs the kernel-rt
-        # for x86_64.
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.4/x86_64/rt/os/
-    content_set:
-      # Only shipping for x86_64
-      default: rhel-9-for-x86_64-rt-rpms__9_DOT_4
       optional: true
     reposync:
       enabled: false

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -24,9 +24,7 @@ enabled_repos:
 - rhel-9-server-ose-rpms-embargoed
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-- rhel-94-baseos-rpms
-- rhel-94-appstream-rpms
-- rhel-94-rt-rpms
+- rhel-9-rt-rpms
 for_payload: true
 from:
   member: openshift-enterprise-base-rhel9


### PR DESCRIPTION
Ref. [ART-10671](https://issues.redhat.com/browse/ART-10671) / [ART-10675](https://issues.redhat.com/browse/ART-10675)

Test build (stacked on top of https://github.com/openshift-eng/ocp-build-data/pull/5407): [driver-toolkit-container-v4.16.0-202409190717.p0.g1d5732f.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3295338)