### PR TITLE
OAPE-35: [openshift-4.19] Add new requirements-build file for ansible-operator-plugins

### DIFF
--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -22,6 +22,7 @@ cachito:
       - requirements.txt
       requirements_build_files:
       - requirements-build.txt
+      - requirements-build1.txt
       - requirements-pre-build.txt
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9


### PR DESCRIPTION
- Add a new requirements-build file for ansible-operator-plugins
- Needed for https://github.com/openshift/ansible-operator-plugins/pull/37

https://issues.redhat.com//browse/OAPE-35