### PR TITLE
Set component for multus-cni to Networking

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -283,7 +283,7 @@ bug_mapping:
     multus-cni-container:
       issue_component: Networking / multus
     multus-cni-container-microshift-container:
-      issue_component: MicroShift
+      issue_component: Networking / multus
     mysql-apb-role:
       issue_component: Service Broker
     networking-console-plugin-container:


### PR DESCRIPTION
We originally had:

```
    multus-cni-container:
      issue_component: Networking / multus
    multus-cni-container-microshift-container:
      issue_component: MicroShift
```

In [images](https://github.com/openshift-eng/ocp-build-data/tree/openshift-4.18/images), we have multus-cni-container-microshift.yml and multus-cni.yml and both have a content.source.git.web of https://github.com/openshift/multus-cni.

So, we'll make the owner as `Networking / multus`.
