### PR TITLE
Ignore stop-ship-tag for non-GA release

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -138,7 +138,7 @@ rpm_deliveries:
       - kernel
     rhel_tag: rhel-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}.0-z-candidate
     integration_tag: early-kernel-candidate
-    stop_ship_tag: early-kernel-stop-ship
+    stop_ship_tag: trashcan
     ship_ok_tag: early-kernel-ship-ok
     target_tag: rhaos-{MAJOR}.{MINOR}-rhel-{RHCOS_EL_MAJOR}-candidate
 


### PR DESCRIPTION
If the stop-ship tag is applied to a kernel, that is a signal that OCP
should not be shipping that release. Strictly speaking, this does not
apply to releases that are not shipping yet. CI of pre-GA releases
should be informing such a decision.

This is a minimal change to not let auatomation run havoc on pre-GA
releases, and to make it a human decision to retract the kernel or not.
