### PR TITLE
refactor vendor name to Red Hat, Inc.

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -45,6 +45,7 @@ labels:
   io.k8s.description: This is a component of OpenShift Container Platform and provides a web console.
   io.k8s.display-name: OpenShift Console
   io.openshift.tags: openshift,console
+  vendor: Red Hat, Inc.
 name: openshift/ose-console-rhel9
 payload_name: console
 owners:


### PR DESCRIPTION
Fixes failing Conforma policy check: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/openshift-4-19/pipelineruns/managed-f7ftx/logs

```
  Reason: The "vendor" label has an unexpected "Red Hat" value. Must be one of: Red Hat, Inc.
```

Since upstream has defined it like that: https://github.com/openshift/console/blob/release-4.20/Dockerfile#L73

Has to be cherry picked all the way down to 4.12