### PR TITLE
disable cachi2 for images

### DIFF
--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -41,3 +41,7 @@ name: openshift/ose-prometheus-alertmanager-rhel9
 payload_name: prometheus-alertmanager
 owners:
 - team-monitoring@redhat.com
+konflux:
+  # Upstream has to fix their vendor.
+  cachi2:
+    enabled: false

--- a/images/ose-azure-service-operator.yml
+++ b/images/ose-azure-service-operator.yml
@@ -29,3 +29,7 @@ owners:
 - ddonati@redhat.com
 - nbrubake@redhat.com
 - yanyang@redhat.com
+konflux:
+  # New issue, need to investigate
+  cachi2:
+    enabled: false

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -10,6 +10,10 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/rdma-cni.git
       web: https://github.com/openshift/rdma-cni
+    modifications:
+    - action: add
+      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.19.0/ginkgo/build/build_command.go"
+      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
Prefetch succeeded for images/ose-sriov-rdma-cni.yml: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-20/pipelineruns/ose-4-20-ose-sriov-rdma-cni-dfphm/logs