### PR TITLE
Remove caching of legacy manila CSI dir

### DIFF
--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -1,7 +1,3 @@
-cachito:
-  packages:
-    gomod:
-    - path: legacy/csi-driver-manila-operator
 arches:
 - x86_64
 - ppc64le


### PR DESCRIPTION
Manila was just integrated to csi-operator. Let's update the build.
https://github.com/openshift/csi-operator/pull/288

The legacy folder is being removed in this PR https://github.com/openshift/csi-operator/pull/317