### PR TITLE
scan-sources:noop disable cachi2 image

### DIFF
--- a/images/multus-networkpolicy.yml
+++ b/images/multus-networkpolicy.yml
@@ -32,3 +32,7 @@ name: openshift/ose-multus-networkpolicy-rhel9
 payload_name: multus-networkpolicy
 owners:
 - multus-dev@redhat.com
+konflux:
+  cachi2:
+    # Until https://github.com/openshift/multus-networkpolicy/pull/69 is merged
+    enabled: false

--- a/images/ose-openshift-controller-manager.yml
+++ b/images/ose-openshift-controller-manager.yml
@@ -25,3 +25,7 @@ name: openshift/ose-openshift-controller-manager-rhel9
 payload_name: openshift-controller-manager
 owners:
 - openshift-build-api@redhat.com
+konflux:
+  cachi2:
+    # Until https://github.com/openshift/openshift-controller-manager/pull/371 is merged
+    enabled: false

--- a/images/pf-status-relay.yml
+++ b/images/pf-status-relay.yml
@@ -27,3 +27,7 @@ name: openshift/pf-status-relay-rhel9
 name_in_bundle: pf-status-relay
 owners:
 - marguerr@redhat.com
+konflux:
+  cachi2:
+    # Until https://github.com/openshift/pf-status-relay/pull/38 is merged
+    enabled: false


### PR DESCRIPTION
Until upstream PRs are merged