### PR TITLE
Remove Unnecessary enabled_repos Definitions from Image Configs

### DIFF
--- a/images/local-storage-mustgather.yml
+++ b/images/local-storage-mustgather.yml
@@ -21,10 +21,6 @@ delivery:
   repo_name: ose-local-storage-mustgather
 dependents:
 - local-storage-operator
-enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
-- rhel-9-server-ose-rpms-embargoed
 for_payload: false
 from:
   member: ose-must-gather

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -18,10 +18,6 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-pod
-enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
-- rhel-9-codeready-builder-rpms
 for_payload: true
 from:
   builder:

--- a/images/openstack-resource-controller.yml
+++ b/images/openstack-resource-controller.yml
@@ -16,9 +16,6 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: openstack-resource-controller
-enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
 for_payload: true
 from:
   builder:

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -16,10 +16,6 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-installer
-enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
-- rhel-9-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -18,10 +18,6 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-secrets-store-csi-mustgather
-enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
-- rhel-9-server-ose-rpms-embargoed
 for_payload: false
 name_in_bundle: secrets-store-csi-mustgather
 from:

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -18,11 +18,6 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ovn-kubernetes-microshift
-enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
-- rhel-9-fast-datapath-rpms
-- rhel-9-server-ose-rpms-embargoed
 # Generally doozer scan-sources will detect all possible change factors automatically and trigger rebuilds.
 # However, certain images may consume RPMs in unexpected way that make it programmatically impossible to
 # detect they were used.


### PR DESCRIPTION
Reviewed all image definitions using [this script](https://gist.github.com/lgarciaaco/e9517b914ba7bff19382a274d727e474) and identified several enabled_repos blocks that are no longer required. This PR removes those redundant definitions to simplify and clean up the configuration.

The following build job was used to validate the changes:
🔗 [OCP4 Build Job #16784](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/16784/console)

All builds passed successfully with these changes.