### PR TITLE
Add Sustaining ART members to owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,8 +10,14 @@ reviewers:
 - ashwindasr
 - mbiarnes
 - lgarciaaco
-- rayfordj
 - germanparente
+- rayfordj
+- san7ket
+- jkaurredhat
+- shannon
+- namansharma18899
+- rhdmalone
+- tonyxrmdavidson
 approvers:
 - sosiouxme
 - jupierce
@@ -24,7 +30,13 @@ approvers:
 - ashwindasr
 - mbiarnes
 - lgarciaaco
-- rayfordj
 - germanparente
+- rayfordj
+- san7ket
+- jkaurredhat
+- shannon
+- namansharma18899
+- rhdmalone
+- tonyxrmdavidson
 # this is to keep automation from complaining about ownership of base image builds
 component: Release


### PR DESCRIPTION
The automated cherry-pick of #6505 failed so this is a manual cherry pick with some re-ordering of the names to keep them consistent across all versions.  I also added the two additional members that needed to be added to avoid spamming PRs.

The intention is to then cherry pick this up to 4.20