### PR TITLE
Fix openstack-16-for-rhel-8-rpms repo

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -317,9 +317,9 @@ repos:
       baseurl:
         ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/openstack/16.2/os/
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16.2/os/
-        # XXX: aarch64 and s390x RHOS don't exist, use puddles for now in order to build Ironic
-        s390x: https://download.hosts.prod.upshift.rdu2.redhat.com/rcm-guest/puddles/Multi-Arch/OpenStack/16.2/latest/OpenStack/s390x/os/
-        aarch64: https://download.hosts.prod.upshift.rdu2.redhat.com/rcm-guest/puddles/Multi-Arch/OpenStack/16.2/latest/OpenStack/aarch64/os/
+        # XXX: aarch64 and s390x RHOS don't exist, so use the same repo as a dummy for other arches.
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16.2/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16.2/os/
       ci_alignment:
         profiles:
         - el8


### PR DESCRIPTION
The aarch64 and s390x RHOS don't exist, so use the same repo as a dummy for other arches.