### PR TITLE
stop using rt repo for DTK

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -27,9 +27,6 @@ enabled_repos:
 - rhel-9-server-ose-rpms-embargoed
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
-- rhel-9-rt-rpms
 for_payload: true
 from:
   member: openshift-enterprise-base-rhel9


### PR DESCRIPTION
kernel-rt becomes a sub package since 9.3 in embargoed plashet repo path like https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.17/stream/el9-embargoed/latest/x86_64/os/Packages/kernel-5.14.0-427.50.1.el9_4__x86_64__fd431d51/
in 4.17.8 DTK installed kernel from rhel-9-baseos-rpms and installed kernel-rt from rhel-9-rt-rpms, the kernel-rt from rhel-9-rt-rpms is not the latest

context link https://redhat-internal.slack.com/archives/CB95J6R4N/p1733927479635069