### PR TITLE
CNTRLPLANE-889: Allow etcd to move to go1.23 [4.18]

### DIFF
--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -14,6 +14,7 @@ cachito:
     - path: server
     - path: tests
     - path: tools/mod
+canonical_builders_from_upstream: true
 content:
   source:
     dockerfile: Dockerfile.art
@@ -27,7 +28,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-9-golang-1.23-ci-build-root
     okd_alignment:
       dockerfile: Dockerfile.rhel
 distgit:
@@ -42,7 +43,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.23
   member: openshift-enterprise-base-rhel9
 labels:
   License: Apache 2.0

--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -15,6 +15,7 @@ cachito:
     - path: server
     - path: tests
     - path: tools/mod
+canonical_builders_from_upstream: true
 content:
   source:
     dockerfile: Dockerfile.installer.art
@@ -29,7 +30,7 @@ content:
       streams_prs:
         enabled: false
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-9-golang-1.23-ci-build-root
     okd_alignment:
       dockerfile: Dockerfile.installer
 distgit:
@@ -44,11 +45,11 @@ from:
   builder:
   # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
   # approval to diverge from what kube apiserver uses for a given release.
-  - stream: rhel-9-golang
-  - stream: rhel-9-golang
-  - stream: rhel-9-golang
-  - stream: rhel-9-golang
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.23
+  - stream: rhel-9-golang-1.23
+  - stream: rhel-9-golang-1.23
+  - stream: rhel-9-golang-1.23
+  - stream: rhel-9-golang-1.23
   member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+


### PR DESCRIPTION
This PR:
- Sets that production build data "listens to upstream" for base images
- Will open two PRs to update the Dockerfiles to go1.23

Probably, best to update the relevant Containerfiles and .ci-operator.yaml by hand. Automation will notice if that happened, and start to build things correctly.