### PR TITLE
[konflux] cli-artifacts use d320 VMs

### DIFF
--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -30,7 +30,7 @@ owners:
 - aos-master@redhat.com
 konflux:
   vm_override:
-    x86_64: linux-d160-c4xlarge/amd64
-    aarch64: linux-d160-c4xlarge/arm64
-    s390x: linux-largecpu/s390x
-    ppc64le: linux-largecpu/ppc64le
+    x86_64: linux-d320-c4xlarge/amd64
+    aarch64: linux-d320-c4xlarge/arm64
+    s390x: linux-d320-largecpu/s390x
+    ppc64le: linux-d320-largecpu/ppc64le


### PR DESCRIPTION
Image build was failing with insufficient storage