### PR TITLE
Add `requirements-build1.txt` to `requirements_build_files` in `openshift-enterprise-ansible-operator.yml`

### DIFF
--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -22,6 +22,7 @@ cachito:
       - requirements.txt
       requirements_build_files:
       - requirements-build.txt
+      - requirements-build1.txt
       - requirements-pre-build.txt
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9


### PR DESCRIPTION
This PR updates the `requirements_build_files` stanza of `openshift-enterprise-ansible-operator.yml` by adding `requirements-build1.txt` to it. This is required as the build requirements of ansible-operator image now includes an additional build requirements file (https://github.com/openshift/ansible-operator-plugins/pull/40).