### PR TITLE
[4.17] monitoring fix

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -22,7 +22,7 @@ content:
       match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
       replacement: |-
         COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/.npmrc
+        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/.npmrc $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/.yarnrc
 
     pkg_managers:
     - yarn


### PR DESCRIPTION
Looking at https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=67912372

```
2025-06-11 15:33:32,837 - atomic_reactor.tasks.binary_container_build - INFO - cp: cannot stat '/remote-source/cachito-gomod-with-deps/app/web/.yarnrc': No such file or directory
```