### PR TITLE
OCPCLOUD-2642: ASO should use commit prefix

### DIFF
--- a/images/ose-azure-service-operator.yml
+++ b/images/ose-azure-service-operator.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/azure-service-operator
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:


### PR DESCRIPTION
This adds the carry prefix to azure-service-operator, so than we can use it with the rebase bot. 