### PR TITLE
[4.13] docs override

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -26,3 +26,320 @@ cdn_repos:
 - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-9-aarch64-rpms
 
 quality_responsibility_name: "OpenShift QE"
+
+boilerplates:
+  image:
+    rhsa:
+      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} bug fix and security update
+      # Enable legacy style comment on advisory creation
+      advisory_type_comment: True
+      topic: |
+        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs and add enhancements.
+
+        This release includes a security update for Red Hat OpenShift Container Platform 4.{MINOR}.
+
+        Red Hat Product Security has rated this update as having a security impact of  {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
+      description: |
+        Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+
+        This advisory contains the container images for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the RPM packages for this release:
+        
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
+        
+        Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
+        
+         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+        
+        Security Fix(es):
+        
+        * [component-1: Description of issue and fix #1 (CVE-YYYY-NNNN)]
+        
+        * [component-2: Description of issue and fix #2 (CVE-YYYY-NNNN)]
+        
+        * [component-3: Description of issue and fix #3 (CVE-YYYY-NNNN)]
+        
+        For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
+        
+        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+
+      solution: |
+        For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+  
+        You may download the oc tool and use it to inspect release image metadata for x86_64, s390x, ppc64le, and aarch64 architectures. The image digests may be found at https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags.
+        
+              The sha values for the release are as follows:
+        
+              (For x86_64 architecture)
+              The image digest is sha256:<SHASUM_HERE>
+        
+              (For s390x architecture)
+              The image digest is sha256:<SHASUM_HERE>
+        
+              (For ppc64le architecture)
+              The image digest is sha256:<SHASUM_HERE>
+        
+              (For aarch64 architecture)
+              The image digest is sha256:<SHASUM_HERE>
+        
+        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+      security_reviewer: sfowler@redhat.com
+    rhba:
+      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} bug fix update
+      topic: Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+      description: |
+        Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+        
+        This advisory contains the container images for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the RPM packages for this release:
+        
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
+        
+        Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
+        
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+
+      solution: |
+        For OpenShift Container Platform 4.{MINOR} see the following documentation,  which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+        
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+        
+        You can download the oc tool and use it to inspect release image metadata for x86_64, s390x, ppc64le, and aarch64 architectures. The image digests can be found at https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags.
+        
+        The sha values for the release are as follows:
+        
+        (For x86_64 architecture)
+        The image digest is sha256:<SHASUM_HERE>
+        
+        (For s390x architecture)
+        The image digest is sha256:<SHASUM_HERE>
+        
+        (For ppc64le architecture)
+        The image digest is sha256:<SHASUM_HERE>
+        
+        (For aarch64 architecture)
+        The image digest is sha256:<SHASUM_HERE>
+        
+        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+    rpm:
+      rhsa:
+        synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} packages and security update
+        topic: |
+          Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs and add enhancements.
+
+          This release includes a security update for Red Hat OpenShift Container Platform 4.{MINOR}.
+          
+          Red Hat Product Security has rated this update as having a security impact of  {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
+
+        description: |
+          Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+
+          This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
+          
+          https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
+          
+          Security Fix(es):
+          
+          * [component-1: Description of issue and fix #1 (CVE-YYYY-NNNN)]
+          
+          * [component-2: Description of issue and fix #2 (CVE-YYYY-NNNN)]
+          
+          * [component-3: Description of issue and fix #3 (CVE-YYYY-NNNN)]
+          
+          For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
+          
+          All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+        solution: |
+          For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+
+          https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+        security_reviewer: sfowler@redhat.com
+      rhba:
+        synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} packages update
+        topic: |
+          Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+        description: |
+          Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+          
+          This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
+          
+          https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
+          
+          All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at
+          https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+
+        solution: |
+          See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+          
+          https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+          
+          Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+  extras:
+    rhsa:
+      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} security and extras update
+      topic: |
+        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+
+        This release includes a security update for Red Hat OpenShift Container Platform 4.{MINOR}.
+
+        Red Hat Product Security has rated this update as having a security impact of  {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
+      description: |
+        Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+
+        This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
+
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
+
+        Security Fix(es):
+
+        * [component-1: Description of issue and fix #1 (CVE-YYYY-NNNN)]
+
+        * [component-2: Description of issue and fix #2 (CVE-YYYY-NNNN)]
+
+        * [component-3: Description of issue and fix #3 (CVE-YYYY-NNNN)]
+
+        For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
+
+        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+      solution: |
+        For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+    rhba:
+      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} extras update
+      topic: Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+      description: |
+        Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+
+        This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
+
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
+
+        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+      solution: |    
+        See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+        
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+        
+        Details on how to access this content are available at
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+  metadata:
+    rhsa:
+      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} security update
+      topic: |
+        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs and add enhancements.
+
+        Red Hat Product Security has rated this update as having a security impact of  {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
+      description: |
+        Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+
+        Security Fix(es):
+
+        * [component-1: Description of issue and fix #1 (CVE-YYYY-NNNN)]
+
+        * [component-2: Description of issue and fix #2 (CVE-YYYY-NNNN)]
+
+        * [component-3: Description of issue and fix #3 (CVE-YYYY-NNNN)]
+
+        For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
+      solution: |
+        See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+
+         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+
+        Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+    rhba:
+      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} OLM Operators metadata update
+      topic: |
+        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+
+        This advisory will be used to release the corresponding Operator manifests by using new Operator metadata containers.
+      description: |
+        Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+
+        This advisory will be used to release the corresponding Operator manifests via new Operator metadata containers.
+
+        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+      solution: |   
+        See the following documentation, which will be updated shortly for this
+        release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+        
+        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+        
+        Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+  microshift:
+    rhsa:
+      synopsis: Red Hat build of MicroShift 4.{MINOR}.{PATCH} security update
+      topic: |
+        Red Hat build of MicroShift release 4.{MINOR}.{PATCH} is now available with updates to packages and images that include a security update.
+        
+        Red Hat Product Security has rated this update as having a security impact of {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
+      description: |
+        Red Hat build of MicroShift is Red Hat's light-weight Kubernetes orchestration solution designed for edge device deployments and is built from the edge capabilities of Red Hat OpenShift Container Platform. MicroShift is an application that is deployed on top of Red Hat Enterprise Linux devices at the edge, providing an efficient way to operate single-node clusters in these low-resource environments.
+
+        This advisory contains the RPM packages for Red Hat build of MicroShift 4.{MINOR}.{PATCH}. Read the following advisory for the container images for this release:
+        
+        https://access.redhat.com/errata/RHSA-XXXX:XXXX
+        
+        All Red Hat build of MicroShift 4.{MINOR} users are advised to use these updated packages and images when they are available in the RPM repository.
+      solution: |
+        For MicroShift 4.{MINOR}, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
+
+        https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
+      security_reviewer: sfowler@redhat.com
+    rhba:
+      synopsis: Red Hat build of MicroShift 4.{MINOR}.{PATCH} bug fix and enhancement update
+      topic: Red Hat build of MicroShift release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+      description: |
+        Red Hat build of MicroShift is Red Hat's light-weight Kubernetes orchestration solution designed for edge device deployments and is built from the edge capabilities of Red Hat OpenShift. MicroShift is an application that is deployed on top of Red Hat Enterprise Linux devices at the edge, providing an efficient way to operate single-node clusters in these low-resource environments.
+
+        This advisory contains the RPM packages for Red Hat build of MicroShift 4.{MINOR}.{PATCH}. Read the following advisory for the container images for this release:
+        
+        https://access.redhat.com/errata/RHXX-XXXX:XXXX
+        
+        All of the bug fixes may not be documented in this advisory. Read the following release notes documentation for details about these changes:
+        
+        https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
+        
+        All Red Hat build of MicroShift 4.{MINOR} users are advised to use these updated packages and images when they are available in the RPM repository.
+
+      solution: |
+        For MicroShift 4.{MINOR}.{PATCH}, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
+        
+        https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
+  bootimage:
+    synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} packages update
+    topic: Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+    description: |
+      Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments. This advisory contains extra RPM packages used in building the initial Red Hat OpenShift Container Platform 4.{MINOR} RHCOS boot-images. See the following advisory for the container images for this release:
+      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
+      There is no need for users to deploy these packages directly, as they are used only indirectly the first time a node is booted.
+    solution: |
+      See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+      https://docs.openshift.com/container-platform/4.{MINOR}/release_notes/ocp-4-{MINOR}-release-notes.html
+      Details on how to access this content are available at https://docs.openshift.com/container-platform/4.{MINOR}/updating/updating-cluster-cli.html
+  prerelease:
+    synopsis: OpenShift Container Platform 4.{MINOR} OLM Operators pre-release
+    topic: |
+      This advisory will be used to pre-release OCP 4.{MINOR} operator bundles and the container image builds on which they depend.
+    description: |
+      Although named OCP product builds are made public for testing prior to release, optional operators cannot be provided in the same way, which is a gap for partners and customers following the latest developments.
+    solution: |
+      This advisory will be used to pre-release OCP 4.{MINOR} operator bundles and the container image builds on which they depend.
+  advance:
+    release: "RHOSE ASYNC"
+    synopsis: OpenShift Container Platform 4.{MINOR} OLM Operators advance release
+    topic: |
+      Red Hat OpenShift Container Platform release 4.{MINOR}.0 is now available with updates to packages and images. This advisory will be used to release Operator manifests via new Operator metadata containers, as well as container images that are dependencies for the Operators.
+    description: |
+      Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments. This advisory will be used to release Operator manifests via new Operator metadata containers, as well as container images that are dependencies for the Operators.
+      All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.{MINOR}/updating/updating-cluster-cli.html
+    solution: |
+      See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+
+      https://docs.openshift.com/container-platform/4.{MINOR}/release_notes/ocp-4-{MINOR}-release-notes.html
+
+      Details on how to access this content are available at https://docs.openshift.com/container-platform/4.{MINOR}/updating/updating-cluster-cli.html

--- a/erratatool.yml
+++ b/erratatool.yml
@@ -52,11 +52,7 @@ boilerplates:
         
         Security Fix(es):
         
-        * [component-1: Description of issue and fix #1 (CVE-YYYY-NNNN)]
-        
-        * [component-2: Description of issue and fix #2 (CVE-YYYY-NNNN)]
-        
-        * [component-3: Description of issue and fix #3 (CVE-YYYY-NNNN)]
+        {CVES}
         
         For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
         
@@ -141,11 +137,7 @@ boilerplates:
           
           Security Fix(es):
           
-          * [component-1: Description of issue and fix #1 (CVE-YYYY-NNNN)]
-          
-          * [component-2: Description of issue and fix #2 (CVE-YYYY-NNNN)]
-          
-          * [component-3: Description of issue and fix #3 (CVE-YYYY-NNNN)]
+          {CVES}
           
           For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
           
@@ -193,11 +185,7 @@ boilerplates:
 
         Security Fix(es):
 
-        * [component-1: Description of issue and fix #1 (CVE-YYYY-NNNN)]
-
-        * [component-2: Description of issue and fix #2 (CVE-YYYY-NNNN)]
-
-        * [component-3: Description of issue and fix #3 (CVE-YYYY-NNNN)]
+        {CVES}
 
         For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
 
@@ -237,11 +225,7 @@ boilerplates:
 
         Security Fix(es):
 
-        * [component-1: Description of issue and fix #1 (CVE-YYYY-NNNN)]
-
-        * [component-2: Description of issue and fix #2 (CVE-YYYY-NNNN)]
-
-        * [component-3: Description of issue and fix #3 (CVE-YYYY-NNNN)]
+        {CVES}
 
         For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
       solution: |


### PR DESCRIPTION
For 4.12 and 4.13, the templates are different: https://docs.google.com/spreadsheets/d/1pySmokqVb-zNYmoZ5D43LQJ8GJh50idwC4Ow_Sn15Gg/edit?gid=1797967923#gid=1797967923

Keeping the config here (`erratatool.yml`) will override the default config (https://github.com/openshift-eng/ocp-build-data/blob/main/config/advisory_templates.yml)