### PR TITLE
Allow child images to add repos

### DIFF
--- a/ci_images/dnf_wrapper.sh
+++ b/ci_images/dnf_wrapper.sh
@@ -12,7 +12,8 @@
 # 1. If the container is running as a build in OCP Test Platform, RPMs are obtained through the RPM mirroring service available in CI.
 # 2. If the container is being run on an engineer's system with "podman build ...", then RPMs can be obtained from hosts accessible via the Red Hat VPN.
 # 3. If the script is run with the ART_DNF_WRAPPER_POLICY environment variable set to "skip", then the base image repositories will be used (host must have subscription to access RHEL content).
-# This script detects which mode is being used at runtime and installs different repository files in /etc/yum.repos.d depending on the mode.
+# This script detects which mode is being used at runtime and uses dnf's "repodir" search path option to change which repo files
+# dnf will search.
 # When running as a pod in a CI build, the content RPM mirror serves RPMs sourced
 # from backends like mirror.openshift.com/enterprise and the Red Hat CDN.
 # The backends are configured in configuration files like:
@@ -47,6 +48,7 @@ fi
 # from our default repo installation logic. Allow them to override
 # the behavior.
 # "default" - Install RPM service repos if running in pod. Install VPN repos if not.
+# "append" - Do not remove base image .repo files from dnf runs - only add ART repos based on invocation context.
 # "skip" - Leave base image repositories intact.
 ART_DNF_WRAPPER_POLICY="${ART_DNF_WRAPPER_POLICY:-default}"
 
@@ -54,6 +56,7 @@ if [[ "${ART_DNF_WRAPPER_POLICY}" == "skip" ]]; then
   SKIP_REPO_INSTALL="1"
 else
   SKIP_REPO_INSTALL="0"
+  INCLUDE_BASE_IMAGE_REPOS="0"
 
   if [[ -f "/tmp/tls-ca-bundle.pem" ]]; then
     # This PEM is copied into place for a brew build. We never want to affect
@@ -69,55 +72,86 @@ else
     echoerr "OPENSHIFT_CI != true, so not executing in the expected environment - no repos will be changed."
   fi
 
+  if [[ "${ART_DNF_WRAPPER_POLICY}" == "append" ]]; then
+    INCLUDE_BASE_IMAGE_REPOS="1"
+  fi
+
 fi
 
 # Container hostnames will differ every run, so this helps ensure we try
 # to acquire repo context whenever we start a new instance of the image
 # even if /tmp is shared between containers.
-FIRST_RUN_MARKER="/tmp/first-dnf-wrapper-run-$(hostname)"
+WRAPPER_MODE_MARKER="/tmp/first-dnf-wrapper-run-$HOSTNAME"
 
 # If we install repos appropriate for CI builds, they will reside here.
-ART_REPOS_PREFIX="/etc/yum.repos.d/art-rpm"
-CI_RPM_REPO_DEST="${ART_REPOS_PREFIX}-ci-svc-repos.repo"
-VPN_RPM_REPO_DEST="${ART_REPOS_PREFIX}-rh-vpn-repos.repo"
-
-if [[ ! -f "${FIRST_RUN_MARKER}" && "${SKIP_REPO_INSTALL}" == "0" ]]; then
-  rm -rf /etc/yum.repos.d/*
-
-  # When not running in CI (e.g. if an engineer is running a local docker build on a Dockerfile)
-  # we can try to use repos available within the Red Hat firewall. They are not meant for
-  # use in a CI pod, but allow engineers to access RHEL content/plashet content if they are connected
-  # to the VPN. INSTALL_ART_RH_VPN_REPOS will remain at "1" if we should install these VPN repos.
-  # If we instead find that the CI_RPM_SVC is available (this should be true only if
-  # we are running as a pod in OCP Test Platform CI, the VPN repos will not be installed.
-  INSTALL_ART_RH_VPN_REPOS="1"
-  echoerr "Checking for CI build pod repo definitions..."
-  for (( i=1; i<=5; i++ )); do
-    if curl --fail "${CI_RPM_SVC}" 2> /dev/null > ${CI_RPM_REPO_DEST}; then
-      echoerr "Installed CI build pod repo definitions from ${CI_RPM_SVC}..."
-      INSTALL_ART_RH_VPN_REPOS="0"
-      break
-    fi
-    rm -f "${CI_RPM_REPO_DEST}"
-    sleep 1
-  done
-
-  if [[ "${INSTALL_ART_RH_VPN_REPOS}" == "1" ]]; then
-    echoerr "Did not detect that this script is running in a CI build pod. Will not install CI repositories."
-    curl --fail --silent --location --retry 5 --retry-delay 2 --output /etc/pki/ca-trust/source/anchors/IT-Root-CAs.pem https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
-    update-ca-trust extract
-    cp "${DNF_WRAPPER_DIR}/unsigned.repo" "${VPN_RPM_REPO_DEST}"
-    echoerr "Installed repos that can be used when connected to the VPN."
-  fi
-
-  touch "${FIRST_RUN_MARKER}"
-fi
+CI_RPM_REPO_DEST="${ART_REPOS_DIR_CI}/ci-svc-repos.repo"
+VPN_RPM_REPO_DEST="${ART_REPOS_DIR_LOCALDEV}/rh-vpn-repos.repo"
 
 EXTRA_DNF_ARGS=""
-if ls "${ART_REPOS_PREFIX}"* 1> /dev/null 2>&1; then
-  # If any ART repo files were populated, eliminate extraneous warnings by
-  # disabling RH subscription manager plugin.
-  EXTRA_DNF_ARGS="--disableplugin=subscription-manager"
+
+if [[ "${SKIP_REPO_INSTALL}" == "0" ]]; then
+  WRAPPER_MODE="unknown"
+
+  if [[ ! -f "${WRAPPER_MODE_MARKER}" ]]; then
+    # When not running in CI (e.g. if an engineer is running a local docker build on a Dockerfile)
+    # we can try to use repos available within the Red Hat firewall. They are not meant for
+    # use in a CI pod, but allow engineers to access RHEL content/plashet content if they are connected
+    # to the VPN. INSTALL_ART_RH_VPN_REPOS will remain at "1" if we should install these VPN repos.
+    # If we instead find that the CI_RPM_SVC is available (this should be true only if
+    # we are running as a pod in OCP Test Platform CI, the VPN repos will not be installed.
+    INSTALL_ART_RH_VPN_REPOS="1"
+    echoerr "Checking for CI build pod repo definitions..."
+    for (( i=1; i<=5; i++ )); do
+      if curl --fail "${CI_RPM_SVC}" 2> /dev/null > "${CI_RPM_REPO_DEST}"; then
+        WRAPPER_MODE="ci"
+        INSTALL_ART_RH_VPN_REPOS="0"
+        echoerr "Installed CI build pod repo definitions from ${CI_RPM_SVC}."
+        break
+      fi
+      rm -f "${CI_RPM_REPO_DEST}"
+      sleep 1
+    done
+
+    if [[ "${INSTALL_ART_RH_VPN_REPOS}" == "1" ]]; then
+      echoerr "Did not detect that this script is running in a CI build pod. Will not install CI repositories."
+      curl --fail --silent --location --retry 5 --retry-delay 2 --output /etc/pki/ca-trust/source/anchors/IT-Root-CAs.pem https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
+      update-ca-trust extract
+      cp "${DNF_WRAPPER_DIR}/unsigned.repo" "${VPN_RPM_REPO_DEST}"
+      WRAPPER_MODE="localdev"
+      echoerr "Installed repos that can be used when connected to the VPN."
+    fi
+
+    # Store the mode in the marker file
+    echo "${WRAPPER_MODE}" > "${WRAPPER_MODE_MARKER}"
+  else
+    # Otherwise, the marker exists. Read the current mode.
+    WRAPPER_MODE=$(cat "${WRAPPER_MODE_MARKER}")
+  fi
+
+  DNF_OPTS_REPOSDIR=""
+  if [[ "${WRAPPER_MODE}" == "ci" ]]; then
+    # If in CI mode, include the ci reposdir in the dnf search path
+    DNF_OPTS_REPOSDIR="${ART_REPOS_DIR_CI}"
+  elif [[ "${WRAPPER_MODE}" == "localdev" ]]; then
+    # If in localdev mode, include the localdev reposdir in the dnf search path
+    DNF_OPTS_REPOSDIR="${ART_REPOS_DIR_LOCALDEV}"
+  fi
+
+  if [[ "${DNF_OPTS_REPOSDIR}" != "" ]]; then
+    if [[ "${INCLUDE_BASE_IMAGE_REPOS}" == "1" ]]; then
+      DNF_OPTS_REPOSDIR="${DNF_OPTS_REPOSDIR},/etc/yum.repos.d"
+    else
+      # If any ART repos files were populated and we are ignoring
+      # base image repos, eliminate extraneous warnings by
+      # disabling RH subscription manager plugin.
+      EXTRA_DNF_ARGS="${EXTRA_DNF_ARGS} --disableplugin=subscription-manager"
+    fi
+
+    # Set the repo file search path for DNF
+    EXTRA_DNF_ARGS="${EXTRA_DNF_ARGS} --setopt=reposdir=${DNF_OPTS_REPOSDIR}"
+    echoerr "DNF will search for repo files in: ${DNF_OPTS_REPOSDIR}"
+  fi
+
 fi
 
 $0.real ${EXTRA_DNF_ARGS} "$@"

--- a/ci_images/install_dnf_wrapper.sh
+++ b/ci_images/install_dnf_wrapper.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 set -euxo pipefail
 
-# DNF_WRAPPER_DIR is set in the Dockerfile for the image.
+# DNF_WRAPPER_DIR and other env vars are set in the Dockerfile for the image.
+# Ensure they are set.
+
+if [[ -z "${DNF_WRAPPER_DIR:-}" || -z "${ART_REPOS_DIR_CI}" || -z "${ART_REPOS_DIR_LOCALDEV}" ]]; then
+  echo "One or more environment variables are not set by Dockerfile ENV. Exiting since environment is not expected."
+  exit 1
+fi
+
 mkdir -p "${DNF_WRAPPER_DIR}"
+
+# Create directories where .repo files can be stored for dnf_wrapper.sh's use.
+mkdir -p "${ART_REPOS_DIR_CI}"
+mkdir -p "${ART_REPOS_DIR_LOCALDEV}"
 
 wrap_command() {
   local command_name="$1"

--- a/ci_images/rhel-8/ci-openshift-base/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-base/Dockerfile
@@ -10,6 +10,11 @@ RUN chmod 777 /etc/yum.repos.d/
 
 # Install the dnf/yum wrapper that will work for CI workloads.
 ENV DNF_WRAPPER_DIR=/bin/dnf_wrapper
+
+# Directories relevant to dnf_wrapper.sh
+ENV ART_REPOS_DIR_CI="/etc/yum.repos.art/ci"
+ENV ART_REPOS_DIR_LOCALDEV="/etc/yum.repos.art/localdev"
+
 ADD ci_images/dnf_wrapper.sh /tmp
 ADD ci_images/install_dnf_wrapper.sh /tmp
 RUN chmod +x /tmp/*.sh && \

--- a/ci_images/rhel-9/ci-openshift-base/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-base/Dockerfile
@@ -10,6 +10,11 @@ RUN chmod 777 /etc/yum.repos.d/
 
 # Install the dnf/yum wrapper that will work for CI workloads.
 ENV DNF_WRAPPER_DIR=/bin/dnf_wrapper
+
+# Directories relevant to dnf_wrapper.sh
+ENV ART_REPOS_DIR_CI="/etc/yum.repos.art/ci"
+ENV ART_REPOS_DIR_LOCALDEV="/etc/yum.repos.art/localdev"
+
 ADD ci_images/dnf_wrapper.sh /tmp
 ADD ci_images/install_dnf_wrapper.sh /tmp
 RUN chmod +x /tmp/*.sh && \


### PR DESCRIPTION
The previous version of this script removed all files from /etc/yum.repos.d and reinitialized content in that directory based on execution context (e.g. running in CI vs localdev mode).

This prevents child images from installing other repos that might be relevant to CI or local development.

The new approach manages only the DNF "reposdir" option to alter which directories in the image are searched for .repo files.

Child images can store .repo files in /etc/yum.repos.art/ci and they will be used during CI context builds or /etc/yum.repos.art/localdev and they will be used in the localdev context.