### PR TITLE
ART-11563: [konflux] disable ose-installer-artifacts until issue is resolved

### DIFF
--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -33,5 +33,7 @@ payload_name: installer-artifacts
 owners:
 - aos-install@redhat.com
 konflux:
+  # Until https://issues.redhat.com/browse/ART-11563 is resolved
+  mode: disabled
   vm_override:
     aarch64: linux-d160/arm64


### PR DESCRIPTION
Until https://issues.redhat.com/browse/ART-11563 is resolved