### PR TITLE
OSASINFRA-3618: Remove caching of legacy cinder CSI dir

### DIFF
--- a/images/ose-openstack-cinder-csi-driver-operator.yml
+++ b/images/ose-openstack-cinder-csi-driver-operator.yml
@@ -1,7 +1,3 @@
-cachito:
-  packages:
-    gomod:
-    - path: legacy/openstack-cinder-csi-driver-operator
 content:
   source:
     dockerfile: Dockerfile.openstack-cinder


### PR DESCRIPTION
This was removed in [1].

[1] needs to merge before this can merge.

[1] https://github.com/openshift/csi-operator/pull/275
