### PR TITLE
[konflux] monitoring-plugin cachito comment out

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -38,3 +38,6 @@ name: openshift/ose-monitoring-plugin-rhel9
 payload_name: monitoring-plugin
 owners:
 - team-observability-ui@redhat.com
+konflux:
+  cachito:
+    mode: removal


### PR DESCRIPTION
Was failing due to 
```
Error: building at STEP "RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; 
```

Successful run: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-19/pipelineruns/ose-4-19-monitoring-plugin-r64lc