### PR TITLE
[4.14] monitoring fix

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -10,6 +10,12 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
+    modifications:
+      - action: replace
+        match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
+        replacement: |-
+          COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
+          RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/.npmrc $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/.yarnrc
     pkg_managers:
     - yarn
     artifacts:


### PR DESCRIPTION
Looking at https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=67912777

```
2025-06-11 16:26:12,641 - atomic_reactor.tasks.binary_container_build - INFO - cp: cannot stat '/remote-source/cachito-gomod-with-deps/app/.npmrc': No such file or directory
2025-06-11 16:26:12,641 - atomic_reactor.tasks.binary_container_build - INFO - cp: cannot stat '/remote-source/cachito-gomod-with-deps/app/.yarnrc': No such file or directory
2025-06-11 16:26:12,644 - atomic_reactor.tasks.binary_container_build - INFO - cp: cannot stat '/remote-source/cachito-gomod-with-deps/app/registry-ca.pem': No such file or directory
```