### PR TITLE
4.18: Pin etcd to build before go1.23 bump

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1463,3 +1463,13 @@ releases:
                 exempt_rpms:
                   - redhat-release* # documents rhel release notes and concerns
                   - tzdata
+          - distgit_key: ose-etcd
+            why: excluding ETCD-727 as microshift does not like golang-1.23
+            metadata:
+              is:
+                nvr: ose-etcd-container-v4.18.0-202506031105.p0.g72173bc.assembly.stream.el9
+          - distgit_key: ose-installer-etcd-artifacts
+            why: excluding ETCD-727 as microshift does not like golang-1.23
+            metadata:
+              is:
+                nvr: ose-installer-etcd-artifacts-container-v4.18.0-202506031105.p0.g72173bc.assembly.stream.el9


### PR DESCRIPTION
etcd requiring go1.23 makes MicroShift rpm builds fail, as its build root is go1.22 based. Pinning to last good build to help tomorrow's zstream release preparation.

[Thread](https://redhat-internal.slack.com/archives/C0310LGMQQY/p1749029774807059?thread_ts=1749029648.024779&cid=C0310LGMQQY)