### PR TITLE
Prune "bring your own RHEL"-rpms for 4.19

### DIFF
--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -15,8 +15,6 @@ name: openshift
 owners:
 - aos-master@redhat.com
 targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
 - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
 hotfix_targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
 - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix

--- a/rpms/ose-aws-ecr-image-credential-provider.yml
+++ b/rpms/ose-aws-ecr-image-credential-provider.yml
@@ -10,8 +10,6 @@ name: ose-aws-ecr-image-credential-provider
 owners:
 - aos-cloud-staff@redhat.com
 targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
 - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
 hotfix_targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
 - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix

--- a/rpms/ose-azure-acr-image-credential-provider.yml
+++ b/rpms/ose-azure-acr-image-credential-provider.yml
@@ -11,8 +11,6 @@ owners:
 - aos-cloud-staff@redhat.com
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
-- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
 hotfix_targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
-- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
 

--- a/rpms/ose-gcp-gcr-image-credential-provider.yml
+++ b/rpms/ose-gcp-gcr-image-credential-provider.yml
@@ -11,8 +11,6 @@ owners:
 - aos-cloud-staff@redhat.com
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
-- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
 hotfix_targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
-- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
 


### PR DESCRIPTION
4.19 is shipping without support for Bring Your Own RHEL8. This change stops to build non-client rpms into the rhel8 target.