### PR TITLE
[4.18] Override public upstram for cloud-event-proxy

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -156,9 +156,11 @@ push:
 
 public_upstreams:
 - private: "https://github.com/openshift-priv/operator-marketplace"
-  public: "https://github.com/operator-framework/operator-marketplace"
+  public:  "https://github.com/operator-framework/operator-marketplace"
 - private: "https://github.com/openshift-priv"
-  public: "https://github.com/openshift"
+  public:  "https://github.com/openshift"
+- private: "https://github.com/openshift-priv/cloud-event-proxy"
+  public:  "https://github.com/redhat-cne/cloud-event-proxy"
 
 repos:
 


### PR DESCRIPTION
Needed after https://github.com/openshift-eng/ocp-build-data/pull/5484