### PR TITLE
[openshift-4.20] Switch to 10.1 repos for CI

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -579,7 +579,7 @@ repos:
     reposync:
       enabled: true
 
-  rhel-101-nfv:
+  rhel-10-nfv:
     conf:
       baseurl:
         x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/NFV/x86_64/os

--- a/group.yml
+++ b/group.yml
@@ -593,7 +593,7 @@ repos:
     reposync:
       enabled: true
 
-  rhel-101-highavailability:
+  rhel-10-highavailability:
     conf:
       baseurl:
         x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/HighAvailability/x86_64/os

--- a/group.yml
+++ b/group.yml
@@ -551,7 +551,7 @@ repos:
       optional: true
     reposync:
       enabled: true
-  rhel-101-baseos:
+  rhel-10-baseos:
     conf:
       baseurl:
         x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os

--- a/group.yml
+++ b/group.yml
@@ -551,13 +551,13 @@ repos:
       optional: true
     reposync:
       enabled: true
-  rhel-100-baseos:
+  rhel-101-baseos:
     conf:
       baseurl:
-        x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/x86_64/os
-        aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/aarch64/os
-        ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/ppc64le/os
-        s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/BaseOS/s390x/os
+        x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os
+        aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/aarch64/os
+        ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/ppc64le/os
+        s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/s390x/os
       extra_options:
         gpgcheck: "1"
     content_set:
@@ -565,13 +565,13 @@ repos:
     reposync:
       enabled: true
 
-  rhel-100-appstream:
+  rhel-101-appstream:
     conf:
       baseurl:
-        x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os
-        aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os
-        ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os
-        s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/AppStream/x86_64/os
+        x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os
+        aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os
+        ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os
+        s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os
       extra_options:
         gpgcheck: "1"
     content_set:
@@ -579,13 +579,13 @@ repos:
     reposync:
       enabled: true
 
-  rhel-100-nfv:
+  rhel-101-nfv:
     conf:
       baseurl:
-        x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/NFV/x86_64/os
-        aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/NFV/aarch64/os
-        ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/NFV/ppc64le/os
-        s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/NFV/s390x/os
+        x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/NFV/x86_64/os
+        aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/NFV/aarch64/os
+        ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/NFV/ppc64le/os
+        s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/NFV/s390x/os
       extra_options:
         gpgcheck: "1"
     content_set:
@@ -593,13 +593,13 @@ repos:
     reposync:
       enabled: true
 
-  rhel-100-highavailability:
+  rhel-101-highavailability:
     conf:
       baseurl:
-        x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/HighAvailability/x86_64/os
-        aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/HighAvailability/aarch64/os
-        ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/HighAvailability/ppc64le/os
-        s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/HighAvailability/s390x/os
+        x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/HighAvailability/x86_64/os
+        aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/HighAvailability/aarch64/os
+        ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/HighAvailability/ppc64le/os
+        s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/HighAvailability/s390x/os
       extra_options:
         gpgcheck: "1"
     content_set:

--- a/group.yml
+++ b/group.yml
@@ -565,7 +565,7 @@ repos:
     reposync:
       enabled: true
 
-  rhel-101-appstream:
+  rhel-10-appstream:
     conf:
       baseurl:
         x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os


### PR DESCRIPTION
As a follow-up of https://github.com/openshift-eng/ocp-build-data/pull/6169.