### PR TITLE
STOR-1844: update OLM manifests to use stable channel

### DIFF
--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -33,7 +33,7 @@ name_in_bundle: smb-csi-driver-rhel9-operator
 owners:
 - aos-storage-staff@redhat.com
 update-csv:
-  bundle-dir: preview
+  bundle-dir: stable
   manifests-dir: config/samba/manifests/
   registry: image-registry.openshift-imageregistry.svc:5000
   valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-1844

(followup for https://github.com/openshift/csi-operator/pull/300)

/cc @openshift/storage