### PR TITLE
Remove EXTRA mentions

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -19,7 +19,7 @@
 
 golang-1.19:
   aliases:
-  - rhel-8-golang-{GO_EXTRA}
+  - rhel-8-golang-1.19
   image: openshift/golang-builder:v1.19.13-202410181055.gfa00de2.el8
   mirror: true
   transform: rhel-8/golang
@@ -45,7 +45,7 @@ golang:
 
 rhel-9-golang-1.19:
   aliases:
-  - rhel-9-golang-{GO_EXTRA}
+  - rhel-9-golang-1.19
   image: openshift/golang-builder:v1.19.13-202410181055.g3172d57.el9
   mirror: true
   transform: rhel-9/golang


### PR DESCRIPTION
ValueError: Duplicate alias detected: rhel-8-golang-{GO_EXTRA} is already mapped to golang-1.19

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/139/console