### PR TITLE
Force CI to use 4.x:base-rhel?

### DIFF
--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -9,7 +9,15 @@ content:
     ci_alignment:
       streams_prs:
         enabled: false
+      # The actual image used by CI for the base image is
+      # built and pushed from ci-openshift-base.rhel9.
+      # This image is technically, the openshift-enterprise-base image
+      # but it shouldn't matter for the purposes of CI
+      # Setting upstream_image here ensures that reconciliation PRs for components referencing
+      # this image as their base image will use the image created by
+      # ci-openshift-base.rhel9 and be able to resolve RPMs.
       mirror: false
+      upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:base-rhel9
     okd_alignment:
       resolve_as:
         stream: centos_stream9

--- a/images/openshift-enterprise-base-rhel9.yml
+++ b/images/openshift-enterprise-base-rhel9.yml
@@ -15,6 +15,13 @@ content:
         - approved
         - lgtm
         merge_first: true
+      # The actual image used by CI for the enterprise base image is
+      # built and pushed from ci-openshift-base.rhel9. Setting upstream_image
+      # here ensures that reconciliation PRs for components referencing
+      # this image as their base image will use the image created by
+      # ci-openshift-base.rhel9 and be able to resolve RPMs.
+      mirror: false
+      upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:base-rhel9
     okd_alignment:
       # The tag name in the okd stream to which this image should be promoted
       tag_name: base-stream9


### PR DESCRIPTION
Before this change, reconciliation PRs were being opened to reference registry.ci.openshift.org/ocp/4.19:openshift-enterprise-base-rhel9 . Confusingly, we have previously opened PRs to use
registry.ci.openshift.org/ocp/4.x:base-rhel9 . This is not the same as the ART base-rhel9, which is just an up-to-date ELS RHEL9 base image.
CI expects this image to be our enterprise-base RHEL9 image.