### PR TITLE
product: Drop ose-hello-openshift-container mapping

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -668,8 +668,6 @@ bug_mapping:
       issue_component: Storage / Operators
     ose-haproxy-router-base-container:
       issue_component: Networking / router
-    ose-hello-openshift-container:
-      issue_component: Networking / router
     ose-hypershift-container:
       issue_component: HyperShift
     ose-ibm-cloud-controller-manager-container:


### PR DESCRIPTION
ART hasn't been building these images since 4.8's a6286e7476, with the router/ingress folks pivoting away in openshift/cluster-ingress-operator@8332af2f56 (openshift/cluster-ingress-operator#561).  Samples had been installing a hello-openshift ImageStream, but they also got away from that in 2021 with
openshift/cluster-samples-operator@d94ad97e49 (openshift/cluster-samples-operator#380).  [Origin hasn't entirely gotten out of the hello-openshift business yet][1], but regardless of whether they still have an interest, neither ART nor ingress is involved anymore, and it's been a long time since 4.7 went end-of-life:

```console
$ curl -s 'https://access.redhat.com/product-life-cycles/api/v1/products?name=Openshift+Container+Platform+4' | jq -r '.data[].versions[] | select(.name == "4.7").phases[] | .date + " " + .name' 2021-02-24T00:00:00.000Z General availability
2021-10-27T00:00:00.000Z Full support
2022-08-24T00:00:00.000Z Maintenance support
N/A Extended update support
N/A Extended update support Term 2
N/A Extended life phase
```

So I'm dropping those lines from the mapping.

[1]: https://github.com/openshift/origin/tree/94a4d2a6f202f64f89a1b747b44484c358f8299d/examples/hello-openshift