### PR TITLE
scan-sources:noop use priv org for ocp-build-data

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -165,6 +165,8 @@ public_upstreams:
   public:  "https://github.com/openshift"
 - private: "https://github.com/openshift-priv/cloud-event-proxy"
   public:  "https://github.com/redhat-cne/cloud-event-proxy"
+- private: "https://github.com/openshift-priv/ocp-build-data"
+  public: "https://github.com/openshift-eng/ocp-build-data"
 
 repos:
 

--- a/images/ci-openshift-base.rhel9.yml
+++ b/images/ci-openshift-base.rhel9.yml
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/ci-openshift-base.rhel9.yml
+++ b/images/ci-openshift-base.rhel9.yml
@@ -7,7 +7,7 @@ content:
       branch:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-build-data.git
-      web: https://github.com/openshift/ocp-build-data
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/ci-openshift-build-root-latest.rhel8.yml
+++ b/images/ci-openshift-build-root-latest.rhel8.yml
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/ci-openshift-build-root-latest.rhel8.yml
+++ b/images/ci-openshift-build-root-latest.rhel8.yml
@@ -7,7 +7,7 @@ content:
       branch:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-build-data.git
-      web: https://github.com/openshift/ocp-build-data
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/ci-openshift-build-root-latest.rhel9.yml
+++ b/images/ci-openshift-build-root-latest.rhel9.yml
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/ci-openshift-build-root-latest.rhel9.yml
+++ b/images/ci-openshift-build-root-latest.rhel9.yml
@@ -7,7 +7,7 @@ content:
       branch:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-build-data.git
-      web: https://github.com/openshift/ocp-build-data
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/ci-openshift-build-root-previous.rhel8.disabled
+++ b/images/ci-openshift-build-root-previous.rhel8.disabled
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/ci-openshift-build-root-previous.rhel8.disabled
+++ b/images/ci-openshift-build-root-previous.rhel8.disabled
@@ -7,7 +7,7 @@ content:
       branch:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-build-data.git
-      web: https://github.com/openshift/ocp-build-data
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/ci-openshift-build-root-previous.rhel9.disabled
+++ b/images/ci-openshift-build-root-previous.rhel9.disabled
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/ci-openshift-build-root-previous.rhel9.disabled
+++ b/images/ci-openshift-build-root-previous.rhel9.disabled
@@ -7,7 +7,7 @@ content:
       branch:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-build-data.git
-      web: https://github.com/openshift/ocp-build-data
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/ci-openshift-golang-builder-latest.rhel8.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel8.yml
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/ci-openshift-golang-builder-latest.rhel8.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel8.yml
@@ -7,7 +7,7 @@ content:
       branch:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-build-data.git
-      web: https://github.com/openshift/ocp-build-data
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/ci-openshift-golang-builder-latest.rhel9.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel9.yml
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/ci-openshift-golang-builder-latest.rhel9.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel9.yml
@@ -7,7 +7,7 @@ content:
       branch:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-build-data.git
-      web: https://github.com/openshift/ocp-build-data
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/ci-openshift-golang-builder-previous.rhel8.disabled
+++ b/images/ci-openshift-golang-builder-previous.rhel8.disabled
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/ci-openshift-golang-builder-previous.rhel8.disabled
+++ b/images/ci-openshift-golang-builder-previous.rhel8.disabled
@@ -7,7 +7,7 @@ content:
       branch:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-build-data.git
-      web: https://github.com/openshift/ocp-build-data
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/ci-openshift-golang-builder-previous.rhel9.disabled
+++ b/images/ci-openshift-golang-builder-previous.rhel9.disabled
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/ci-openshift-golang-builder-previous.rhel9.disabled
+++ b/images/ci-openshift-golang-builder-previous.rhel9.disabled
@@ -7,7 +7,7 @@ content:
       branch:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-build-data.git
-      web: https://github.com/openshift/ocp-build-data
+      web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/openshift-base-nodejs.rhel9.yml
+++ b/images/openshift-base-nodejs.rhel9.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: openshift-base-nodejs-rhel9
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:

--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: openshift-base-rhel9
-      url: git@github.com:openshift-eng/ocp-build-data.git
+      url: git@github.com:openshift-priv/ocp-build-data.git
       web: https://github.com/openshift-eng/ocp-build-data
     ci_alignment:
       streams_prs:


### PR DESCRIPTION
Using the new repo in priv https://github.com/openshift-priv/ocp-build-data so that we can keep config uniform across all components and konflux can rebase to priv