### PR TITLE
SDN-5457: Move kube-proxy image from openshift/sdn to openshift/kubernetes

### DIFF
--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -1,11 +1,11 @@
 content:
   source:
-    dockerfile: images/kube-proxy/Dockerfile.rhel
+    dockerfile: openshift-hack/images/kube-proxy/Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/sdn.git
-      web: https://github.com/openshift/sdn
+      url: git@github.com:openshift-priv/kubernetes.git
+      web: https://github.com/openshift/kubernetes
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
With the deprecation of openshift-sdn, the Dockerfile for the standalone kube-proxy image build has been moved from openshift/sdn to openshift/kubernetes (https://github.com/openshift/kubernetes/pull/2082). CI update is https://github.com/openshift/release/pull/58505.

(See #5712 for the `openshift-4.18` update, and discuss there if there are any problems with this...)