### PR TITLE
update valid-subscription-label for pf-status-relay-operator

### DIFF
--- a/images/pf-status-relay-operator.yml
+++ b/images/pf-status-relay-operator.yml
@@ -30,4 +30,4 @@ update-csv:
   bundle-dir: 'stable/'
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
-  valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+  valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
To fix failed CVP [test](http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/pf-status-relay-operator-bundle-container-v4.18.0.202412131108.p0.g1c649ad.assembly.stream.el9-1/9693e891-715b-46d9-b59f-fbdd25510456/operator-valid-subscriptions-bundle-image-output.txt)

```
[INVALID] 'openshift4/pf-status-relay-operator-bundle' subscription type: OCP and up
 -> The annotation must contain: 'OpenShift Container Platform', 'OpenShift Platform Plus', but not contain: 'OpenShift Kubernetes Engine'
````

ref [thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1736535516497769?thread_ts=1721917527.586489&cid=CB95J6R4N)
