### PR TITLE
Fix non-x86 arches for rhel-96-nfv

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -520,9 +520,9 @@ repos:
     conf:
       baseurl:
         x86_64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/NFV/x86_64/os
-        aarch64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/NFV/x86_64/os
-        ppc64le: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/NFV/x86_64/os
-        s390x: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/NFV/x86_64/os
+        aarch64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/NFV/aarch64/os
+        ppc64le: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/NFV/ppc64le/os
+        s390x: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.6/compose/NFV/s390x/os
       extra_options:
         gpgcheck: "1"
     content_set:


### PR DESCRIPTION
This commit fixes the arches for rhel-96-nfv accidentally changed in https://github.com/openshift-eng/ocp-build-data/pull/5999/files.