### PR TITLE
disable ptp, nfd

### DIFF
--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -27,3 +27,7 @@ name: openshift/ose-node-feature-discovery-rhel9
 name_in_bundle: node-feature-discovery
 owners:
 - edge-kmm@redhat.com
+konflux:
+  # New issue, need to investigate
+  cachi2:
+    enabled: false

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -35,3 +35,7 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+konflux:
+  # New issue, need to investigate
+  cachi2:
+    enabled: false


### PR DESCRIPTION
Since IBM arches are working, priority has shifted to getting green builds non-hermetically first