### PR TITLE
[konflux] cachi2 disable group

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -15,6 +15,10 @@ compliance:
 arches:
 - x86_64
 
+konflux:
+  cachi2:
+    enabled: false
+
 multi_arch:
   enabled: false
 


### PR DESCRIPTION
Since multiple builds are failing in 4.12