### PR TITLE
enable repos for ose-installer-etcd-artifacts

### DIFF
--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -35,6 +35,9 @@ content:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-installer-etcd-artifacts-container
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 for_payload: false
 for_release: false
 from:


### PR DESCRIPTION
needed for konflux
```
[build] Error: There are no enabled repositories in "/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d".
[build] subprocess exited with status 1
[build] subprocess exited with status 1
[build] Error: building at STEP "RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*": exit status 1
```
https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-17/pipelineruns/ose-4-17-ose-installer-etcd-artifacts-2cp7b/logs