### PR TITLE
[konflux] ironic reset network mode

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -43,7 +43,6 @@ payload_name: ironic
 owners:
 - ironic-osp-owners@redhat.com
 konflux:
-  network_mode: internal-only
   cachito:
     # Right now art-tools comments out lines with REMOTE_SOURCES_DIR as a temporary fix to cachito
     # But this image has indirect references to the env variable, which breaks builds.


### PR DESCRIPTION
Since hermetic builds are not a priority for now, switching back to open, to unblock build sync.