### PR TITLE
ovn-kubernetes: Remove exemptions for now unpinned OVS rpms.

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -30,9 +30,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 for_payload: true
 from:
   builder:

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -28,9 +28,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 for_payload: false
 for_release: false
 from:

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -25,9 +25,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
openvswitch* RPMs will no longer pinned in ovn-kubernetes images once https://github.com/openshift/ovn-kubernetes/pull/2525 lands in order to facilitate timely CVE and bug fix delivery.  Remove from exemptions.