### PR TITLE
[konflux] use linux-d160/arm64 VM for ose-cli-artifacts

### DIFF
--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -28,3 +28,6 @@ payload_name: cli-artifacts
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com
+konflux:
+  vm_override:
+    aarch64: linux-d160/arm64


### PR DESCRIPTION
Build failing due to insufficient storage ([logs](https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-19/pipelineruns/ose-4-19-ose-cli-artifacts-4pjmw/logs?task=build-images))