### PR TITLE
Updates MicroShift bootc image boiler plate advisory text

### DIFF
--- a/config/advisory_templates.yml
+++ b/config/advisory_templates.yml
@@ -68,28 +68,28 @@ boilerplates:
       solution: |
         For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions
         on how to upgrade your cluster and fully apply this asynchronous errata update:
-        
+
         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
-        
+
         You can download the oc tool and use it to inspect release image metadata
         for x86_64, s390x, ppc64le, and aarch64 architectures. The image digests
         can be found at
         https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags.
-        
+
         The sha values for the release are as follows:
-        
+
         (For x86_64 architecture)
         The image digest is sha256:<SHASUM_HERE>
-        
+
         (For s390x architecture)
         The image digest is sha256:<SHASUM_HERE>
-        
+
         (For ppc64le architecture)
         The image digest is sha256:<SHASUM_HERE>
-        
+
         (For aarch64 architecture)
         The image digest is sha256:<SHASUM_HERE>
-        
+
         All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate
         release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
   rpm:
@@ -105,15 +105,15 @@ boilerplates:
         Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
 
         This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
-        
+
         https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
-        
+
         Security Fix(es):
-        
+
         {CVES}
-        
+
         For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
-        
+
         All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       solution: |
         For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
@@ -131,13 +131,13 @@ boilerplates:
         https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
 
         All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at
-        
+
         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli."
       solution: |
         See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
-        
+
         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
-        
+
         Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
   extras:
     rhsa:
@@ -185,9 +185,9 @@ boilerplates:
         See the following documentation, which will be updated shortly for this
         release, for important instructions on how to upgrade your cluster and
         fully apply this asynchronous errata update:
-        
+
         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
-        
+
         Details on how to access this content are available at
         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
   metadata:
@@ -209,7 +209,7 @@ boilerplates:
         See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
-        
+
         Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       security_reviewer: sfowler@redhat.com
     rhba:
@@ -226,28 +226,28 @@ boilerplates:
         All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       solution: |
         See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
-        
+
         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
-        
+
         Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli
   microshift:
     rhsa:
       synopsis: Red Hat build of MicroShift 4.{MINOR}.{PATCH} security update
       topic: |
         Red Hat build of MicroShift release 4.{MINOR}.{PATCH} is now available with updates to packages and images that include a security update.
-        
+
         Red Hat Product Security has rated this update as having a security impact of {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
       description: |
         Red Hat build of MicroShift is Red Hat's light-weight Kubernetes orchestration solution designed for edge device deployments and is built from the edge capabilities of Red Hat OpenShift Container Platform. MicroShift is an application that is deployed on top of Red Hat Enterprise Linux devices at the edge, providing an efficient way to operate single-node clusters in these low-resource environments.
 
         This advisory contains the RPM packages for Red Hat build of MicroShift 4.{MINOR}.{PATCH}. Read the following advisory for the container images for this release:
-        
+
         https://access.redhat.com/errata/RHSA-XXXX:XXXX
-        
+
         Security Fix(es):
 
         {CVES}
-        
+
         All Red Hat build of MicroShift 4.{MINOR} users are advised to use these updated packages and images when they are available in the RPM repository.
       solution: |
         For MicroShift 4.{MINOR}, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
@@ -261,26 +261,26 @@ boilerplates:
         Red Hat build of MicroShift is Red Hat's light-weight Kubernetes orchestration solution designed for edge device deployments and is built from the edge capabilities of Red Hat OpenShift. MicroShift is an application that is deployed on top of Red Hat Enterprise Linux devices at the edge, providing an efficient way to operate single-node clusters in these low-resource environments.
 
         This advisory contains the RPM packages for Red Hat build of MicroShift 4.{MINOR}.{PATCH}. Read the following advisory for the container images for this release:
-        
+
         https://access.redhat.com/errata/RHXX-XXXX:XXXX
-        
+
         All of the bug fixes may not be documented in this advisory. Read the following release notes documentation for details about these changes:
-        
+
         https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
-        
+
         All Red Hat build of MicroShift 4.{MINOR} users are advised to use these updated packages and images when they are available in the RPM repository.
 
       solution: |
         For MicroShift 4.{MINOR}.{PATCH}, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
-        
+
         https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
   microshift-bootc:
     synopsis: Red Hat build of MicroShift 4.{MINOR}, image mode for RHEL
     topic: Red Hat build of MicroShift 4.{MINOR}, image mode for RHEL
     description: |
-      Red Hat build of MicroShift is Red Hat's light-weight Kubernetes orchestration solution designed for edge device deployments and is built from the edge capabilities of Red Hat OpenShift. MicroShift is deployed on top of Red Hat Enterprise Linux (RHEL) devices at the edge, providing a single-node cluster in these low-resource environments. Image mode for RHEL is used to build, test, and deploy operating systems by using the same tools and techniques as application containers. RHEL bootc images contain the additional components necessary to boot.
+      Red Hat build of MicroShift is Red Hat's light-weight Kubernetes orchestration solution designed for edge device deployments and is built from Red Hat OpenShift. This microshift-bootc image can be used to boot and install MicroShift using image mode for Red Hat Enterprise Linux (RHEL). It can also be used as a base layer for customized solutions with MicroShift. For example, by layering applications and configurations on top of the base microshift-bootc image during image building.
     solution: |
-      For MicroShift 4.{MINOR}, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update: https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
+      For MicroShift 4.{MINOR}, read the following documentation for details on any important changes to this image: https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
   bootimage:
     synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} packages update
     topic: Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.


### PR DESCRIPTION
See https://issues.redhat.com/browse/OSDOCS-14853 for details; this PR creates separate advisory text for the **image mode for RHEL MicroShift ready-to-use image** so that it is different than the general advisory text for MicroShift product releases.

Please cherry-pick to 4.18 and 4.19 branches as applicable.