### PR TITLE
ART-10785: parameter for new release versioning scheme

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -41,6 +41,10 @@ arches:
 multi_arch:
   enabled: true
 
+# It is not decided yet from which OCP version on a new release version will have the format i.e. 4.18.0-0
+# Until then the new_payload_versioning_scheme will have the value False  
+new_payload_versioning_scheme: false
+
 operator_image_ref_mode: manifest-list
 
 signing_advisory: 136879


### PR DESCRIPTION
Looking forward to work on [ART-10785](https://issues.redhat.com/browse/ART-10785) a new var in group.yml
is needed: NEW_RELEASE_VERSION
This new var will decide if the coming up format of the release version has to have a certain format or not. 
**4.16.0** or **4.20.0-0**.
This var is needed in gen-assembly jobs to verify that a correct format for the OCP release version was used.