### PR TITLE
update ose-alibaba-cloud-csi-driver replace

### DIFF
--- a/images/ose-alibaba-cloud-csi-driver.yml
+++ b/images/ose-alibaba-cloud-csi-driver.yml
@@ -19,7 +19,7 @@ content:
       # Konflux build fails because it's building on detached mode (since it doesn't fetch the branch and just the commit)
       # https://github.com/openshift/alibaba-cloud-csi-driver/blob/master/build/build-all-amd.sh#L26
       - action: replace
-        match: "RUN build/build-all-amd.sh noimage"
+        match: "RUN build/build-all.sh noimage"
         replacement: "RUN git checkout -b rhaos-{MAJOR}.{MINOR}-rhel8 && build/build-all-amd.sh noimage"
 enabled_repos:
 - rhel-8-baseos-rpms


### PR DESCRIPTION
4.12 and 4.13 has a different script name: https://github.com/openshift/alibaba-cloud-csi-driver/blob/release-4.12/Dockerfile.openshift#L5