### PR TITLE
Revert "4.18.0: pin rpm-ostree rpm"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -26,9 +26,6 @@ releases:
             - why: for CVE fixes
               non_gc_tag: rhaos-4.18-ironic-rhel-9
               el9: python-zipp-3.19.1-1.el9
-            - why: for RHCOS
-              non_gc_tag: rhel-9.4.0-z
-              el9: rpm-ostree-2024.3-6.el9_4
   rc.10:
     assembly:
       basis:


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#6156

rpm-ostree-2024.3-6.el9_4 has been shipped in RHEL.