### PR TITLE
OCPCRT-339: Update with missing components

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -91,6 +91,8 @@ bug_mapping:
       issue_component: Observability UI
     console-login-helper-messages:
       issue_component: Management Console
+    container-networking-plugins-microshift-container:
+      issue_component: Microshift / Networking
     container-selinux:
       issue_component: Containers
     containernetworking-plugins:


### PR DESCRIPTION
Of the image names defined in the [openshift-4.18 branch images subdir](https://github.com/openshift-eng/ocp-build-data/tree/openshift-4.18/images) that had 'master' as the main branch, I found these that had no mapping:

* [container-networking-plugins-microshift](https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.18/images/container-networking-plugins-microshift.yml)
* [ose-kubevirt-csi-driver-rhel8](https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.18/images/ose-kubevirt-csi-driver-rhel8.yml)

This PR adds those components and has my best guess for the Jira component they should map to.