### PR TITLE
remove gomod for ovn

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -10,8 +10,6 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-9-golang-1.23-ci-build-root
-    pkg_managers:
-    - gomod
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ovn-kubernetes-container

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -10,8 +10,6 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
-    pkg_managers:
-    - gomod
 distgit:
   component: ovn-kubernetes-microshift-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9


### PR DESCRIPTION
Upstream doesnt have a go.mod file: https://github.com/openshift/ovn-kubernetes/tree/release-4.18