### PR TITLE
Remove altinfra container

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -690,8 +690,6 @@ bug_mapping:
       issue_component: insights-runtime-extractor
     ose-insights-runtime-extractor-container:
       issue_component: insights-runtime-extractor
-    ose-installer-altinfra-container:
-      issue_component: Installer / openshift-installer
     ose-installer-artifacts-container:
       issue_component: Installer / openshift-installer
     ose-installer-container:


### PR DESCRIPTION
Altinfra was a terraform-free version of the installer, which is now terraform-free by default.