### PR TITLE
4.20 - Fix build root stream name

### DIFF
--- a/images/aws-karpenter-provider-aws.yml
+++ b/images/aws-karpenter-provider-aws.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: aws-karpenter-provider-aws-container


### PR DESCRIPTION
Image was added with wrong ci build root name: https://github.com/openshift-eng/ocp-build-data/pull/6450

`OSError: Unable to find definition for stream 'rhel-9-golang-ci-build-root'`
Seen at: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/scheduled-builds/job/sync-ci-images/37910/consoleFull