### PR TITLE
[4.19] unpin dtk

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -114,8 +114,3 @@ releases:
                 exempt_rpms:
                   - redhat-release* # documents rhel release notes and concerns
                   - tzdata
-          - distgit_key: driver-toolkit
-            why: Pin to existing rhcos build to match kernel
-            metadata:
-              is:
-                nvr: driver-toolkit-container-v4.19.0-202501301107.p0.g81c6fa2.assembly.stream.el9


### PR DESCRIPTION
RHCOS has a newer kernel now, DTK should probably float to match it