### PR TITLE
use priv repo for cloud-event-proxy

### DIFF
--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -8,7 +8,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-event-proxy.git
-      web: https://github.com/openshift/cloud-event-proxy
+      web: https://github.com/redhat-cne/cloud-event-proxy
     ci_alignment:
       streams_prs:
         ci_build_root:

--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -8,7 +8,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-event-proxy.git
-      web: https://github.com/redhat-cne/cloud-event-proxy
+      web: https://github.com/openshift/cloud-event-proxy
     ci_alignment:
       streams_prs:
         ci_build_root:

--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -7,7 +7,7 @@ content:
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:redhat-cne/cloud-event-proxy.git
+      url: git@github.com:openshift-priv/cloud-event-proxy.git
       web: https://github.com/redhat-cne/cloud-event-proxy
     ci_alignment:
       streams_prs:


### PR DESCRIPTION
To setup commit forwarding for a repo that does not have a fork in openshift-priv yet:
- Created a priv repo ([openshift-priv/cloud-event-proxy](https://github.com/openshift-priv/cloud-event-proxy)): [ticket](https://issues.redhat.com/browse/DPP-15691) (though the name is different from the request)
- Setup a whitelist: https://github.com/openshift/release/pull/57236

After that we see that commits are being forwarded (cloud-event-proxy mentioned in CI deck [logs](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/?job=periodic-openshift-release-private-org-sync))

Docs: https://docs.ci.openshift.org/docs/architecture/private-repositories/#openshift-priv-organization

This PR can be backported if needed