### PR TITLE
ART-11250: Enable hermetic mode for 4.12 images which can be built hermetically

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -20,6 +20,7 @@ konflux:
     enabled: false
   sast:
     enabled: true
+  network_mode: hermetic
 
 multi_arch:
   enabled: false

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -28,3 +28,5 @@ from:
 name: openshift/ose-azure-file-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -25,3 +25,5 @@ from:
 name: openshift/ose-baremetal-runtimecfg
 owners:
 - asegurap@redhat.com
+konflux:
+  network_mode: open

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -26,3 +26,5 @@ from:
 name: openshift/ose-cluster-node-tuning-operator
 owners:
 - openshift-psap@redhat.com
+konflux:
+  network_mode: open

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -26,3 +26,5 @@ from:
 name: openshift/ose-csi-driver-nfs
 owners:
 - shiftstack-team@redhat.com
+konflux:
+  network_mode: open

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -40,3 +40,4 @@ konflux:
   - rhel-8-baseos-rpms
   - rhel-8-appstream-rpms
   - rhel-8-rt-rpms
+  network_mode: open

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -27,3 +27,5 @@ labels:
 name: openshift/ose-prometheus-alertmanager
 owners:
 - team-monitoring@redhat.com
+konflux:
+  network_mode: open

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -27,3 +27,5 @@ labels:
 name: openshift/ose-prometheus-node-exporter
 owners:
 - team-monitoring@redhat.com
+konflux:
+  network_mode: open

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -27,3 +27,5 @@ labels:
 name: openshift/ose-prometheus
 owners:
 - team-monitoring@redhat.com
+konflux:
+  network_mode: open

--- a/images/ibm-vpc-node-label-updater.yml
+++ b/images/ibm-vpc-node-label-updater.yml
@@ -26,3 +26,5 @@ from:
 name: openshift/ose-ibm-vpc-node-label-updater
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -20,3 +20,5 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms
 - rhel-9-server-ironic-rpms
+konflux:
+  network_mode: open

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -22,3 +22,5 @@ from:
 name: openshift/ose-ironic-machine-os-downloader
 owners:
 - ironic-osp-owners@redhat.com
+konflux:
+  network_mode: open

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -19,3 +19,5 @@ from:
 name: openshift/ose-ironic-static-ip-manager
 owners:
 - ironic-osp-owners@redhat.com
+konflux:
+  network_mode: open

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -29,3 +29,4 @@ konflux:
     # But this image has indirect references to the env variable, which breaks builds.
     # Since this build works without commenting out the lines, keeping it in for now.
     comment: false
+  network_mode: open

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -21,3 +21,5 @@ from:
 name: openshift/ose-kube-proxy
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -39,3 +39,5 @@ name: openshift/ose-kuryr-cni
 owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
+konflux:
+  network_mode: open

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -33,3 +33,5 @@ name: openshift/ose-kuryr-controller
 owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
+konflux:
+  network_mode: open

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -27,3 +27,5 @@ from:
 name: openshift/ose-ptp
 owners:
 - multus-dev@redhat.com
+konflux:
+  network_mode: open

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -26,3 +26,5 @@ from:
 name: openshift/ose-local-storage-diskmaker
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/multus-networkpolicy.yml
+++ b/images/multus-networkpolicy.yml
@@ -27,3 +27,5 @@ from:
 name: openshift/ose-multus-networkpolicy
 owners:
 - multus-dev@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-base-nodejs.yml
+++ b/images/openshift-base-nodejs.yml
@@ -42,3 +42,5 @@ labels:
 name: openshift/base-nodejs
 owners:
 - aos-team-art@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-base-rhel8.yml
+++ b/images/openshift-base-rhel8.yml
@@ -35,3 +35,5 @@ from:
 name: openshift/base-rhel8
 owners:
 - aos-team-art@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -34,3 +34,5 @@ from:
 name: openshift/base-rhel9
 owners:
 - aos-team-art@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -28,3 +28,5 @@ owners:
 - jesusr@redhat.com
 - jlanford@redhat.com
 - fabian@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-base.yml
+++ b/images/openshift-enterprise-base.yml
@@ -56,3 +56,5 @@ labels:
 name: openshift/ose-base
 owners:
 - ccoleman@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -27,3 +27,5 @@ labels:
 name: openshift/ose-docker-builder
 owners:
 - openshift-build-api@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -43,3 +43,4 @@ konflux:
     mode: removal
   cachi2:
     enabled: false
+  network_mode: open

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -24,3 +24,5 @@ labels:
 name: openshift/ose-egress-dns-proxy
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -20,3 +20,5 @@ labels:
 name: openshift/ose-egress-router
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -21,3 +21,5 @@ labels:
 name: openshift/ose-haproxy-router
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -32,3 +32,5 @@ labels:
 name: openshift/ose-hyperkube
 owners:
 - aos-master@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -20,3 +20,5 @@ labels:
 name: openshift/ose-keepalived-ipfailover
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-operator-sdk.yml
+++ b/images/openshift-enterprise-operator-sdk.yml
@@ -28,3 +28,5 @@ owners:
 - jlanford@redhat.com
 - fabian@redhat.com
 - cmacedo@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -32,3 +32,5 @@ labels:
 name: openshift/ose-pod
 owners:
 - aos-pod@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -26,3 +26,5 @@ labels:
 name: openshift/ose-docker-registry
 owners:
 - openshift-image-registry@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-service-idler.yml
+++ b/images/openshift-enterprise-service-idler.yml
@@ -28,3 +28,5 @@ labels:
 name: openshift/ose-service-idler
 owners:
 - anbhat@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -41,3 +41,5 @@ name: openshift/ose-tests
 owners:
 - aos-master@redhat.com
 - openshift-technical-release-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -31,3 +31,5 @@ owners:
 - ellorent@redhat.com
 - phoracek@redhat.com
 - yboaron@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -26,3 +26,5 @@ maintainer:
 name: openshift/ose-agent-installer-api-server
 owners:
 - ocp-agent-team@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -25,3 +25,5 @@ maintainer:
 name: openshift/ose-agent-installer-node-agent
 owners:
 - ocp-agent-team@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-alibaba-cloud-csi-driver.yml
+++ b/images/ose-alibaba-cloud-csi-driver.yml
@@ -32,3 +32,5 @@ from:
 name: openshift/ose-alibaba-cloud-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -26,3 +26,5 @@ from:
 name: openshift/ose-aws-ebs-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-aws-efs-utils.yml
+++ b/images/ose-aws-efs-utils.yml
@@ -20,3 +20,5 @@ from:
 name: openshift/ose-aws-efs-utils-base
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -26,3 +26,5 @@ from:
 name: openshift/ose-azure-disk-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -25,3 +25,4 @@ konflux:
   vm_override:
     x86_64: linux-c4xlarge/amd64
     aarch64: linux-c4xlarge/arm64
+  network_mode: open

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -30,3 +30,5 @@ owners:
 - fpan@redhat.com
 - tohayash@redhat.com
 - dcbw@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -20,3 +20,5 @@ labels:
 name: openshift/ose-egress-http-proxy
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -52,3 +52,4 @@ konflux:
   content:
     source:
       dockerfile: Dockerfile.rhel
+  network_mode: open

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -19,3 +19,5 @@ name: openshift/frr-rhel8
 name_in_bundle: metallb-frr-rhel8
 owners:
 - metallb-dev@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -31,3 +31,5 @@ name: openshift/ose-gcp-filestore-csi-driver-rhel8
 name_in_bundle: gcp-filestore-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -26,3 +26,5 @@ from:
 name: openshift/ose-gcp-pd-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -26,3 +26,5 @@ from:
 name: openshift/ose-ibm-vpc-block-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -23,3 +23,5 @@ from:
 name: openshift/ose-machine-image-customization-controller
 owners:
 - metal-platform@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -29,3 +29,5 @@ owners:
 - rgolan@redhat.com
 - nargaman@redhat.com
 - dvossel@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -27,3 +27,5 @@ from:
 name: openshift/ose-libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -24,3 +24,5 @@ owners:
 - imcleod@redhat.com
 - runcom@redhat.com
 - smilner@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -24,3 +24,4 @@ konflux:
     # ref thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1743022042311039
     # can be removed after whilelist is in
     x86_64: linux/amd64
+  network_mode: open

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -21,3 +21,5 @@ from:
 name: openshift/ose-must-gather
 owners:
 - aos-master@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -22,3 +22,5 @@ from:
 name: openshift/ose-network-tools
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -25,3 +25,5 @@ name: openshift/ose-openstack-cinder-csi-driver
 owners:
 - aos-storage-staff@redhat.com
 - mfedosin@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -21,3 +21,5 @@ from:
 name: openshift/ose-ovirt-csi-driver
 owners:
 - rgolan@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -44,3 +44,4 @@ owners:
 konflux:
   cachi2:
     enabled: false
+  network_mode: open

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -27,3 +27,5 @@ name: openshift/ose-powervs-block-csi-driver
 owners:
 - mchellam@redhat.com
 - mkumatag@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -24,3 +24,5 @@ from:
 name: openshift/ose-sdn
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -28,3 +28,5 @@ name: openshift/ose-tools
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com
+konflux:
+  network_mode: open

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -26,3 +26,5 @@ from:
 name: openshift/ose-vsphere-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -45,3 +45,5 @@ labels:
 name: openshift/ose-ovn-kubernetes-base
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -43,3 +43,5 @@ labels:
 name: openshift/ose-ovn-kubernetes-microshift
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  network_mode: open

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -22,3 +22,5 @@ from:
 name: openshift/ose-prom-label-proxy
 owners:
 - team-monitoring@redhat.com
+konflux:
+  network_mode: open

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -25,3 +25,5 @@ from:
 name: openshift/ose-sriov-network-config-daemon
 owners:
 - multus-dev@redhat.com
+konflux:
+  network_mode: open

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -25,3 +25,5 @@ from:
 name: openshift/ose-sriov-network-device-plugin
 owners:
 - zshi@redhat.com
+konflux:
+  network_mode: open

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -24,3 +24,5 @@ from:
 name: openshift/ose-thanos
 owners:
 - team-monitoring@redhat.com
+konflux:
+  network_mode: open


### PR DESCRIPTION
Add `konflux.network_mode: hermetic` to group.yml and see which images can be built with this change.