### PR TITLE
ART-11250: Enable hermetic mode for 4.19 images which can be built hermetically

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -47,6 +47,7 @@ konflux:
     gomod_version_patch: true
   sast:
     enabled: true
+  network_mode: hermetic
 
 multi_arch:
   enabled: true

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -35,3 +35,5 @@ name: openshift/ose-azure-file-csi-driver-rhel9
 payload_name: azure-file-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -29,3 +29,5 @@ name: openshift/ose-baremetal-machine-controllers-rhel9
 payload_name: baremetal-machine-controllers
 owners:
   - metal-platform@redhat.com
+konflux:
+  network_mode: open

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -32,3 +32,5 @@ name: openshift/ose-baremetal-runtimecfg-rhel9
 payload_name: baremetal-runtimecfg
 owners:
 - asegurap@redhat.com
+konflux:
+  network_mode: open

--- a/images/ci-openshift-base.rhel9.yml
+++ b/images/ci-openshift-base.rhel9.yml
@@ -64,3 +64,5 @@ canonical_builders_from_upstream: false
 scan_sources:
   exempt_rpms:
   - '*'
+konflux:
+  network_mode: open

--- a/images/ci-openshift-build-root-latest.rhel8.yml
+++ b/images/ci-openshift-build-root-latest.rhel8.yml
@@ -54,3 +54,5 @@ canonical_builders_from_upstream: false
 scan_sources:
   exempt_rpms:
   - '*'
+konflux:
+  network_mode: open

--- a/images/ci-openshift-build-root-latest.rhel9.yml
+++ b/images/ci-openshift-build-root-latest.rhel9.yml
@@ -56,3 +56,5 @@ canonical_builders_from_upstream: false
 scan_sources:
   exempt_rpms:
   - '*'
+konflux:
+  network_mode: open

--- a/images/ci-openshift-golang-builder-latest.rhel8.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel8.yml
@@ -58,3 +58,5 @@ canonical_builders_from_upstream: false
 scan_sources:
   exempt_rpms:
   - '*'
+konflux:
+  network_mode: open

--- a/images/ci-openshift-golang-builder-latest.rhel9.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel9.yml
@@ -58,3 +58,5 @@ canonical_builders_from_upstream: false
 scan_sources:
   exempt_rpms:
   - '*'
+konflux:
+  network_mode: open

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -29,3 +29,5 @@ name: openshift/ose-cluster-etcd-rhel9-operator
 payload_name: cluster-etcd-operator
 owners:
 - sbatsche@redhat.com
+konflux:
+  network_mode: open

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -33,3 +33,5 @@ name: openshift/ose-cluster-node-tuning-rhel9-operator
 payload_name: cluster-node-tuning-operator
 owners:
 - openshift-psap@redhat.com
+konflux:
+  network_mode: open

--- a/images/container-networking-plugins-microshift.yml
+++ b/images/container-networking-plugins-microshift.yml
@@ -39,3 +39,5 @@ owners:
 - tohayash@redhat.com
 - dosmith@redhat.com
 - microshift-devel@redhat.com
+konflux:
+  network_mode: open

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -34,3 +34,5 @@ name: openshift/ose-csi-driver-nfs-rhel9
 payload_name: csi-driver-nfs
 owners:
 - shiftstack-team@redhat.com
+konflux:
+  network_mode: open

--- a/images/dpu-daemon.yml
+++ b/images/dpu-daemon.yml
@@ -34,3 +34,5 @@ owners:
 - bnemeth@redhat.com
 - sdaniele@redhat.com
 - vpunj@redhat.com
+konflux:
+  network_mode: open

--- a/images/dpu-intel-ipu-vsp.yml
+++ b/images/dpu-intel-ipu-vsp.yml
@@ -49,3 +49,5 @@ owners:
 - bnemeth@redhat.com
 - sdaniele@redhat.com
 - vpunj@redhat.com
+konflux:
+  network_mode: open

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -49,3 +49,4 @@ konflux:
   - rhel-9-baseos-rpms
   - rhel-9-appstream-rpms
   - rhel-9-rt-rpms
+  network_mode: open

--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -28,3 +28,5 @@ name: openshift/ose-egress-router-cni-rhel9
 payload_name: egress-router-cni
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -45,3 +45,4 @@ konflux:
   # Upstream has to fix their vendor.
   cachi2:
     enabled: false
+  network_mode: open

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -41,3 +41,5 @@ name: openshift/ose-prometheus-node-exporter-rhel9
 payload_name: prometheus-node-exporter
 owners:
 - team-monitoring@redhat.com
+konflux:
+  network_mode: open

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -41,3 +41,5 @@ name: openshift/ose-prometheus-rhel9
 payload_name: prometheus
 owners:
 - team-monitoring@redhat.com
+konflux:
+  network_mode: open

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -39,3 +39,5 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-codeready-builder-rpms
 - rhel-9-server-ironic-rpms
+konflux:
+  network_mode: open

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -32,3 +32,5 @@ name: openshift/ose-ironic-machine-os-downloader-rhel9
 payload_name: ironic-machine-os-downloader
 owners:
 - ironic-osp-owners@redhat.com
+konflux:
+  network_mode: open

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -25,3 +25,5 @@ name: openshift/ose-ironic-static-ip-manager-rhel9
 payload_name: ironic-static-ip-manager
 owners:
 - ironic-osp-owners@redhat.com
+konflux:
+  network_mode: open

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -42,3 +42,5 @@ name: openshift/ose-ironic-rhel9
 payload_name: ironic
 owners:
 - ironic-osp-owners@redhat.com
+konflux:
+  network_mode: open

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -28,3 +28,5 @@ name: openshift/ose-kube-proxy-rhel9
 payload_name: kube-proxy
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -35,3 +35,5 @@ name: openshift/ose-ptp-rhel9
 name_in_bundle: ptp
 owners:
 - multus-dev@redhat.com
+konflux:
+  network_mode: open

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -33,3 +33,5 @@ name: openshift/ose-local-storage-diskmaker-rhel9
 name_in_bundle: local-storage-diskmaker
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/local-storage-mustgather.yml
+++ b/images/local-storage-mustgather.yml
@@ -28,3 +28,5 @@ name: openshift/ose-local-storage-mustgather-rhel9
 name_in_bundle: local-storage-mustgather
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -41,3 +41,4 @@ owners:
 konflux:
   cachito:
     mode: emulation
+  network_mode: open

--- a/images/multus-cni-container-microshift.yml
+++ b/images/multus-cni-container-microshift.yml
@@ -39,3 +39,5 @@ owners:
 - tohayash@redhat.com
 - dosmith@redhat.com
 - microshift-devel@redhat.com
+konflux:
+  network_mode: open

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -36,3 +36,5 @@ name: openshift/ose-multus-cni-rhel9
 payload_name: multus-cni
 owners:
 - multus-dev@redhat.com
+konflux:
+  network_mode: open

--- a/images/multus-networkpolicy.yml
+++ b/images/multus-networkpolicy.yml
@@ -36,3 +36,4 @@ konflux:
   cachi2:
     # Until https://github.com/openshift/multus-networkpolicy/pull/69 is merged
     enabled: false
+  network_mode: open

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -42,3 +42,4 @@ payload_name: networking-console-plugin
 konflux:
   cachito:
     mode: removal
+  network_mode: open

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -48,3 +48,4 @@ owners:
 konflux:
   cachito:
     mode: removal
+  network_mode: open

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -31,3 +31,4 @@ konflux:
   # New issue, need to investigate
   cachi2:
     enabled: false
+  network_mode: open

--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -35,3 +35,4 @@ owners:
 konflux:
   cachito:
     mode: removal
+  network_mode: open

--- a/images/okd-only-upi-installer.yml
+++ b/images/okd-only-upi-installer.yml
@@ -38,3 +38,5 @@ name: openshift/ose-upi-installer-rhel9
 payload_name: upi-installer
 owners:
 - aos-install@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-base-nodejs.rhel9.yml
+++ b/images/openshift-base-nodejs.rhel9.yml
@@ -42,3 +42,5 @@ name: openshift/base-nodejs-rhel9
 owners:
 - aos-team-art@redhat.com
 canonical_builders_from_upstream: false
+konflux:
+  network_mode: open

--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -38,3 +38,5 @@ name: openshift/base-rhel9
 owners:
 - aos-team-art@redhat.com
 canonical_builders_from_upstream: false
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -49,3 +49,5 @@ owners:
 - tgeer@redhat.com
 - ckyal@redhat.com
 - arsen@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-base-rhel9.yml
+++ b/images/openshift-enterprise-base-rhel9.yml
@@ -46,3 +46,5 @@ labels:
 name: openshift/openshift-enterprise-base-rhel9
 owners:
 - lmeyer@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -34,3 +34,5 @@ name: openshift/ose-docker-builder-rhel9
 payload_name: docker-builder
 owners:
 - openshift-build-api@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -51,3 +51,4 @@ konflux:
   cachi2:
     # Unique issue, need to discuss with console team
     enabled: false
+  network_mode: open

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -28,3 +28,5 @@ labels:
 name: openshift/ose-egress-dns-proxy-rhel9
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -26,3 +26,5 @@ labels:
 name: openshift/ose-egress-router-rhel9
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -28,3 +28,5 @@ name: openshift/ose-haproxy-router-rhel9
 payload_name: haproxy-router
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -38,3 +38,5 @@ name: openshift/ose-hyperkube-rhel9
 payload_name: hyperkube
 owners:
 - aos-master@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -29,3 +29,5 @@ name: openshift/ose-keepalived-ipfailover-rhel9
 payload_name: keepalived-ipfailover
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -34,3 +34,5 @@ name: openshift/ose-pod-rhel9
 payload_name: pod
 owners:
 - aos-pod@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -33,3 +33,5 @@ name: openshift/ose-docker-registry-rhel9
 payload_name: docker-registry
 owners:
 - openshift-image-registry@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -40,3 +40,5 @@ payload_name: tests
 owners:
 - aos-master@redhat.com
 - openshift-technical-release-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -40,3 +40,4 @@ konflux:
   cachi2:
     # Until upstream issue is resolved
     enabled: false
+  network_mode: open

--- a/images/openstack-resource-controller.yml
+++ b/images/openstack-resource-controller.yml
@@ -25,3 +25,5 @@ name: openshift/ose-openstack-resource-controller-rhel9
 payload_name: openstack-resource-controller
 owners:
 - emacchi@redhat.com, maandre@redhat.com, pprinett@redhat.com, mdbooth@redhat.com@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -33,3 +33,5 @@ name: openshift/ose-agent-installer-api-server-rhel9
 payload_name: agent-installer-api-server
 owners:
 - ocp-agent-team@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -32,3 +32,5 @@ name: openshift/ose-agent-installer-csr-approver-rhel9
 payload_name: agent-installer-csr-approver
 owners:
 - ocp-agent-team@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -32,3 +32,5 @@ name: openshift/ose-agent-installer-node-agent-rhel9
 payload_name: agent-installer-node-agent
 owners:
 - ocp-agent-team@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -33,3 +33,5 @@ name: openshift/ose-agent-installer-utils-rhel9
 payload_name: agent-installer-utils
 owners:
 - ocp-agent-team@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -39,3 +39,5 @@ name: openshift/ose-aws-ebs-csi-driver-rhel9
 payload_name: aws-ebs-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -34,3 +34,5 @@ name: openshift/ose-aws-efs-csi-driver-container-rhel9
 name_in_bundle: aws-efs-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-aws-efs-utils.yml
+++ b/images/ose-aws-efs-utils.yml
@@ -24,3 +24,5 @@ from:
 name: openshift/ose-aws-efs-utils-base
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -35,3 +35,5 @@ name: openshift/ose-azure-disk-csi-driver-rhel9
 payload_name: azure-disk-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-azure-service-operator.yml
+++ b/images/ose-azure-service-operator.yml
@@ -33,3 +33,4 @@ konflux:
   # New issue, need to investigate
   cachi2:
     enabled: false
+  network_mode: open

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -37,3 +37,4 @@ konflux:
   vm_override:
     x86_64: linux-c4xlarge/amd64
     aarch64: linux-c4xlarge/arm64
+  network_mode: open

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -34,3 +34,5 @@ owners:
 - fpan@redhat.com
 - tohayash@redhat.com
 - dcbw@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -26,3 +26,5 @@ labels:
 name: openshift/ose-egress-http-proxy-rhel9
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -62,3 +62,4 @@ konflux:
   content:
     source:
       dockerfile: Dockerfile.rhel
+  network_mode: open

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -28,3 +28,5 @@ name_in_bundle: metallb-frr-rhel9
 payload_name: metallb-frr
 owners:
 - metallb-dev@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -38,3 +38,5 @@ name: openshift/ose-gcp-filestore-csi-driver-rhel9
 name_in_bundle: gcp-filestore-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -36,3 +36,5 @@ name: openshift/ose-gcp-pd-csi-driver-rhel9
 payload_name: gcp-pd-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -39,3 +39,4 @@ konflux:
   # New issue, need to investigate
   cachi2:
     enabled: false
+  network_mode: open

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -31,3 +31,5 @@ name: openshift/ose-machine-image-customization-controller-rhel9
 payload_name: machine-image-customization-controller
 owners:
 - metal-platform@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-insights-runtime-extractor.yml
+++ b/images/ose-insights-runtime-extractor.yml
@@ -29,3 +29,5 @@ payload_name: insights-runtime-extractor
 name: openshift/ose-insights-runtime-extractor-rhel9
 owners:
 - jmesnil@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -66,3 +66,4 @@ konflux:
   content:
     source:
       dockerfile: Dockerfile.installer.art-cachi2
+  network_mode: open

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -28,3 +28,5 @@ name: openshift/ose-installer-rhel9
 payload_name: installer
 owners:
 - aos-install@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -31,3 +31,5 @@ owners:
 - rgolan@redhat.com
 - nargaman@redhat.com
 - dvossel@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -39,3 +39,5 @@ name: openshift/ose-libvirt-machine-controllers-rhel9
 payload_name: libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -42,3 +42,5 @@ owners:
 - jkyros@redhat.com
 - skumari@redhat.com
 - zzlotnik@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -33,3 +33,4 @@ konflux:
     # ref thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1743022042311039
     # can be removed after whilelist is in
     x86_64: linux/amd64
+  network_mode: open

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -28,3 +28,5 @@ name: openshift/ose-must-gather-rhel9
 payload_name: must-gather
 owners:
 - aos-master@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -33,3 +33,4 @@ konflux:
   cachi2:
     # Until upstream issue is resolved
     enabled: false
+  network_mode: open

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -34,3 +34,5 @@ name: openshift/ose-olm-operator-controller-rhel9
 payload_name: olm-operator-controller
 owners:
 - aos-odin@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -32,3 +32,5 @@ payload_name: openstack-cinder-csi-driver
 owners:
 - aos-storage-staff@redhat.com
 - mfedosin@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -28,3 +28,5 @@ name: openshift/ovirt-csi-driver-rhel9
 payload_name: ovirt-csi-driver
 owners:
 - rgolan@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -48,3 +48,5 @@ name: openshift/ose-ovn-kubernetes-rhel9
 payload_name: ovn-kubernetes
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -35,3 +35,5 @@ payload_name: powervs-block-csi-driver
 owners:
 - mchellam@redhat.com
 - mkumatag@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -34,3 +34,5 @@ name: openshift/ose-secrets-store-csi-driver-rhel9
 name_in_bundle: secrets-store-csi-driver-container
 owners:
 - secrets-store-csi-driver-oap-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -25,3 +25,5 @@ from:
 name: openshift/ose-secrets-store-csi-mustgather-rhel9
 owners:
 - secrets-store-csi-driver-oap-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -34,3 +34,5 @@ name: openshift/ose-smb-csi-driver-rhel9
 name_in_bundle: smb-csi-driver-container-rhel9
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -39,3 +39,5 @@ owners:
 - apanatto@redhat.com
 - wizhao@redhat.com
 - sscheink@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -36,3 +36,5 @@ name: openshift/ose-tools-rhel9
 payload_name: tools
 owners:
 - aos-master@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -34,3 +34,5 @@ name: openshift/ose-vsphere-csi-driver-rhel9
 payload_name: vsphere-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -43,3 +43,5 @@ labels:
 name: openshift/ose-ovn-kubernetes-base
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -42,3 +42,5 @@ name: openshift/ose-ovn-kubernetes-microshift-rhel9
 payload_name: ovn-kubernetes-microshift
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -36,3 +36,5 @@ name: openshift/ose-prom-label-proxy-rhel9
 payload_name: prom-label-proxy
 owners:
 - team-monitoring@redhat.com
+konflux:
+  network_mode: open

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -30,3 +30,5 @@ from:
 name: openshift/ose-ptp-operator-must-gather-rhel9
 owners:
 - multus-dev@redhat.com
+konflux:
+  network_mode: open

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -39,3 +39,4 @@ konflux:
   # New issue, need to investigate
   cachi2:
     enabled: false
+  network_mode: open

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -34,3 +34,5 @@ name: openshift/ose-sriov-network-config-daemon-rhel9
 name_in_bundle: sriov-network-config-daemon
 owners:
 - multus-dev@redhat.com
+konflux:
+  network_mode: open

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -34,3 +34,5 @@ name: openshift/ose-sriov-network-device-plugin-rhel9
 name_in_bundle: sriov-network-device-plugin
 owners:
 - zshi@redhat.com
+konflux:
+  network_mode: open

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -36,3 +36,5 @@ name: openshift/ose-thanos-rhel9
 payload_name: thanos
 owners:
 - team-monitoring@redhat.com
+konflux:
+  network_mode: open


### PR DESCRIPTION
Add `konflux.network_mode: open` to `group.yml` and see which images can be built with this change.