### PR TITLE
handle bugs for 4.16.17

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -25,6 +25,11 @@ releases:
           - el9: cri-o-1.29.9-2.rhaos4.16.git933bdd2.el9
             why: "pin what's in rhcos"
             non_gc_tag: "Build will be shipped via advisory and therefore will not be gc'd"
+      issues:
+        include:
+        - id: OCPBUGS-42300
+        exclude:
+        - id: OCPBUGS-42624  # not in this release
       members:
         images:
         - distgit_key: openshift-enterprise-console


### PR DESCRIPTION
OCPBUGS-42624 is targeting new cri-o after this release
OCPBUGS-42300 has the wrong pscomponet but pr is included in this release