### PR TITLE
rc.8 pre-release

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -12,7 +12,7 @@ releases:
           metadata: 138190
           microshift: 138191
           rpm: 138193
-          advance: 145676
+          prerelease: -1
         release_jira: ART-10610
         upgrades: 4.17.11,4.17.12,4.17.13,4.17.14,4.17.15,4.17.16,4.18.0-ec.3,4.18.0-ec.4,4.18.0-rc.0,4.18.0-rc.1,4.18.0-rc.2,4.18.0-rc.3,4.18.0-rc.4,4.18.0-rc.5,4.18.0-rc.6
       members:


### PR DESCRIPTION
Telco only requires the kube-rbac build to be prod, which happens when we push out a pre-release. Advance release is for the bundles themselves, which does not need to be shipped out.