### PR TITLE
Fix 4.20 bug sweep

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -11,7 +11,7 @@ bugzilla_config:
 
 target_release:
   - "4.20.0"
-  - "4.20.z"
+  #  - "4.20.z"
   - "4.20"
 
 version:


### PR DESCRIPTION
ART opted for greedy bug sweep, but that fails because jira throws an error when a Target Version does not exist. Temporarily disabling.