### PR TITLE
[4.19] temporarily allow RHCOS RPM inconsistencies

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -105,6 +105,10 @@ releases:
           component: openshift-clients
         - code: CONFLICTING_GROUP_RPM_INSTALLED
           component: local-storage-mustgather
+        # RHCOS extensions temporarily use inconsistent RPMs between arches.
+        # ref. https://redhat-internal.slack.com/archives/C01CQA76KMX/p1738863088399379
+        - code: INCONSISTENT_RHCOS_RPMS
+          component: rhcos
       members:
         images:
           - distgit_key: '*'


### PR DESCRIPTION
RHCOS extensions temporarily use inconsistent RPMs between arches. allow this for now.

ref. https://redhat-internal.slack.com/archives/C01CQA76KMX/p1738863088399379

trying it out [here](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/14595/console)