### PR TITLE
cachi2 images update

### DIFF
--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -10,6 +10,10 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ib-sriov-cni.git
       web: https://github.com/openshift/ib-sriov-cni
+    modifications:
+    - action: add
+      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.19.0/ginkgo/build/build_command.go"
+      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -27,6 +27,3 @@ name: openshift/ose-node-feature-discovery-rhel9
 name_in_bundle: node-feature-discovery
 owners:
 - edge-kmm@redhat.com
-konflux:
-  cachi2:
-    enabled: false

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -49,5 +49,5 @@ konflux:
   cachito:
     mode: removal
   cachi2:
-    # Upstream is fixed
+    # Unique issue, need to discuss with console team
     enabled: false

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -36,3 +36,7 @@ owners:
 - mko@redhat.com
 - phoracek@redhat.com
 - yboaron@redhat.com
+konflux:
+  cachi2:
+    # Until upstream issue is resolved
+    enabled: false

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -10,6 +10,43 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-ibmcloud.git
       web: https://github.com/openshift/cluster-api-provider-ibmcloud
+    modifications:
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/refs/tags/v1.9.4/util/kubeconfig/kubeconfig.go"
+      path: "vendor/sigs.k8s.io/cluster-api/util/kubeconfig/kubeconfig.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/refs/tags/v1.9.4/util/kubeconfig/testing.go"
+      path: "vendor/sigs.k8s.io/cluster-api/util/kubeconfig/testing.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/internal/kubeconfig/encode.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/encode.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/internal/kubeconfig/helpers.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/helpers.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/internal/kubeconfig/lock.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/lock.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/internal/kubeconfig/merge.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/merge.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/paths.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/internal/kubeconfig/read.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/read.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/internal/kubeconfig/remove.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/remove.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/internal/kubeconfig/types.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/types.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/internal/kubeconfig/write.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/internal/kubeconfig/write.go"
+    - action: add
+      source: "https://raw.githubusercontent.com/kubernetes-sigs/kind/refs/tags/v0.25.0/pkg/cluster/internal/kubeconfig/kubeconfig.go"
+      path: "vendor/sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig/kubeconfig.go"
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -29,3 +29,7 @@ name: openshift/ose-network-tools-rhel9
 payload_name: network-tools
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  cachi2:
+    # Until upstream issue is resolved
+    enabled: false

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -35,6 +35,3 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
-konflux:
-  cachi2:
-    enabled: false


### PR DESCRIPTION
Changes in this PR:
- Adding `modifications` for `ose-ibmcloud-cluster-api-controllers`, `ib-sriov-cni`
- Disabling images with known issues.
- Enabling `ptp-operator` and `node-feature-discovery` images which are failing on the build step, if prefetch is enabled. Prefetch succeeds. If prefetch is not enabled, build-step succeeds.