### PR TITLE
missing distgit:component

### DIFF
--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -12,6 +12,7 @@ content:
           stream: rhel-9-golang-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ose-agent-installer-utils-container
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms


### PR DESCRIPTION
rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

Related to https://redhat-internal.slack.com/archives/CB95J6R4N/p1728565713451239 it could be sen that the was missing a distgit:component.

Tested here: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/9965/console --> https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3333071