### PR TITLE
STOR-1873: update OLM manifests to use stable channel

### DIFF
--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -33,7 +33,7 @@ name_in_bundle: secrets-store-csi-driver-operator # name in image reference
 owners:
 - aos-storage-staff@redhat.com
 update-csv:
-  bundle-dir: 'preview/'
+  bundle-dir: 'stable/'
   manifests-dir: config/manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-1873

/hold for https://github.com/openshift/secrets-store-csi-driver-operator/pull/63
/cc @openshift/storage
