### PR TITLE
ci build root images: No nobest

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -33,7 +33,7 @@ RUN set -euxo pipefail && \
     /tmp/install_etcd.sh "3.5.16"
 
 RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
-    dnf install -y --nobest $INSTALL_PKGS && \
+    dnf install -y $INSTALL_PKGS && \
     dnf clean all && \
     touch /os-build-image && \
     git config --system user.name origin-release-container && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -33,7 +33,7 @@ RUN set -euxo pipefail && \
     /tmp/install_etcd.sh "3.5.16"
 
 RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build rpmdevtools selinux-policy-devel" && \
-    dnf install -y --nobest $INSTALL_PKGS && \
+    dnf install -y $INSTALL_PKGS && \
     dnf clean all && \
     touch /os-build-image && \
     git config --system user.name origin-release-container && \


### PR DESCRIPTION
With `--nobest`, packages that are explicitly being installed, but where an outdated version is already installed, will not see an upgrade. This causes problems for packages that are available on, say, x86_64, but not on one of the other arches. The OSBS plugin that checks for consistent RPMs across the arches will fail the build.

This PR says: _Do better, dnf!_