### PR TITLE
[konflux] use VM with higher disk for ose-installer-artifacts

### DIFF
--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -32,3 +32,6 @@ name: openshift/ose-installer-artifacts-rhel9
 payload_name: installer-artifacts
 owners:
 - aos-install@redhat.com
+konflux:
+  vm_override:
+    aarch64: linux-d160/arm64


### PR DESCRIPTION
Alongside https://github.com/openshift-eng/art-tools/pull/1186