### PR TITLE
[4.19] secrets-store-csi-driver: update owners alias

### DIFF
--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -28,7 +28,7 @@ from:
 name: openshift/ose-secrets-store-csi-driver-rhel9-operator
 name_in_bundle: secrets-store-csi-driver-operator # name in image reference
 owners:
-- aos-storage-staff@redhat.com
+- secrets-store-csi-driver-oap-staff@redhat.com
 update-csv:
   bundle-dir: 'stable/'
   manifests-dir: config/manifests/

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -33,4 +33,4 @@ from:
 name: openshift/ose-secrets-store-csi-driver-rhel9
 name_in_bundle: secrets-store-csi-driver-container
 owners:
-- aos-storage-staff@redhat.com
+- secrets-store-csi-driver-oap-staff@redhat.com

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -28,4 +28,4 @@ from:
   member: ose-must-gather
 name: openshift/ose-secrets-store-csi-mustgather-rhel9
 owners:
-- aos-storage-staff@redhat.com
+- secrets-store-csi-driver-oap-staff@redhat.com


### PR DESCRIPTION
We are transferring ownership of the secrets-store csi driver and operator to the OAP team.
This PR updates the alias for the new image owners.

/cc @arkadeepsen
