### PR TITLE
Revert "[konflux] disable kuryr images in 4.12"

### DIFF
--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -39,6 +39,3 @@ name: openshift/ose-kuryr-cni
 owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
-konflux:
-  # Stuck in infinite rebuild
-  mode: disabled

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -33,6 +33,3 @@ name: openshift/ose-kuryr-controller
 owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
-konflux:
-  # Stuck in infinite rebuild
-  mode: disabled


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#6088

scan-sources bug fixed with https://github.com/openshift-eng/art-tools/pull/1359