### PR TITLE
Implementing Multi-Arch Support for MCO with Multi-Base Builders

### DIFF
--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -32,13 +32,13 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
-  - stream: rhel-8-golang
+  - member: ci-openshift-golang-builder-latest.rhel9
+  - member: ci-openshift-golang-builder-latest.rhel8
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-machine-config-operator-rhel9
 payload_name: machine-config-operator
 owners:
 - jerzhang@redhat.com
-- jkyros@redhat.com
+- dkhater@redhat.com
 - skumari@redhat.com
 - zzlotnik@redhat.com


### PR DESCRIPTION
Updated the Machine Config Operator’s build configuration to use both RHEL 9 and RHEL 8 Golang builders, aligning with ART tooling for consistent multi-architecture compatibility. No additional streams or members were needed beyond the dual-builder setup.

See [this slack message](https://redhat-internal.slack.com/archives/CB95J6R4N/p1730308757526909) for more info






