### PR TITLE
Re-enable vertical-pod-autoscaler-operator build

### DIFF
--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#5741

Now that https://github.com/openshift/vertical-pod-autoscaler-operator/pull/185 and https://github.com/openshift/vertical-pod-autoscaler-operator/pull/183 have merged, could we try ART builds again?