### PR TITLE
disable cachi2 in group

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -43,7 +43,7 @@ konflux:
   - s390x
   - ppc64le
   cachi2:
-    enabled: true
+    enabled: false
     gomod_version_patch: true
   sast:
     enabled: true


### PR DESCRIPTION
Since IBM builds are relatively stable now