### PR TITLE
Assembly definition for 4.18.10

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,4 +1,36 @@
 releases:
+  4.18.10:
+    assembly:
+      basis:
+        brew_event: 63391712
+        reference_releases!: {}
+# nightlies used not available now because of RC outage
+#          x86_64: 4.18.0-0.nightly-2025-04-15-161728
+      group:
+        advisories:
+          extras: -1
+          image: -1
+          metadata: -1
+          rpm: -1
+        release_jira: ART-0
+        upgrades: 4.17.11,4.17.12,4.17.13,4.17.14,4.17.15,4.17.16,4.17.17,4.17.18,4.17.19,4.17.20,4.17.21,4.17.22,4.17.23,4.17.24,4.17.25,4.17.26,4.18.1,4.18.2,4.18.3,4.18.4,4.18.5,4.18.6,4.18.7,4.18.8,4.18.9
+      members:
+        images: []
+        rpms: []
+      rhcos:
+        rhel-coreos:
+          images:
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fcbc20aae499e6aaa29fb5f01a8e6903c2fbbc8a704dece5089d762b6667aba3
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f68b86759897a92f373a9d1946c2879eab3a103cacbaa744ebeb7c14532e65b0
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ab2362683fb19fae83990a8af48a7879bf9ddab280aab3751a04805416b84127
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c994fe903c9eb439da993f2bb9c4a1f122a7f988371efd4c5a04448459e4ef15
+        rhel-coreos-extensions:
+          images:
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:40ad637a3b64ff40941e0b6c4224b444bfd0484320b9d46695bb9f1ff1a4424f
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f05b6fc2dbd85562f768ea2b9b84deadf60ee8745cc0f06716a25c49e2604b72
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0e0f65d699f494a65de2cf1209ac03a86734a3afdae98463d57315d24a9e2850
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:498128bc448549cf55aa8032b44ae51b6f849e10506c60e023c2b3d99aabf9ef
+      type: standard
   4.18.9:
     assembly:
       basis:

--- a/releases.yml
+++ b/releases.yml
@@ -30,7 +30,11 @@ releases:
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d5a08457b8b8a6766205b2db991c4f1f9242a1d32ffd1f4d8d2a589739d4739
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:83165dcce5d9a7ef37cdf8beb7b7d0494306f640f09c219e020e26d359584e53
             x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0ea88113812c77a770e4a2d80bfb2d210389fa2c10959c69d4e0d8c28962a174
-
+      permits:
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: openshift-enterprise-builder
+          # why: image build has an older runc build than the one in the assembly
+          # but it is not a blocker
       type: standard
   4.18.9:
     assembly:

--- a/releases.yml
+++ b/releases.yml
@@ -20,16 +20,17 @@ releases:
       rhcos:
         rhel-coreos:
           images:
-            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fcbc20aae499e6aaa29fb5f01a8e6903c2fbbc8a704dece5089d762b6667aba3
-            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f68b86759897a92f373a9d1946c2879eab3a103cacbaa744ebeb7c14532e65b0
-            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ab2362683fb19fae83990a8af48a7879bf9ddab280aab3751a04805416b84127
-            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c994fe903c9eb439da993f2bb9c4a1f122a7f988371efd4c5a04448459e4ef15
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:91f0f0baea2eb63c5682ebb457851cfb36d62e3923587c0dd86bac4d9ab135ae
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b0f1df88e66d7541ff27b428d4669a889fa318905839bf0a7b446c5b4f1ed65b
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:628fe444d111d6d505fab247a7ccfd4a70f8e3b8fbe10b5073388b5fdbd58827
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:93a7126af71a638df2d7f34f64629ff116a25fff9d6433be3228bbd41eaeffc4
         rhel-coreos-extensions:
           images:
-            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:40ad637a3b64ff40941e0b6c4224b444bfd0484320b9d46695bb9f1ff1a4424f
-            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f05b6fc2dbd85562f768ea2b9b84deadf60ee8745cc0f06716a25c49e2604b72
-            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0e0f65d699f494a65de2cf1209ac03a86734a3afdae98463d57315d24a9e2850
-            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:498128bc448549cf55aa8032b44ae51b6f849e10506c60e023c2b3d99aabf9ef
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:693e8618ff031c296972ec2528bc0a35593d0c088b9faa9f8cfc50741ee4d518
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1d5a08457b8b8a6766205b2db991c4f1f9242a1d32ffd1f4d8d2a589739d4739
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:83165dcce5d9a7ef37cdf8beb7b7d0494306f640f09c219e020e26d359584e53
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0ea88113812c77a770e4a2d80bfb2d210389fa2c10959c69d4e0d8c28962a174
+
       type: standard
   4.18.9:
     assembly:


### PR DESCRIPTION
Hand constructed assembly definition by doing the following:
- Find a green nightly on RC from 2 days back: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.18.0-0.nightly/release/4.18.0-0.nightly-2025-04-15-161728 , which is not available now on registry since RC outage.
- Find the 4.18 build-sync job that lines up with the nightly creation time: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/17672/
- Inspect artifacts to get brew_event: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync/17672/artifact/gen-payload-artifacts/updated-tags-for.ocp.4.18-art-latest.yaml/*view*/ and also confirm inconsistency annotations match up: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.18.0-0.nightly/inconsistency/4.18.0-0.nightly-2025-04-15-161728
- Get rhcos-id from inconsistency annotation
- Construct assembly definition by hand with the found brew event
- Get rhcos config: `elliott -g openshift-4.18 --assembly 4.18.10 --data-path ../ocp-build-data pin-builds rhcos-418.94.202504141420-0 --why "consistent rhcos"`

Edit: use newer rhcos 418.94.202504151440-0 - https://releases-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com/?stream=prod/streams/4.18-9.4&release=418.94.202504151440-0&arch=x86_64#418.94.202504151440-0 to resolve inconsistency