### PR TITLE
Re-enable cluster-resource-override-operator build for 4.19

### DIFF
--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
Now that https://github.com/openshift/cluster-resource-override-admission-operator/pull/174 is merged, hopefully we get cluster-resource-override-operator 4.19 builds again.