### PR TITLE
helloworld-operator: Add bundle_delivery_repo_name

### DIFF
--- a/images/helloworld-operator.yml
+++ b/images/helloworld-operator.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name:  helloworld-operator
+  bundle_delivery_repo_name: openshift4/helloworld-operator-bundle
 for_payload: false
 from:
   builder:


### PR DESCRIPTION
Needs to explicitly specify the delivery repo name of the operator bundle in order to generate correct FBC segments.