### PR TITLE
scan-sources:noop [4.19][konflux] fix enabled repos for DTK

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -40,3 +40,11 @@ name: openshift/ose-driver-toolkit-rhel9
 payload_name: driver-toolkit
 owners:
 - edge-sro@redhat.com
+konflux:
+  enabled_repos:
+  - rhel-9-server-ose-rpms-embargoed
+  - rhel-9-baseos-rpms
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+  - rhel-9-appstream-rpms
+  - rhel-9-rt-rpms


### PR DESCRIPTION
https://github.com/openshift-eng/ocp-build-data/pull/5999 broke DTK builds for Konflux. By replacing the konflux config stanza for `enabled_repos` with the old values, the builds succeed.
Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/3339/console

Needs https://github.com/openshift-eng/art-tools/pull/1314

Ref. https://issues.redhat.com/browse/ART-11911