### PR TITLE
add exempt_rpms for layered rhcos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -99,6 +99,10 @@ rhcos:
     - kernel  # since 9.3, kernel-rt is merged into the kernel package.
     ose-ovn-kubernetes:
     - libreswan
+  exempt_rpms: # skip check these rpms as they will aligned with rhel base image in rhcos
+  - crun-wasm
+  - lld
+  - llvm
   allow_missing_brew_rpms: false
   layered_rhcos: True
 


### PR DESCRIPTION
Add exempt rpms for node image rpm check because they could be outdated to align with rhel base image