### PR TITLE
scan-sources:noop enable ppc, cachi2

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -40,7 +40,9 @@ konflux:
   arches:
   - x86_64
   - aarch64
+  - ppc64le
   cachi2:
+    enabled: true
     gomod_version_patch: true
   sast:
     enabled: true


### PR DESCRIPTION
Changes in this PR:
- ppc is stable enough for us to enable them for 4.19
- we have good workarounds for prefetch. enabling to sort out the errors