### PR TITLE
[konflux] ppc VM with bigger disk space, s390x

### DIFF
--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -35,3 +35,5 @@ owners:
 konflux:
   vm_override:
     aarch64: linux-d160/arm64
+    ppc64le: linux-d400-large/ppc64le
+    s390x: linux-large/s390x


### PR DESCRIPTION
ose-installer-artifacts requires higher disk space for its builds, for ppc. For s390x, using a bigger VM to shorten build times.