### PR TITLE
[konflux] disable kuryr images in 4.12

### DIFF
--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -39,3 +39,6 @@ name: openshift/ose-kuryr-cni
 owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
+konflux:
+  # Stuck in infinite rebuild
+  mode: disabled

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -33,3 +33,6 @@ name: openshift/ose-kuryr-controller
 owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
+konflux:
+  # Stuck in infinite rebuild
+  mode: disabled


### PR DESCRIPTION
Stuck in infinite rebuild

Ref [thread](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1736264134036469)