### PR TITLE
[chore] disable few operators with wrong metadata.{name,version}

### DIFF
--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: build/Dockerfile.operator.openshift

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     git:

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - x86_64
 - aarch64


### PR DESCRIPTION
metadata refers 4.17.0 instead of 4.18.0, temporary disable until upstream fixes it

```
Bundle ose-metallb-operator-bundle-container-v4.18.0.202410071541.p0.g785764e.assembly.stream.el9-2 CSV metadata.name has no datestamp: metallb-operator.v4.17.0
Bundle ose-metallb-operator-bundle-container-v4.18.0.202410071541.p0.g785764e.assembly.stream.el9-2 CSV spec.version has no datestamp: 4.17.0
Bundle cluster-nfd-operator-metadata-container-v4.18.0.202410071842.p0.g58df9de.assembly.stream.el9-2 CSV metadata.name has no datestamp: nfd.v4.17.0
Bundle cluster-nfd-operator-metadata-container-v4.18.0.202410071842.p0.g58df9de.assembly.stream.el9-2 CSV spec.version has no datestamp: 4.17.0
Bundle ose-clusterresourceoverride-operator-metadata-container-v4.18.0.202410022110.p0.ga720b90.assembly.stream.el9-2 CSV metadata.name has no datestamp: clusterresourceoverride-operator.v4.17.0
Bundle ose-clusterresourceoverride-operator-metadata-container-v4.18.0.202410022110.p0.ga720b90.assembly.stream.el9-2 CSV spec.version has no datestamp: 4.17.0
Bundle ose-kubernetes-nmstate-operator-bundle-container-v4.18.0.202410080040.p0.g07e36e5.assembly.stream.el9-2 CSV metadata.name has no datestamp: kubernetes-nmstate-operator.v4.17.0
Bundle ose-kubernetes-nmstate-operator-bundle-container-v4.18.0.202410080040.p0.g07e36e5.assembly.stream.el9-2 CSV spec.version has no datestamp: 4.17.0
Bundle ose-ptp-operator-metadata-container-v4.18.0.202410021543.p0.g57466fb.assembly.stream.el9-2 CSV metadata.name has no datestamp: ptp-operator.v4.17.0
Bundle ose-ptp-operator-metadata-container-v4.18.0.202410021543.p0.g57466fb.assembly.stream.el9-2 CSV spec.version has no datestamp: 4.17.0

            The following bundles failed CSV validation:
              cluster-nfd-operator-metadata-container-v4.18.0.202410071842.p0.g58df9de.assembly.stream.el9-2
              ose-kubernetes-nmstate-operator-bundle-container-v4.18.0.202410080040.p0.g07e36e5.assembly.stream.el9-2
              ose-ptp-operator-metadata-container-v4.18.0.202410021543.p0.g57466fb.assembly.stream.el9-2
              ose-clusterresourceoverride-operator-metadata-container-v4.18.0.202410022110.p0.ga720b90.assembly.stream.el9-2
              ose-metallb-operator-bundle-container-v4.18.0.202410071541.p0.g785764e.assembly.stream.el9-2
            Check art.yaml substitutions for failing matches.
            
```