### PR TITLE
[4.20 ex.2] remove brewevent since its for konflux

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -4,6 +4,7 @@ releases:
       type: preview
       basis:
         time: "2025-05-26T07:41:37+00:00"
+        brew_event: 63905880
         reference_releases:
           x86_64: 4.20.0-0.nightly-2025-05-26-181128
       group:
@@ -41,17 +42,7 @@ releases:
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fb38d6b19b0199512ad91303b445b2f368e3a6caa27a6fee603c87e82f80444c
       members:
         rpms: [ ]
-        images:
-          - distgit_key: ose-insights-operator
-            why: Pin commit due to source commit conflict in upstream repo
-            metadata:
-              is:
-                nvr: ose-insights-operator-container-v4.20.0-202505210258.p0.g231bf07.assembly.stream.el9
-              content:
-                source:
-                  git:
-                    branch:
-                      target: 231bf07325dc47797b788ec90407d9db1a733211
+        images: [ ]
   ec.1:
     assembly:
       type: preview

--- a/releases.yml
+++ b/releases.yml
@@ -4,7 +4,6 @@ releases:
       type: preview
       basis:
         time: "2025-05-26T07:41:37+00:00"
-        brew_event: 63905880
         reference_releases:
           x86_64: 4.20.0-0.nightly-2025-05-26-181128
       group:


### PR DESCRIPTION
Our automation gets confused if it sees brewevent and search for brew builds when the builds are actually from konflux. Removing the brewevent should work