### PR TITLE
Fix ci build root stream

### DIFF
--- a/images/openstack-resource-controller.yml
+++ b/images/openstack-resource-controller.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openstack-resource-controller-container


### PR DESCRIPTION
Fix stream to the one that exists and should be used

Failure first seen at https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/scheduled-builds/job/sync-ci-images/32349/

```
raise IOError(f"Unable to find definition for stream '{stream_name}'")
OSError: Unable to find definition for stream 'rhel-9-golang-ci-build-root'
```