### PR TITLE
Revert "Add assembly 4.17.6"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -2,12 +2,12 @@ releases:
   4.17.6:
     assembly:
       basis:
-        brew_event: 61526772
+        brew_event: 61526655
         reference_releases:
-          aarch64: 4.17.0-0.nightly-arm64-2024-11-21-132344
-          ppc64le: 4.17.0-0.nightly-ppc64le-2024-11-21-132343
-          s390x: 4.17.0-0.nightly-s390x-2024-11-21-132347
-          x86_64: 4.17.0-0.nightly-2024-11-21-153158
+          aarch64: 4.17.0-0.nightly-arm64-2024-11-21-052344
+          ppc64le: 4.17.0-0.nightly-ppc64le-2024-11-21-052343
+          s390x: 4.17.0-0.nightly-s390x-2024-11-21-052347
+          x86_64: 4.17.0-0.nightly-2024-11-21-052346
       group:
         advisories:
           extras: 143044


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#5717 per https://redhat-internal.slack.com/archives/CJARLA942/p1732240809175579?thread_ts=1732105733.058509&cid=CJARLA942