### PR TITLE
Revert "ART-11740: 4.18: remove ovirt-machine-controllers"

### DIFF
--- a/images/ose-ovirt-machine-controllers.yml
+++ b/images/ose-ovirt-machine-controllers.yml
@@ -1,0 +1,28 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhel
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/cluster-api-provider-ovirt.git
+      web: https://github.com/openshift/cluster-api-provider-ovirt
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-9-golang-ci-build-root
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ose-ovirt-machine-controllers-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-ovirt-machine-controllers
+for_payload: true
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-ovirt-machine-controllers-rhel9
+payload_name: ovirt-machine-controllers
+owners:
+- rgolan@redhat.com


### PR DESCRIPTION
This reverts commit d55a2b563a568b011cbbd6e82eb08097c15066bf.