### PR TITLE
[4.20 ec.2] Pin cri-o to build microshift-bootc

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,11 @@ releases:
         reference_releases:
           x86_64: 4.20.0-0.nightly-2025-05-26-181128
       group:
+        dependencies:
+          rpms:
+            - el9: cri-o-1.33.1-2.rhaos4.20.gitde5978d.el9
+              non_gc_tag: insert tag here if needed
+              why: microshift-bootc build needs it
         advisories:
           rpm: 149403
           prerelease: 150366


### PR DESCRIPTION
Fix for bootc failure: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc/110/console

slack ref: https://redhat-internal.slack.com/archives/CB95J6R4N/p1750254395157229?thread_ts=1750240522.131989&cid=CB95J6R4N

Build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc/112/console