### PR TITLE
[konflux] 4.19 disable cachi2

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -40,8 +40,6 @@ konflux:
   arches:
   - x86_64
   - aarch64
-  cachi2:
-    enabled: true
 
 multi_arch:
   enabled: true


### PR DESCRIPTION
Seeing new build failures