### PR TITLE
Dynamic removal of cachito references to REMOTE_SOURCES

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -47,3 +47,5 @@ konflux:
     x86_64: linux-d160-m2xlarge/amd64
     aarch64: linux-d160-m2xlarge/arm64
     s390x: linux-large/s390x
+  cachito:
+    mode: removal


### PR DESCRIPTION
The console image builds fine with commenting out cachito specific env vars.