### PR TITLE
OSDOCS-11376-414: updates release note link for MicroShift 4.14

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -113,16 +113,15 @@ boilerplates:
 
       <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHSA-2023:1234
 
-      All of the bug fixes may not be documented in this advisory. Read the following release notes documentation for details about these changes:
+      Read the following release notes documentation for details about changes with this release:
 
-      https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14/html/release_notes/index
-
+      https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.14/html/release_notes/index
 
       All Red Hat build of MicroShift 4.14 users are advised to use these updated packages and images when they are available in the RPM repository.
     solution: |
-      For MicroShift 4.14, read the following documentation, which will be updated shortly for this release, for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
+      For MicroShift 4.14, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
 
-      https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14/html/release_notes/index
+      https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.14/html/release_notes/index
   cve:
     synopsis: OpenShift Container Platform 4.14.z security update
     topic: |


### PR DESCRIPTION
Issue:
https://issues.redhat.com/browse/OSDOCS-13376

The documentation has moved to docs.redhat.com; this PR updates the link in the Errata.