### PR TITLE
ART-11250 Disable hermetic mode for additional images in 4.18

### DIFF
--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -34,3 +34,5 @@ name: openshift/ose-aws-efs-csi-driver-container-rhel9
 name_in_bundle: aws-efs-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-installer-altinfra.yml
+++ b/images/ose-installer-altinfra.yml
@@ -31,3 +31,4 @@ konflux:
   vm_override:
     x86_64: linux-c4xlarge/amd64
     aarch64: linux-c4xlarge/arm64
+  network_mode: open

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -36,3 +36,4 @@ konflux:
   vm_override:
     x86_64: linux-d160-c4xlarge/amd64
     aarch64: linux-d160-c4xlarge/arm64
+  network_mode: open

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -30,3 +30,5 @@ from:
 name: openshift/ose-ptp-operator-must-gather-rhel9
 owners:
 - multus-dev@redhat.com
+konflux:
+  network_mode: open


### PR DESCRIPTION
After enabling hermetic builds in 4.18 in https://github.com/openshift-eng/ocp-build-data/pull/6686, 14 images failed to build during a [test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/8362/). 
To double-check, I triggered another [test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/8496/) with only the 14 images. 4 of those failed to build once again.

This PR disables hermetic mode for these 4 images.