### PR TITLE
scan-sources:noop [konflux] use Dockerfile.rhel for ose-etcd

### DIFF
--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -59,5 +59,6 @@ owners:
 maintainer:
   component: "Etcd"
 konflux:
-  # Until cachito support is setup https://issues.redhat.com/browse/ART-11115
-  mode: disabled
+  content:
+    source:
+      dockerfile: Dockerfile.rhel


### PR DESCRIPTION
ref [thread](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1730381903233859?thread_ts=1730227468.852159&cid=GDBRP5YJH)