### PR TITLE
[konflux] restrict arches to x86,arm

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -39,7 +39,6 @@ arches:
 konflux:
   arches:
   - x86_64
-  - s390x
   - aarch64
 
 multi_arch:


### PR DESCRIPTION
Until IBM arches are reliable again