### PR TITLE
ART-12402: Stop 4.20 automation

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,7 +4,7 @@
 #   - weekdays: always allow manual builds; forbid scheduled builds from Monday to Friday
 #   - no|false: always allow builds
 # Note that ocp4 builds are always permitted  for non-stream assemblies
-freeze_automation: scheduled
+freeze_automation: true
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
Working on "[ART-12402](https://issues.redhat.com//browse/ART-12402): Make early build of go1.24 available to CI"