### PR TITLE
[4.18] Enable hermetic mode for additional images

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -29,5 +29,3 @@ name: openshift/ose-baremetal-machine-controllers-rhel9
 payload_name: baremetal-machine-controllers
 owners:
   - metal-platform@redhat.com
-konflux:
-  network_mode: open

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -29,5 +29,3 @@ name: openshift/ose-cluster-etcd-rhel9-operator
 payload_name: cluster-etcd-operator
 owners:
 - sbatsche@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -34,5 +34,3 @@ name: openshift/ose-olm-operator-controller-rhel9
 payload_name: olm-operator-controller
 owners:
 - aos-odin@redhat.com
-konflux:
-  network_mode: open


### PR DESCRIPTION
Enable hermetic mode for images which have only `cachito` and no `enabled_repos`