### PR TITLE
disable vertical-pod-autoscaler-operator build

### DIFF
--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
build is failing dues to issues with the CSV for 4.18.

```
2024-11-22 20:30:04,900 artcommonlib INFO Task state: FREE
2024-11-22 20:33:04,945 artcommonlib INFO Fault: <Fault 2001: 'Image
build failed. Error in plugin pin_operator_digest: Both relatedImages
and RELATED_IMAGE_* env vars present in
/workspace/ws-build-dir/x86_64/manifests/vertical-pod-autoscaler.clusterserviceversion.yaml.
Please remove the relatedImages section, it will be reconstructed
automatically.; . OSBS build id:
vertical-pod-autosca-rhaos-418-rhel-9-f331015954-20241122203110'>
```

Removing `RELATED_IMAGES_` seems to fix the issue but the change is not trivial for upstream

https://github.com/openshift/vertical-pod-autoscaler-operator/pull/182