### PR TITLE
remove non_shipping field for thanos

### DIFF
--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -34,7 +34,5 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-thanos-rhel9
 payload_name: thanos
-non_shipping_repos:
-- rhel-9-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com


### PR DESCRIPTION
This was blocking the rpm from being available for konflux. (failed [run](https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-18/pipelineruns/4-18-thanos-j62zq/logs?task=build-images))

Removing this seems to have [fixed](https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-18/pipelineruns/ose-4-18-thanos-5trtt/logs?task=build-images) it