### PR TITLE
Revert "OPRUN-3711: OLMv1: Get catalogd image from operator-controller repo"

### DIFF
--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -1,11 +1,11 @@
 content:
   source:
-    dockerfile: openshift/catalogd.Dockerfile
+    dockerfile: openshift/Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/operator-framework-operator-controller.git
-      web: https://github.com/openshift/operator-framework-operator-controller
+      url: git@github.com:openshift-priv/operator-framework-catalogd.git
+      web: https://github.com/openshift/operator-framework-catalogd
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#6027 to prepare ec.1 Errata.
Will get it back once the advisories are prepared.