### PR TITLE
[4.16] monitoring fix

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -15,7 +15,7 @@ content:
       match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
       replacement: |-
         COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/.npmrc
+        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/.npmrc $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/.yarnrc
     pkg_managers:
     - yarn
     artifacts:


### PR DESCRIPTION
Looking at https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=67913936

```
2025-06-11 17:30:21,690 - atomic_reactor.tasks.binary_container_build - INFO - touch: cannot touch '/remote-source/cachito-gomod-with-deps/app/web/registry-ca.pem': No such file or directory
2025-06-11 17:30:21,690 - atomic_reactor.tasks.binary_container_build - INFO - touch: cannot touch '/remote-source/cachito-gomod-with-deps/app/web/.npmrc': No such file or directory
```
Since path is default dir