### PR TITLE
Update external providers

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -467,13 +467,13 @@ bug_mapping:
     ose-alibaba-disk-csi-driver-operator-container:
       issue_component: Storage / Operators
     ose-alibaba-machine-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-apiserver-network-proxy-container:
       issue_component: openshift-apiserver
     ose-aws-cloud-controller-manager-container:
       issue_component: Cloud Compute / Cloud Controller Manager
     ose-aws-cluster-api-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-aws-ebs-csi-driver-container:
       issue_component: Storage
     ose-aws-ebs-csi-driver-operator-container:
@@ -487,7 +487,7 @@ bug_mapping:
     ose-aws-efs-utils-container:
       issue_component: Storage
     ose-aws-machine-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-aws-pod-identity-webhook-container:
       issue_component: Cloud Credential Operator
     ose-azure-cloud-controller-manager-container:
@@ -497,7 +497,7 @@ bug_mapping:
     ose-azure-cloud-node-manager-container:
       issue_component: Cloud Compute / Cloud Controller Manager
     ose-azure-cluster-api-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-azure-disk-csi-driver-container:
       issue_component: Storage / Kubernetes External Components
     ose-azure-disk-csi-driver-operator-container:
@@ -507,7 +507,7 @@ bug_mapping:
     ose-azure-file-csi-driver-operator-container:
       issue_component: Storage / Operators
     ose-azure-machine-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-azure-storage-azcopy-base-container:
       issue_component: Storage / Kubernetes External Components
     ose-azure-workload-identity-webhook-container:
@@ -529,7 +529,7 @@ bug_mapping:
     ose-cloud-network-config-controller-container:
       issue_component: Networking / ovn-kubernetes
     ose-cluster-api-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-cluster-authentication-operator-container:
       issue_component: apiserver-auth
     ose-cluster-autoscaler-operator-container:
@@ -539,7 +539,7 @@ bug_mapping:
     ose-cluster-bootstrap-container:
       issue_component: kube-apiserver
     ose-cluster-capi-operator-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-cluster-cloud-controller-manager-operator-container:
       issue_component: Cloud Compute / Cloud Controller Manager
     ose-cluster-config-api-container:
@@ -547,7 +547,7 @@ bug_mapping:
     ose-cluster-config-operator-container:
       issue_component: config-operator
     ose-cluster-control-plane-machine-set-operator-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-cluster-csi-snapshot-controller-operator-container:
       issue_component: Storage / Operators
     ose-cluster-dns-operator-container:
@@ -559,7 +559,7 @@ bug_mapping:
     ose-cluster-kube-apiserver-operator-container:
       issue_component: kube-apiserver
     ose-cluster-kube-cluster-api-operator-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-cluster-kube-controller-manager-operator-container:
       issue_component: kube-controller-manager
     ose-cluster-kube-descheduler-operator-container:
@@ -571,7 +571,7 @@ bug_mapping:
     ose-cluster-kube-storage-version-migrator-operator-container:
       issue_component: kube-storage-version-migrator
     ose-cluster-machine-approver-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-cluster-olm-operator-container:
       issue_component: OLM
     ose-cluster-openshift-apiserver-operator-container:
@@ -639,7 +639,7 @@ bug_mapping:
     ose-gcp-cloud-controller-manager-container:
       issue_component: Cloud Compute / Cloud Controller Manager
     ose-gcp-cluster-api-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-gcp-filestore-csi-driver-container:
       issue_component: Storage
     ose-gcp-filestore-csi-driver-operator-bundle-container:
@@ -647,7 +647,7 @@ bug_mapping:
     ose-gcp-filestore-csi-driver-operator-container:
       issue_component: Storage / Operators
     ose-gcp-machine-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-gcp-pd-csi-driver-container:
       issue_component: Storage / Kubernetes External Components
     ose-gcp-pd-csi-driver-operator-container:
@@ -709,7 +709,7 @@ bug_mapping:
     ose-leader-elector-container:
       issue_component: Networking / kuryr
     ose-libvirt-machine-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-linuxptp-daemon-container:
       issue_component: Networking / ptp
     ose-local-storage-mustgather-container:
@@ -717,11 +717,11 @@ bug_mapping:
     ose-machine-api-operator-container:
       issue_component: Cloud Compute / Cloud Controller Manager
     ose-machine-api-provider-aws-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-machine-api-provider-azure-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-machine-api-provider-gcp-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-machine-api-provider-openstack-container:
       issue_component: Cloud Compute / OpenStack Provider
     ose-machine-config-operator-container:
@@ -849,7 +849,7 @@ bug_mapping:
     ose-vsphere-cloud-controller-manager-container:
       issue_component: Cloud Compute / Cloud Controller Manager
     ose-vsphere-cluster-api-controllers-container:
-      issue_component: Cloud Compute / Other Provider
+      issue_component: Cloud Compute / External Provider
     ose-vsphere-problem-detector-container:
       issue_component: Storage / Operators
     ostree:


### PR DESCRIPTION
ocp-build-data is using a deprecated component 'Cloud Compute / Other Provider' that no longer exists in the OCPBUGS project. Approx 17 components are impacted with this change. The closest alternative I can see is 'Cloud Compute / External Provider'.