### PR TITLE
scan-sources:noop [konflux] disable ose-installer-etcd-artifacts

### DIFF
--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -59,6 +59,8 @@ external_scanners:
     jira_integration:
       enabled: false
 konflux:
+  # Until https://github.com/openshift/etcd/pull/298 is merged
+  mode: disabled
   content:
     source:
       dockerfile: Dockerfile.installer.art-cachi2


### PR DESCRIPTION
Disabling until upstream issue is fixed