### PR TITLE
Revert "Add assembly 4.15.45"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -2,12 +2,12 @@ releases:
   4.15.45:
     assembly:
       basis:
-        brew_event: 62441478
+        brew_event: 62417654
         reference_releases:
-          aarch64: 4.15.0-0.nightly-arm64-2025-02-06-110033
-          ppc64le: 4.15.0-0.nightly-ppc64le-2025-02-06-110032
-          s390x: 4.15.0-0.nightly-s390x-2025-02-06-110032
-          x86_64: 4.15.0-0.nightly-2025-02-06-020928
+          aarch64: 4.15.0-0.nightly-arm64-2025-02-04-013508
+          ppc64le: 4.15.0-0.nightly-ppc64le-2025-02-04-013509
+          s390x: 4.15.0-0.nightly-s390x-2025-02-04-013508
+          x86_64: 4.15.0-0.nightly-2025-02-03-164127
       group:
         advisories:
           extras: 145614


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#6064
Newer nightly has fixes that corresponding 4.16 release cut today does not,
so revert to older 4.15 nightly we selected.

https://redhat-internal.slack.com/archives/C05FEGT8SH2/p1738858463249309?thread_ts=1738856739.237459&cid=C05FEGT8SH2