### PR TITLE
ART-12284: Update `nodejs-rhel9` to node 22

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -68,7 +68,7 @@ rhel9:
   mirror: false
 
 nodejs-rhel9:
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-18:1-98
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-1741637231
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true
 

--- a/streams.yml
+++ b/streams.yml
@@ -68,7 +68,7 @@ rhel9:
   mirror: false
 
 nodejs-rhel9:
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-1741637231
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-3
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-12284

/hold