### PR TITLE
[konflux] ose-cli-artifacts IBM flavor update

### DIFF
--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -32,5 +32,5 @@ konflux:
   vm_override:
     x86_64: linux-d320-c4xlarge/amd64
     aarch64: linux-d320-c4xlarge/arm64
-    s390x: linux-d320-largecpu/s390x
-    ppc64le: linux-d320-largecpu/ppc64le
+    s390x: linux-largecpu/s390x
+    ppc64le: linux-largecpu/ppc64le


### PR DESCRIPTION
IBM arches doesn't seem to need the increased disk space