### PR TITLE
ec.1: temporarily disable openstack-resource-controller

### DIFF
--- a/images/openstack-resource-controller.yml
+++ b/images/openstack-resource-controller.yml
@@ -1,3 +1,4 @@
+mode: disabled  # temporarily disabled for ec.1
 content:
   source:
     dockerfile: Dockerfile.rhel


### PR DESCRIPTION
This image doesn't exist in ec.1