### PR TITLE
Turn on cachito emulation for ironic-agent Konflux builds

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -40,4 +40,5 @@ enabled_repos:
 - rhel-9-codeready-builder-rpms
 - rhel-9-server-ironic-rpms
 konflux:
-  mode: disabled # https://issues.redhat.com/browse/ART-11792
+  cachito:
+    emulation: true


### PR DESCRIPTION
The ironic-agent upstream has a Dockerfile that explicitly references variables defined by cachito. Konflux's cachi2 does not have these variables defined. doozer will inject them if cachito emulation mode is enabled.