### PR TITLE
Revert "Add required annotations to make EC happy"

### DIFF
--- a/bundle/manifests/helloworld-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/helloworld-operator.clusterserviceversion.yaml
@@ -31,9 +31,6 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    features.operators.openshift.io/cnf: "false"
-    features.operators.openshift.io/cni: "false"
-    features.operators.openshift.io/csi: "false"
   name: helloworld-operator.v0.0.1
   namespace: placeholder
 spec:


### PR DESCRIPTION
This reverts commit 1a444eee3a8c3f9ba3542ccd359b77e1b2dbdc7f.

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1750106081479639 has been resvoled, these annotations have been removed from mandatory status. Removing it from helloworld-operator to test out the prod pipeline.