### PR TITLE
pinning sriov with correct imagestreams

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -50,6 +50,21 @@ releases:
               is:
                 nvr: cluster-nfd-operator-container-v4.19.0-202506021915.p0.g54c0a77.assembly.stream.el9
             why: This contains fix for nfd operator. Pinning correct nfd to assembly.
+          - distgit_key: sriov-network-operator
+            metadata:
+              is:
+                nvr: sriov-network-operator-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9
+            why: Pinning build for sriov
+          - distgit_key: sriov-network-webhook-container
+            metadata:
+              is:
+                nvr: sriov-network-webhook-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9
+            why: Pinning build for sriov-network-webook-container
+          - distgit_key: sriov-network-config-daemon-container
+            metadata:
+              is:
+                nvr: sriov-network-config-daemon-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9
+            why: Pinning build for sriov-network-config-daemon-container
   rc.4:
     assembly:
       type: candidate

--- a/releases.yml
+++ b/releases.yml
@@ -55,7 +55,7 @@ releases:
               is:
                 nvr: sriov-network-operator-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9
             why: Pinning build for sriov
-          - distgit_key: sriov-network-webhook-container
+          - distgit_key: sriov-network-webhook
             metadata:
               is:
                 nvr: sriov-network-webhook-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9

--- a/releases.yml
+++ b/releases.yml
@@ -60,7 +60,7 @@ releases:
               is:
                 nvr: sriov-network-webhook-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9
             why: Pinning build for sriov-network-webook-container
-          - distgit_key: sriov-network-config-daemon-container
+          - distgit_key: sriov-network-config-daemon
             metadata:
               is:
                 nvr: sriov-network-config-daemon-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9


### PR DESCRIPTION
As per the slack thread conversation these images are required in 4.19:

https://redhat-internal.slack.com/archives/CB95J6R4N/p1749112753370699

[sriov-network-operator-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676510)
[sriov-network-webhook-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676507)
[sriov-network-config-daemon-container-v4.19.0-202506041351.p0.gf66d332.assembly.stream.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3676508)
