### PR TITLE
Add bundle_delivery_repo_name for all OLM bundles - 4.20

### DIFF
--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-nfd-operator
+  bundle_delivery_repo_name: openshift4/ose-cluster-nfd-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-clusterresourceoverride-operator
+  bundle_delivery_repo_name: openshift4/ose-clusterresourceoverride-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/dpu-operator.yml
+++ b/images/dpu-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-dpu-operator
+  bundle_delivery_repo_name: openshift4/ose-dpu-rhel9-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/ingress-node-firewall-operator.yml
+++ b/images/ingress-node-firewall-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ingress-node-firewall-operator
+  bundle_delivery_repo_name: openshift4/ingress-node-firewall-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-local-storage-operator
+  bundle_delivery_repo_name: openshift4/ose-local-storage-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: kubernetes-nmstate-operator
+  bundle_delivery_repo_name: openshift4/kubernetes-nmstate-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-aws-efs-csi-driver-operator
+  bundle_delivery_repo_name: openshift4/ose-aws-efs-csi-driver-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/ose-gcp-filestore-csi-driver-operator.yml
+++ b/images/ose-gcp-filestore-csi-driver-operator.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-gcp-filestore-csi-driver-operator
+  bundle_delivery_repo_name: openshift4/ose-gcp-filestore-csi-driver-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: metallb-operator
+  bundle_delivery_repo_name: openshift4/ose-metallb-operator-bundle
 name: openshift/metallb-rhel9-operator
 name_in_bundle: metallb-rhel9-operator # matches exactly the name in image-references
 for_payload: false

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-secrets-store-csi-driver-operator
+  bundle_delivery_repo_name: openshift4/ose-secrets-store-csi-driver-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-smb-csi-driver-operator
+  bundle_delivery_repo_name: openshift4/ose-smb-csi-driver-rhel9-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/pf-status-relay-operator.yml
+++ b/images/pf-status-relay-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: pf-status-relay-operator-container
+  bundle_delivery_repo_name: openshift4/pf-status-relay-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -40,3 +40,5 @@ konflux:
   cachi2:
     enabled: false
   network_mode: open
+delivery:
+  bundle_delivery_repo_name: openshift4/ose-ptp-operator-bundle

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-sriov-network-operator
+  bundle_delivery_repo_name: openshift4/ose-sriov-network-operator-bundle
 for_payload: false
 from:
   builder:

--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-vertical-pod-autoscaler-operator
+  bundle_delivery_repo_name: openshift4/ose-vertical-pod-autoscaler-operator-bundle
 for_payload: false
 from:
   builder:


### PR DESCRIPTION
This field will be required by building FBC segments on Konflux.