### PR TITLE
scan-sources:noop [konflux] disable openshift-kubernetes-nmstate-ope

### DIFF
--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -36,3 +36,6 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+konflux:
+  # Since no green build exists for parent nmstate-console-plugin (since its disabled)
+  mode: disabled


### PR DESCRIPTION
Since parent is disabled and no green build exists