### PR TITLE
Bump golang-1.22 builder to RHEL 9.4

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -76,29 +76,29 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/baseos/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/
     content_set:
-      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_0
-      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_0
-      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_0
-      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_0
+      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4
+      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_4
+      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_4
+      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_4
     reposync:
       enabled: false
 
   rhel-9-appstream-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/appstream/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/
     content_set:
-      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_0
-      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_0
-      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_0
-      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_0
+      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4
+      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4
+      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4
+      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4
     reposync:
       enabled: false

--- a/streams.yml
+++ b/streams.yml
@@ -1,4 +1,4 @@
 ---
 rhel9:
-# rhel-els-container-9.0.0-974
-  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:c00fe5ad75658431c97b3a225db5625a97c8f3a28253af7ec3aa622db235ff64
+# rhel-els-container-9.4-943.1726661131
+  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7


### PR DESCRIPTION
Ref. [ART-11107](https://issues.redhat.com/browse/ART-11107)