### PR TITLE
[konflux] disable openshift-base-nodejs

### DIFF
--- a/images/openshift-base-nodejs.yml
+++ b/images/openshift-base-nodejs.yml
@@ -38,3 +38,6 @@ labels:
 name: openshift/base-nodejs
 owners:
 - aos-team-art@redhat.com
+konflux:
+  # Until this thread (https://redhat-internal.slack.com/archives/GDBRP5YJH/p1734124941864459) is resolved
+  mode: disabled


### PR DESCRIPTION
Since we don't want to retrigger builds continuously 