### PR TITLE
scan-sources:noop [4.19] re-enable installer-artifacts for Konflux

### DIFF
--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -33,7 +33,5 @@ payload_name: installer-artifacts
 owners:
 - aos-install@redhat.com
 konflux:
-  # Until https://issues.redhat.com/browse/ART-11563 is resolved
-  mode: disabled
   vm_override:
     aarch64: linux-d160/arm64


### PR DESCRIPTION
Looks like [ART-11563](https://issues.redhat.com/browse/ART-11563) is resolved, test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/3291/parameters/