### PR TITLE
Update bug mapping for Secrets Store CSI driver images

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -821,13 +821,13 @@ bug_mapping:
     ose-sdn-container:
       issue_component: Networking / openshift-sdn
     ose-secrets-store-csi-driver-container:
-      issue_component: Storage
+      issue_component: Secrets Store CSI driver
     ose-secrets-store-csi-driver-operator-bundle-container:
-      issue_component: Storage / Operators
+      issue_component: Secrets Store CSI driver
     ose-secrets-store-csi-driver-operator-container:
-      issue_component: Storage / Operators
+      issue_component: Secrets Store CSI driver
     ose-secrets-store-csi-mustgather-container:
-      issue_component: Storage
+      issue_component: Secrets Store CSI driver
     ose-service-ca-operator-container:
       issue_component: service-ca
     ose-smb-csi-driver-container:


### PR DESCRIPTION
This PR updates the bug mapping for Secrets Store CSI driver images.
ref: [DPP-16392](https://issues.redhat.com/browse/DPP-16392)