### PR TITLE
Enable IBM arches

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -21,6 +21,8 @@ arches:
 konflux:
   arches:
   - x86_64
+  - ppc64le
+  - s390x
   - aarch64
   cachi2:
     enabled: false


### PR DESCRIPTION
At the request of konflux infra: https://redhat-internal.slack.com/archives/C06Q309QUDV/p1744211584812859?thread_ts=1744211222.760909&cid=C06Q309QUDV