### PR TITLE
[4.20] Reinstate brew event for ec.2

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -3,7 +3,8 @@ releases:
     assembly:
       type: preview
       basis:
-        time: "2025-05-26T07:41:37+00:00"
+        time: "2025-05-26T07:41:37+00:00"  # required for konflux image advisories prep
+        brew_event: 63905880  # required for brew rpm advisories prep
         reference_releases:
           x86_64: 4.20.0-0.nightly-2025-05-26-181128
       group:


### PR DESCRIPTION
Lack of brew event breaks microshift jobs and will break rpm prep as well.
Until we have rpm prep working with basis.time, we need this defined.