### PR TITLE
ART-12704 add exempt rpms

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -98,6 +98,16 @@ rhcos:
     - kernel  # since 9.3, kernel-rt is merged into the kernel package.
     ose-ovn-kubernetes:
     - libreswan
+  exempt_rpms:
+  - conmon
+  - containers-common
+  - crun
+  - ose-aws-ecr-image-credential-provider
+  - skopeo
+  - toolbox
+  - crun-wasm
+  - lld
+  - llvm
   allow_missing_brew_rpms: false
   layered_rhcos: True
 

--- a/group.yml
+++ b/group.yml
@@ -98,7 +98,7 @@ rhcos:
     - kernel  # since 9.3, kernel-rt is merged into the kernel package.
     ose-ovn-kubernetes:
     - libreswan
-  exempt_rpms:
+  exempt_rpms: # skip check these rpms as they will aligned with rhel base image in rhcos
   - conmon
   - containers-common
   - crun

--- a/group.yml
+++ b/group.yml
@@ -99,12 +99,6 @@ rhcos:
     ose-ovn-kubernetes:
     - libreswan
   exempt_rpms: # skip check these rpms as they will aligned with rhel base image in rhcos
-  - conmon
-  - containers-common
-  - crun
-  - ose-aws-ecr-image-credential-provider
-  - skopeo
-  - toolbox
   - crun-wasm
   - lld
   - llvm


### PR DESCRIPTION
Add exempt rpms for node image rpm check because they could be outdated to align with rhel base image