### PR TITLE
disable prefetch for failing images

### DIFF
--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -31,3 +31,7 @@ payload_name: ibmcloud-cluster-api-controllers
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
+konflux:
+  # Upstream has to fix their vendor.
+  cachi2:
+    enabled: false

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -27,3 +27,7 @@ name: openshift/metallb-rhel9
 name_in_bundle: metallb-rhel9
 owners:
 - metallb-dev@redhat.com
+konflux:
+  # Upstream has to fix their vendor.
+  cachi2:
+    enabled: false

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -31,3 +31,7 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
+konflux:
+  # Upstream has to fix their vendor.
+  cachi2:
+    enabled: false


### PR DESCRIPTION
Since we removed the `modifications` to unblock brew builds, these images started to fail. Disabling cachi2/prefetch for now, while we raise an upstream PR to enable verify-deps CI test