### PR TITLE
CLID-252: renaming oc-mirror component

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -307,7 +307,7 @@ bug_mapping:
     oc-compliance-container:
       issue_component: oc-compliance
     oc-mirror-plugin-container:
-      issue_component: oc / oc-mirror
+      issue_component: oc-mirror
     oniguruma:
       issue_component: Metering Operator
     openshift:


### PR DESCRIPTION
This change is required since oc-mirror component field is going to be renamed in the OCPBUGS jira project.