### PR TITLE
Fix metallb rebase

### DIFF
--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/metallb.git
       web: https://github.com/openshift/metallb
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.22.2/ginkgo/build/build_command.go"
-      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
https://github.com/openshift/metallb/pull/239/files#diff-f20a7cf8ba7e8b20f3bd1963e18191e6ba4474bb0bf92bdd745bb62841e4a6c3 seems to have fixed the problem that called for modification. They did specify a builder that is not present in the production build system:

```
FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-nofips-openshift-4.19 AS builder
```

I expect the rebase to continue, but the build to fail, but let's see.