### PR TITLE
Enabling rebase tagging for impacted images

### DIFF
--- a/images/ose-cluster-autoscaler-operator.yml
+++ b/images/ose-cluster-autoscaler-operator.yml
@@ -25,3 +25,5 @@ name: openshift/ose-cluster-autoscaler-rhel9-operator
 payload_name: cluster-autoscaler-operator
 owners:
 - aos-cloud@redhat.com
+konflux:
+  tagging_mode: enabled

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -25,3 +25,5 @@ name: openshift/ose-machine-api-rhel9-operator
 payload_name: machine-api-operator
 owners:
 - aos-cloud@redhat.com
+konflux:
+  tagging_mode: enabled

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -28,3 +28,5 @@ name: openshift/ose-machine-api-provider-aws-rhel9
 payload_name: aws-machine-controllers
 owners:
 - aos-cloud@redhat.com
+konflux:
+  tagging_mode: enabled

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -28,3 +28,5 @@ name: openshift/ose-machine-api-provider-azure-rhel9
 payload_name: azure-machine-controllers
 owners:
 - aos-cloud@redhat.com
+konflux:
+  tagging_mode: enabled

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -29,3 +29,5 @@ name: openshift/ose-machine-api-provider-gcp-rhel9
 payload_name: gcp-machine-controllers
 owners:
 - aos-cloud@redhat.com
+konflux:
+  tagging_mode: enabled

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -26,3 +26,5 @@ name: openshift/ose-machine-api-provider-openstack-rhel9
 payload_name: openstack-machine-api-provider
 owners:
 - aos-cloud@redhat.com
+konflux:
+  tagging_mode: enabled


### PR DESCRIPTION
Example: https://github.com/openshift/cluster-autoscaler-operator/blob/227f7537c3b459d4940522809df60b2dfca738ed/Makefile#L5-L6 is checked for semver compliance at runtime.