### PR TITLE
ART-9905 [openshift-4.18] Publish golang builders for partner access

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -69,33 +69,37 @@ rhel-8-golang:
   upstream_image_mirror:
   - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}
 
-ibm-rhel-9-golang-1.21:
-  # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.21.11-202407030000.gab74a9a.el9
-  mirror: true
-  mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
-
-ibm-rhel-8-golang-1.21:
-  # Mirror non-embargoed golang builders for IBM
+partner-rhel-8-golang-1.21:
   image: openshift/golang-builder:v1.21.11-202407021847.g1ac3e39.el8
   mirror: true
   mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
+  upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
+  upstream_image_mirror:
+  - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-ibm-rhel-9-golang-1.22:
-  # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.22.7-202410111609.gc451559.el9
+partner-rhel-9-golang-1.21:
+  image: openshift/golang-builder:v1.21.11-202407030000.gab74a9a.el9
   mirror: true
   mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}
+  upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
+  upstream_image_mirror:
+  - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
 
-ibm-rhel-8-golang-1.22:
-  # Mirror non-embargoed golang builders for IBM
+partner-rhel-8-golang-1.22:
   image: openshift/golang-builder:v1.22.7-202410111416.gd54e8ac.el8
   mirror: true
   mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}
+  upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}
+  upstream_image_mirror:
+  - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}
+
+partner-rhel-9-golang-1.22:
+  image: openshift/golang-builder:v1.22.7-202410111609.gc451559.el9
+  mirror: true
+  mirror_manifest_list: true
+  upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}
+  upstream_image_mirror:
+  - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}
 
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on


### PR DESCRIPTION
Ref. [ART-9905](https://issues.redhat.com/browse/ART-9905)

Make unembargoed golang builders available to our partners. We can combine mirroring locations in a single (per-builder) stream entry, where:
- `upstream_image` is the mandatory mirroring location for the first partner
- additional partners can be added by populating an optional `upstream_image_info` list in the same entry

