### PR TITLE
cluster-update-keys: use Dockerfile for OKD, not Dockerfile.rhel

### DIFF
--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -14,6 +14,8 @@ content:
         - backport-risk-assessed
         - bugzilla/valid-bug
         - cherry-pick-approved
+    okd_alignment:
+      dockerfile: Dockerfile
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-update-keys-container


### PR DESCRIPTION
The okd_alignment was missing from this. add it back