### PR TITLE
4.14: Stop eternal rebuild loop for ovn-kubernets

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -29,6 +29,7 @@ scan_sources:
   - openvswitch*
   - ovn*
   - python3-openvswitch*
+  - libreswan
 
 for_payload: true
 from:


### PR DESCRIPTION
Following https://github.com/openshift/ovn-kubernetes/pull/2323

For some reason, this is only pinned in 4.14:
```
ose-ovn-kubernetes_4.12_Dockerfile:	libreswan \
ose-ovn-kubernetes_4.13_Dockerfile:	libreswan \
ose-ovn-kubernetes_4.14_Dockerfile:	libreswan-4.5-1.el9 \
ose-ovn-kubernetes_4.15_Dockerfile:	libreswan \
ose-ovn-kubernetes_4.16_Dockerfile:	libreswan \
ose-ovn-kubernetes_4.17_Dockerfile:	libreswan \
ose-ovn-kubernetes_4.18_Dockerfile:	libreswan \
```