### PR TITLE
ovn images remove gomod

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -10,8 +10,7 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
-    pkg_managers:
-    - gomod
+    pkg_managers: []
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ovn-kubernetes-container
@@ -49,7 +48,3 @@ name: openshift/ose-ovn-kubernetes-rhel9
 payload_name: ovn-kubernetes
 owners:
 - aos-networking-staff@redhat.com
-konflux:
-  cachi2:
-    # Until https://redhat-internal.slack.com/archives/GDBRP5YJH/p1745000508652589 is merged
-    enabled: false

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -10,8 +10,7 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
-    pkg_managers:
-    - gomod
+    pkg_managers: []
 distgit:
   component: ovn-kubernetes-microshift-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
@@ -43,7 +42,3 @@ name: openshift/ose-ovn-kubernetes-microshift-rhel9
 payload_name: ovn-kubernetes-microshift
 owners:
 - aos-networking-staff@redhat.com
-konflux:
-  cachi2:
-    # Until https://redhat-internal.slack.com/archives/GDBRP5YJH/p1745000508652589 is merged
-    enabled: false


### PR DESCRIPTION
`gomod` was initially added to the pkg_mangers list as part of [this commit](https://github.com/openshift-eng/ocp-build-data/commit/0364c238ab0aa61a4c1c39720c76802ec747b2b2), but the situation seems to be different right now. There is no go.mod file found in the default (root) dir of upstream, hence package manager is not required here