### PR TITLE
support CI builds in Konflux

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -23,7 +23,7 @@ ADD ci_images/install_etcd.sh /tmp
 
 RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
-    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
+    export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ l
 RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
-    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
+    export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/cover@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install github.com/tools/godep@latest && \

--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -23,12 +23,12 @@ ADD ci_images/install_etcd.sh /tmp
 
 RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
-    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
 RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
-    dnf install -y $INSTALL_PKGS && \
+    dnf install -y --nobest $INSTALL_PKGS && \
     dnf clean all && \
     touch /os-build-image && \
     git config --system user.name origin-release-container && \
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ l
 RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
-    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/cover@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install github.com/tools/godep@latest && \

--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile.previous
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile.previous
@@ -23,7 +23,7 @@ ADD ci_images/install_etcd.sh /tmp
 
 RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
-    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
+    export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ l
 RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
-    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
+    export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
     go install github.com/tools/godep@latest && \
     go install golang.org/x/lint/golint@latest && \

--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile.previous
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile.previous
@@ -23,12 +23,12 @@ ADD ci_images/install_etcd.sh /tmp
 
 RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
-    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
 RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
-    dnf install -y $INSTALL_PKGS && \
+    dnf install -y --nobest $INSTALL_PKGS && \
     dnf clean all && \
     touch /os-build-image && \
     git config --system user.name origin-release-container && \
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ l
 RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
-    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
     go install github.com/tools/godep@latest && \
     go install golang.org/x/lint/golint@latest && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -23,12 +23,12 @@ ADD ci_images/install_etcd.sh /tmp
 
 RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
-    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
 RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build rpmdevtools selinux-policy-devel" && \
-    dnf install -y $INSTALL_PKGS && \
+    dnf install -y --nobest $INSTALL_PKGS && \
     dnf clean all && \
     touch /os-build-image && \
     git config --system user.name origin-release-container && \
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm
 RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
-    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/cover@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install github.com/tools/godep@latest && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -23,7 +23,7 @@ ADD ci_images/install_etcd.sh /tmp
 
 RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
-    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
+    export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm
 RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
-    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
+    export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/cover@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     go install github.com/tools/godep@latest && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile.previous
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile.previous
@@ -23,7 +23,7 @@ ADD ci_images/install_etcd.sh /tmp
 
 RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
-    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
+    export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm
 RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
-    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
+    export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
     go install github.com/tools/godep@latest && \
     go install golang.org/x/lint/golint@latest && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile.previous
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile.previous
@@ -23,12 +23,12 @@ ADD ci_images/install_etcd.sh /tmp
 
 RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
-    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
     /tmp/install_etcd.sh "3.5.10"
 
 RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build rpmdevtools selinux-policy-devel" && \
-    dnf install -y $INSTALL_PKGS && \
+    dnf install -y --nobest $INSTALL_PKGS && \
     dnf clean all && \
     touch /os-build-image && \
     git config --system user.name origin-release-container && \
@@ -42,7 +42,7 @@ RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm
 RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
-    export SSL_CERT_FILE=/tmp/tls-ca-bundle.pem && \
+    export SSL_CERT_FILE=$(test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem) && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
     go install github.com/tools/godep@latest && \
     go install golang.org/x/lint/golint@latest && \


### PR DESCRIPTION
CI builds were failing on Konflux with:
- cert error ([example](https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-18/pipelineruns/doozer-build-openshift-4-18-ci-openshift-build-root-latest42xkh/detail))
- Condition with repos ([example](https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-18/pipelineruns/doozer-build-openshift-4-18-ci-openshift-build-root-latestjxmmn/logs))

This PR includes fixes proposed by Justin