### PR TITLE
linuxptp-daemon: Update dockerfile path

### DIFF
--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -4,7 +4,7 @@ arches:
 - ppc64le
 content:
   source:
-    dockerfile: Dockerfile.art
+    dockerfile: addons/redhat/Dockerfile.ocp
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
ART Dockerfile was recently moved (https://github.com/openshift/linuxptp-daemon/pull/402/commits/5c0fc1c44ab2dc810ab802b00d6288f6d037edb8) to https://github.com/openshift/linuxptp-daemon/blob/release-4.19/addons/redhat/Dockerfile.ocp

This is causing the rebase to fail https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/14904/consoleFull