### PR TITLE
CFE-1176: Update openshift-enterprise-ansible-operator 4.16 image configuration to use pip from openshift/ansible-operator-plugins repo

### DIFF
--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -5,27 +5,39 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ansible-operator-plugins.git
-      web: https://github.com/openshift/ansible-operator-plugins.git
+      web: https://github.com/openshift/ansible-operator-plugins
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: rhel-9-golang-ci-build-root
+    pkg_managers:
+    - pip
+cachito:
+  enabled: true
+  packages:
+    pip:
+    - path: openshift
+      requirements_files:
+      - requirements.txt
+      requirements_build_files:
+      - requirements-build.txt
+      - requirements-pre-build.txt
 distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-ansible-operator-container
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms-embargoed
-- rhel-8-server-ansible-2.9-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-codeready-builder-rpms
 for_payload: false
 from:
   builder:
-  - stream: golang
-  member: openshift-enterprise-base
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
 maintainer:
   component: Operator SDK
-name: openshift/ose-ansible-operator
+name: openshift/ose-ansible-rhel9-operator
 owners:
 - aos-operator-sdk@redhat.com
 - jlanford@redhat.com
@@ -33,5 +45,3 @@ owners:
 - tgeer@redhat.com
 - ckyal@redhat.com
 - arsen@redhat.com
-non_shipping_repos:
-- rhel-8-server-ose-rpms-embargoed

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -1,11 +1,11 @@
 content:
   source:
-    dockerfile: release/ansible/Dockerfile.rhel8
+    dockerfile: openshift/Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/ocp-release-operator-sdk.git
-      web: https://github.com/openshift/ocp-release-operator-sdk
+      url: git@github.com:openshift-priv/ansible-operator-plugins.git
+      web: https://github.com/openshift/ansible-operator-plugins.git
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -30,3 +30,8 @@ owners:
 - aos-operator-sdk@redhat.com
 - jlanford@redhat.com
 - fabian@redhat.com
+- tgeer@redhat.com
+- ckyal@redhat.com
+- arsen@redhat.com
+non_shipping_repos:
+- rhel-8-server-ose-rpms-embargoed


### PR DESCRIPTION
Manual cherrypick of fbca3b7d743074e44dca49ce3051c7b75b9eb15e and e9fa0f16c5556bedc6b948e4f542c366691ab924