### PR TITLE
add explicit delivery repo names

### DIFF
--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-autoscaler
+  delivery_repo_name: openshift4/ose-cluster-autoscaler-rhel9
 for_payload: true
 from:
   builder:

--- a/images/aws-karpenter-provider-aws.yml
+++ b/images/aws-karpenter-provider-aws.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: aws-karpenter-provider-aws
+  delivery_repo_name: openshift4/aws-karpenter-provider-aws-rhel9
 for_payload: true
 payload_name: aws-karpenter-provider-aws
 from:

--- a/images/aws-kms-encryption-provider.yml
+++ b/images/aws-kms-encryption-provider.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: aws-kms-encryption-provider
+  delivery_repo_name: openshift4/aws-kms-encryption-provider-rhel9
 for_payload: true
 from:
   builder:

--- a/images/azure-file-csi-driver-operator.yml
+++ b/images/azure-file-csi-driver-operator.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-azure-file-csi-driver-operator
+  delivery_repo_name: openshift4/ose-azure-file-csi-driver-operator-rhel9
 for_payload: true
 from:
   builder:

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-azure-file-csi-driver
+  delivery_repo_name: openshift4/ose-azure-file-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/azure-kms-encryption-provider.yml
+++ b/images/azure-kms-encryption-provider.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: azure-kms-encryption-provider
+  delivery_repo_name: openshift4/azure-kms-encryption-provider-rhel9
 for_payload: true
 from:
   builder:

--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-baremetal-machine-controllers
+  delivery_repo_name: openshift4/ose-baremetal-machine-controllers-rhel9
 for_payload: true
 from:
   builder:
@@ -28,4 +29,4 @@ from:
 name: openshift/ose-baremetal-machine-controllers-rhel9
 payload_name: baremetal-machine-controllers
 owners:
-  - metal-platform@redhat.com
+- metal-platform@redhat.com

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-baremetal-runtimecfg
+  delivery_repo_name: openshift4/ose-baremetal-runtimecfg-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cloud-event-proxy
+  delivery_repo_name: openshift4/ose-cloud-event-proxy-rhel9
 for_payload: false
 from:
   builder:

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-etcd-operator
+  delivery_repo_name: openshift4/ose-cluster-etcd-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/cluster-monitoring-operator.yml
+++ b/images/cluster-monitoring-operator.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-monitoring-operator
+  delivery_repo_name: openshift4/ose-cluster-monitoring-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-network-operator
+  delivery_repo_name: openshift4/ose-cluster-network-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -18,6 +18,7 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-nfd-operator
   bundle_delivery_repo_name: openshift4/ose-cluster-nfd-operator-bundle
+  delivery_repo_name: openshift4/ose-cluster-nfd-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-node-tuning-operator
+  delivery_repo_name: openshift4/ose-cluster-node-tuning-rhel9-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-policy-controller.yml
+++ b/images/cluster-policy-controller.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-policy-controller
+  delivery_repo_name: openshift4/ose-cluster-policy-controller-rhel9
 for_payload: true
 from:
   builder:

--- a/images/cluster-storage-operator.yml
+++ b/images/cluster-storage-operator.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-storage-operator
+  delivery_repo_name: openshift4/ose-cluster-storage-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-version-operator
+  delivery_repo_name: openshift4/ose-cluster-version-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-clusterresourceoverride
+  delivery_repo_name: openshift4/ose-clusterresourceoverride-rhel9
 for_payload: false
 from:
   builder:

--- a/images/configmap-reload.yml
+++ b/images/configmap-reload.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-configmap-reloader
+  delivery_repo_name: openshift4/ose-configmap-reloader-rhel9
 for_payload: true
 from:
   builder:

--- a/images/container-networking-plugins-microshift.yml
+++ b/images/container-networking-plugins-microshift.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: container-networking-plugins-microshift
+  delivery_repo_name: openshift4/container-networking-plugins-microshift-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-coredns
+  delivery_repo_name: openshift4/ose-coredns-rhel9
 for_payload: true
 from:
   builder:

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-external-attacher
+  delivery_repo_name: openshift4/ose-csi-external-attacher-rhel9
 for_payload: true
 from:
   builder:

--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-driver-manila-operator
+  delivery_repo_name: openshift4/ose-csi-driver-manila-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-driver-manila
+  delivery_repo_name: openshift4/ose-csi-driver-manila-rhel9
 for_payload: true
 from:
   builder:

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-driver-nfs
+  delivery_repo_name: openshift4/ose-csi-driver-nfs-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -25,6 +25,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-livenessprobe
+  delivery_repo_name: openshift4/ose-csi-livenessprobe-rhel9
 for_payload: true
 from:
   builder:

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -25,6 +25,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-node-driver-registrar
+  delivery_repo_name: openshift4/ose-csi-node-driver-registrar-rhel9
 for_payload: true
 from:
   builder:

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-external-provisioner
+  delivery_repo_name: openshift4/ose-csi-external-provisioner-rhel9
 for_payload: true
 from:
   builder:

--- a/images/dpu-cni.yml
+++ b/images/dpu-cni.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-dpu-cni
+  delivery_repo_name: openshift4/ose-dpu-cni-rhel9
 for_payload: false
 from:
   builder:

--- a/images/dpu-daemon.yml
+++ b/images/dpu-daemon.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-dpu-daemon
+  delivery_repo_name: openshift4/ose-dpu-daemon-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/dpu-intel-ipu-p4sdk.yml
+++ b/images/dpu-intel-ipu-p4sdk.yml
@@ -20,6 +20,7 @@ distgit:
   component: dpu-intel-ipu-p4sdk-container
 delivery:
   repo_name: ose-dpu-intel-ipu-p4sdk
+  delivery_repo_name: openshift4/ose-dpu-intel-ipu-p4sdk-rhel9
 for_payload: false
 from:
   member: openshift-enterprise-base-rhel9

--- a/images/dpu-intel-ipu-vsp.yml
+++ b/images/dpu-intel-ipu-vsp.yml
@@ -36,6 +36,7 @@ enabled_repos:
 - rhel-9-server-ose-rpms-embargoed
 delivery:
   repo_name: ose-dpu-intel-ipu-vsp
+  delivery_repo_name: openshift4/ose-dpu-intel-ipu-vsp-rhel9
 for_payload: false
 from:
   builder:

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: driver-toolkit
+  delivery_repo_name: openshift4/driver-toolkit-rhel9
 enabled_repos:
 - rhel-9-server-ose-rpms-embargoed
 - rhel-9-baseos-rpms

--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: egress-router-cni
+  delivery_repo_name: openshift4/egress-router-cni-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/gcp-workload-identity-federation-webhook.yml
+++ b/images/gcp-workload-identity-federation-webhook.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-gcp-workload-identity-federation-webhook
+  delivery_repo_name: openshift4/ose-gcp-workload-identity-federation-webhook-rhel9
 for_payload: true
 from:
   builder:

--- a/images/golang-github-openshift-oauth-proxy.yml
+++ b/images/golang-github-openshift-oauth-proxy.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-oauth-proxy
+  delivery_repo_name: openshift4/ose-oauth-proxy-rhel9
 for_payload: true
 from:
   builder:

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-prometheus-alertmanager
+  delivery_repo_name: openshift4/ose-prometheus-alertmanager-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-prometheus-node-exporter
+  delivery_repo_name: openshift4/ose-prometheus-node-exporter-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-prometheus
+  delivery_repo_name: openshift4/ose-prometheus-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-hypershift
+  delivery_repo_name: openshift4/ose-hypershift-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-sriov-infiniband-cni
+  delivery_repo_name: openshift4/ose-sriov-infiniband-cni-rhel9
 for_payload: false
 from:
   builder:

--- a/images/ingress-node-firewall-daemon.yml
+++ b/images/ingress-node-firewall-daemon.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ingress-node-firewall
+  delivery_repo_name: openshift4/ingress-node-firewall-rhel9
 dependents:
 - ingress-node-firewall-operator
 for_payload: false

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -27,6 +27,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ironic-agent
+  delivery_repo_name: openshift4/ose-ironic-agent-rhel9
 for_payload: true
 from:
   member: openshift-enterprise-base-rhel9

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ironic-machine-os-downloader
+  delivery_repo_name: openshift4/ose-ironic-machine-os-downloader-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ironic-static-ip-manager
+  delivery_repo_name: openshift4/ose-ironic-static-ip-manager-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -27,6 +27,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ironic
+  delivery_repo_name: openshift4/ose-ironic-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: kube-compare-artifacts
+  delivery_repo_name: openshift4/kube-compare-artifacts-rhel9
 for_payload: false
 from:
   builder:

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-kube-proxy
+  delivery_repo_name: openshift4/ose-kube-proxy-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -29,6 +29,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-kube-rbac-proxy
+  delivery_repo_name: openshift4/ose-kube-rbac-proxy-rhel9
 for_payload: true
 from:
   builder:

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-kube-state-metrics
+  delivery_repo_name: openshift4/ose-kube-state-metrics-rhel9
 for_payload: true
 from:
   builder:

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ptp
+  delivery_repo_name: openshift4/ose-ptp-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-local-storage-diskmaker
+  delivery_repo_name: openshift4/ose-local-storage-diskmaker-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/local-storage-mustgather.yml
+++ b/images/local-storage-mustgather.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-local-storage-mustgather
+  delivery_repo_name: openshift4/ose-local-storage-mustgather-rhel9
 dependents:
 - local-storage-operator
 for_payload: false

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -21,6 +21,7 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-local-storage-operator
   bundle_delivery_repo_name: openshift4/ose-local-storage-operator-bundle
+  delivery_repo_name: openshift4/ose-local-storage-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-operator-marketplace
+  delivery_repo_name: openshift4/ose-operator-marketplace-rhel9
 for_payload: true
 from:
   builder:

--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -34,6 +34,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-monitoring-plugin
+  delivery_repo_name: openshift4/ose-monitoring-plugin-rhel9
 for_payload: true
 from:
   builder:

--- a/images/multus-cni-container-microshift.yml
+++ b/images/multus-cni-container-microshift.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-multus-cni-microshift
+  delivery_repo_name: openshift4/ose-multus-cni-microshift-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-multus-cni
+  delivery_repo_name: openshift4/ose-multus-cni-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/multus-networkpolicy.yml
+++ b/images/multus-networkpolicy.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-multus-networkpolicy
+  delivery_repo_name: openshift4/ose-multus-networkpolicy-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -31,6 +31,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-networking-console-plugin
+  delivery_repo_name: openshift4/ose-networking-console-plugin-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -35,6 +35,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: nmstate-console-plugin
+  delivery_repo_name: openshift4/nmstate-console-plugin-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-node-feature-discovery
+  delivery_repo_name: openshift4/ose-node-feature-discovery-rhel9
 for_payload: false
 from:
   builder:

--- a/images/oauth-server.yml
+++ b/images/oauth-server.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-oauth-server
+  delivery_repo_name: openshift4/ose-oauth-server-rhel9
 for_payload: true
 from:
   builder:

--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: oc-mirror-plugin
+  delivery_repo_name: openshift4/oc-mirror-plugin-rhel9
 for_payload: true
 from:
   builder:

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -30,6 +30,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ansible-operator
+  delivery_repo_name: openshift4/ose-ansible-rhel9-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-docker-builder
+  delivery_repo_name: openshift4/ose-docker-builder-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cli
+  delivery_repo_name: openshift4/ose-cli-rhel9
 for_payload: true
 from:
   builder:

--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-capacity
+  delivery_repo_name: openshift4/ose-cluster-capacity-rhel9
 for_payload: false
 from:
   builder:

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-console-operator
+  delivery_repo_name: openshift4/ose-console-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -34,6 +34,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-console
+  delivery_repo_name: openshift4/ose-console-rhel9
 for_payload: true
 from:
   builder:

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -13,6 +13,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-deployer
+  delivery_repo_name: openshift4/ose-deployer-rhel9
 for_payload: true
 from:
   member: openshift-enterprise-cli

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -13,6 +13,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-egress-dns-proxy
+  delivery_repo_name: openshift4/ose-egress-dns-proxy-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -12,6 +12,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-egress-router
+  delivery_repo_name: openshift4/ose-egress-router-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -12,6 +12,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-haproxy-router
+  delivery_repo_name: openshift4/ose-haproxy-router-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-helm-operator
+  delivery_repo_name: openshift4/ose-helm-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-hyperkube
+  delivery_repo_name: openshift4/ose-hyperkube-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -14,6 +14,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-keepalived-ipfailover
+  delivery_repo_name: openshift4/ose-keepalived-ipfailover-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-pod
+  delivery_repo_name: openshift4/ose-pod-rhel9
 for_payload: true
 from:
   builder:

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-docker-registry
+  delivery_repo_name: openshift4/ose-docker-registry-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-tests
+  delivery_repo_name: openshift4/ose-tests-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-kubernetes-nmstate-handler
+  delivery_repo_name: openshift4/ose-kubernetes-nmstate-handler-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/openshift-state-metrics.yml
+++ b/images/openshift-state-metrics.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-openshift-state-metrics
+  delivery_repo_name: openshift4/ose-openshift-state-metrics-rhel9
 for_payload: true
 from:
   builder:

--- a/images/openstack-cluster-api-controllers.yml
+++ b/images/openstack-cluster-api-controllers.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-openstack-cluster-api-controllers
+  delivery_repo_name: openshift4/ose-openstack-cluster-api-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/openstack-resource-controller.yml
+++ b/images/openstack-resource-controller.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: openstack-resource-controller
+  delivery_repo_name: openshift4/openstack-resource-controller-rhel9
 for_payload: true
 from:
   builder:

--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-operator-lifecycle-manager
+  delivery_repo_name: openshift4/ose-operator-lifecycle-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-operator-registry
+  delivery_repo_name: openshift4/ose-operator-registry-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-agent-installer-api-server
+  delivery_repo_name: openshift4/ose-agent-installer-api-server-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-agent-installer-csr-approver
+  delivery_repo_name: openshift4/ose-agent-installer-csr-approver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-agent-installer-node-agent
+  delivery_repo_name: openshift4/ose-agent-installer-node-agent-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-orchestrator.yml
+++ b/images/ose-agent-installer-orchestrator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-agent-installer-orchestrator
+  delivery_repo_name: openshift4/ose-agent-installer-orchestrator-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-agent-installer-utils
+  delivery_repo_name: openshift4/ose-agent-installer-utils-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-apiserver-network-proxy
+  delivery_repo_name: openshift4/ose-apiserver-network-proxy-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-aws-cloud-controller-manager.yml
+++ b/images/ose-aws-cloud-controller-manager.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-aws-cloud-controller-manager
+  delivery_repo_name: openshift4/ose-aws-cloud-controller-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-aws-cluster-api-controllers
+  delivery_repo_name: openshift4/ose-aws-cluster-api-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-aws-ebs-csi-driver-operator
+  delivery_repo_name: openshift4/ose-aws-ebs-csi-driver-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-aws-ebs-csi-driver
+  delivery_repo_name: openshift4/ose-aws-ebs-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -24,6 +24,7 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-aws-efs-csi-driver-operator
   bundle_delivery_repo_name: openshift4/ose-aws-efs-csi-driver-operator-bundle
+  delivery_repo_name: openshift4/ose-aws-efs-csi-driver-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -25,6 +25,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-aws-efs-csi-driver-container
+  delivery_repo_name: openshift4/ose-aws-efs-csi-driver-container-rhel9
 for_payload: false
 from:
   builder:

--- a/images/ose-aws-pod-identity-webhook.yml
+++ b/images/ose-aws-pod-identity-webhook.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-aws-pod-identity-webhook
+  delivery_repo_name: openshift4/ose-aws-pod-identity-webhook-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-azure-cloud-controller-manager.yml
+++ b/images/ose-azure-cloud-controller-manager.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-azure-cloud-controller-manager
+  delivery_repo_name: openshift4/ose-azure-cloud-controller-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-azure-cloud-node-manager.yml
+++ b/images/ose-azure-cloud-node-manager.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-azure-cloud-node-manager
+  delivery_repo_name: openshift4/ose-azure-cloud-node-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-azure-cluster-api-controllers
+  delivery_repo_name: openshift4/ose-azure-cluster-api-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-azure-disk-csi-driver-operator.yml
+++ b/images/ose-azure-disk-csi-driver-operator.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-azure-disk-csi-driver-operator
+  delivery_repo_name: openshift4/ose-azure-disk-csi-driver-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-azure-disk-csi-driver
+  delivery_repo_name: openshift4/ose-azure-disk-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-azure-service-operator.yml
+++ b/images/ose-azure-service-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: azure-service-operator
+  delivery_repo_name: openshift4/azure-service-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-azure-workload-identity-webhook
+  delivery_repo_name: openshift4/ose-azure-workload-identity-webhook-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-baremetal-cluster-api-controllers
+  delivery_repo_name: openshift4/ose-baremetal-cluster-api-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -15,13 +15,14 @@ content:
         baremetal-installer:
           requests:
             cpu: "3"
-            memory: 5Gi        
+            memory: 5Gi
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-installer-container
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-baremetal-installer
+  delivery_repo_name: openshift4/ose-baremetal-installer-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-baremetal-operator
+  delivery_repo_name: openshift4/ose-baremetal-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cli-artifacts
+  delivery_repo_name: openshift4/ose-cli-artifacts-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-cloud-credential-operator.yml
+++ b/images/ose-cloud-credential-operator.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cloud-credential-operator
+  delivery_repo_name: openshift4/ose-cloud-credential-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cloud-network-config-controller.yml
+++ b/images/ose-cloud-network-config-controller.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: cloud-network-config-controller
+  delivery_repo_name: openshift4/cloud-network-config-controller-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-api
+  delivery_repo_name: openshift4/ose-cluster-api-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-authentication-operator.yml
+++ b/images/ose-cluster-authentication-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-authentication-operator
+  delivery_repo_name: openshift4/ose-cluster-authentication-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-autoscaler-operator.yml
+++ b/images/ose-cluster-autoscaler-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-autoscaler-operator
+  delivery_repo_name: openshift4/ose-cluster-autoscaler-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-baremetal-operator
+  delivery_repo_name: openshift4/ose-cluster-baremetal-operator-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-bootstrap.yml
+++ b/images/ose-cluster-bootstrap.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-bootstrap
+  delivery_repo_name: openshift4/ose-cluster-bootstrap-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-capi-operator.yml
+++ b/images/ose-cluster-capi-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-capi-operator
+  delivery_repo_name: openshift4/ose-cluster-capi-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-cloud-controller-manager-operator
+  delivery_repo_name: openshift4/ose-cluster-cloud-controller-manager-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-config-api.yml
+++ b/images/ose-cluster-config-api.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-config-api
+  delivery_repo_name: openshift4/ose-cluster-config-api-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-config-operator.yml
+++ b/images/ose-cluster-config-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-config-operator
+  delivery_repo_name: openshift4/ose-cluster-config-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-control-plane-machine-set-operator.yml
+++ b/images/ose-cluster-control-plane-machine-set-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-control-plane-machine-set-operator
+  delivery_repo_name: openshift4/ose-cluster-control-plane-machine-set-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-csi-snapshot-controller-operator.yml
+++ b/images/ose-cluster-csi-snapshot-controller-operator.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-csi-snapshot-controller-operator
+  delivery_repo_name: openshift4/ose-cluster-csi-snapshot-controller-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-dns-operator.yml
+++ b/images/ose-cluster-dns-operator.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-dns-operator
+  delivery_repo_name: openshift4/ose-cluster-dns-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-image-registry-operator.yml
+++ b/images/ose-cluster-image-registry-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-image-registry-operator
+  delivery_repo_name: openshift4/ose-cluster-image-registry-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-ingress-operator.yml
+++ b/images/ose-cluster-ingress-operator.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-ingress-operator
+  delivery_repo_name: openshift4/ose-cluster-ingress-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-kube-apiserver-operator.yml
+++ b/images/ose-cluster-kube-apiserver-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-kube-apiserver-operator
+  delivery_repo_name: openshift4/ose-cluster-kube-apiserver-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-kube-cluster-api-operator.yml
+++ b/images/ose-cluster-kube-cluster-api-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-kube-cluster-api-operator
+  delivery_repo_name: openshift4/ose-cluster-kube-cluster-api-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-kube-controller-manager-operator.yml
+++ b/images/ose-cluster-kube-controller-manager-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-kube-controller-manager-operator
+  delivery_repo_name: openshift4/ose-cluster-kube-controller-manager-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-kube-scheduler-operator
+  delivery_repo_name: openshift4/ose-cluster-kube-scheduler-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-kube-storage-version-migrator-operator.yml
+++ b/images/ose-cluster-kube-storage-version-migrator-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-kube-storage-version-migrator-operator
+  delivery_repo_name: openshift4/ose-cluster-kube-storage-version-migrator-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-machine-approver.yml
+++ b/images/ose-cluster-machine-approver.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-machine-approver
+  delivery_repo_name: openshift4/ose-cluster-machine-approver-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-olm-operator
+  delivery_repo_name: openshift4/ose-cluster-olm-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-openshift-apiserver-operator.yml
+++ b/images/ose-cluster-openshift-apiserver-operator.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-openshift-apiserver-operator
+  delivery_repo_name: openshift4/ose-cluster-openshift-apiserver-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-openshift-controller-manager-operator.yml
+++ b/images/ose-cluster-openshift-controller-manager-operator.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-openshift-controller-manager-operator
+  delivery_repo_name: openshift4/ose-cluster-openshift-controller-manager-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-ovirt-csi-operator.yml
+++ b/images/ose-cluster-ovirt-csi-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ovirt-csi-driver-operator
+  delivery_repo_name: openshift4/ovirt-csi-driver-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-samples-operator.yml
+++ b/images/ose-cluster-samples-operator.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-samples-operator
+  delivery_repo_name: openshift4/ose-cluster-samples-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-cluster-update-keys
+  delivery_repo_name: openshift4/ose-cluster-update-keys-rhel9
 for_payload: true
 from:
   member: openshift-enterprise-base-rhel9

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-container-networking-plugins
+  delivery_repo_name: openshift4/ose-container-networking-plugins-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-external-resizer
+  delivery_repo_name: openshift4/ose-csi-external-resizer-rhel9
 dependents:
 - ose-gcp-filestore-csi-driver-operator
 for_payload: true

--- a/images/ose-csi-external-snapshotter.yml
+++ b/images/ose-csi-external-snapshotter.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-external-snapshotter
+  delivery_repo_name: openshift4/ose-csi-external-snapshotter-rhel9
 dependents:
 - ose-gcp-filestore-csi-driver-operator
 for_payload: true

--- a/images/ose-csi-snapshot-controller.yml
+++ b/images/ose-csi-snapshot-controller.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-snapshot-controller
+  delivery_repo_name: openshift4/ose-csi-snapshot-controller-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -12,6 +12,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-egress-http-proxy
+  delivery_repo_name: openshift4/ose-egress-http-proxy-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -36,6 +36,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-etcd
+  delivery_repo_name: openshift4/ose-etcd-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -12,6 +12,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: frr
+  delivery_repo_name: openshift4/frr-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-gcp-cloud-controller-manager
+  delivery_repo_name: openshift4/ose-gcp-cloud-controller-manager-rhel9
 name: openshift/ose-gcp-cloud-controller-manager-rhel9
 payload_name: gcp-cloud-controller-manager
 for_payload: true

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-gcp-cluster-api-controllers
+  delivery_repo_name: openshift4/ose-gcp-cluster-api-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-gcp-filestore-csi-driver-operator.yml
+++ b/images/ose-gcp-filestore-csi-driver-operator.yml
@@ -25,6 +25,7 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-gcp-filestore-csi-driver-operator
   bundle_delivery_repo_name: openshift4/ose-gcp-filestore-csi-driver-operator-bundle
+  delivery_repo_name: openshift4/ose-gcp-filestore-csi-driver-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-gcp-filestore-csi-driver
+  delivery_repo_name: openshift4/ose-gcp-filestore-csi-driver-rhel9
 dependents:
 - ose-gcp-filestore-csi-driver-operator
 enabled_repos:

--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-gcp-pd-csi-driver-operator
+  delivery_repo_name: openshift4/ose-gcp-pd-csi-driver-operator-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-gcp-pd-csi-driver
+  delivery_repo_name: openshift4/ose-gcp-pd-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ibm-cloud-controller-manager
+  delivery_repo_name: openshift4/ose-ibm-cloud-controller-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-ibm-vpc-block-csi-driver-operator.yml
+++ b/images/ose-ibm-vpc-block-csi-driver-operator.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ibm-vpc-block-csi-driver-operator
+  delivery_repo_name: openshift4/ose-ibm-vpc-block-csi-driver-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ibm-vpc-block-csi-driver
+  delivery_repo_name: openshift4/ose-ibm-vpc-block-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ibmcloud-cluster-api-controllers
+  delivery_repo_name: openshift4/ose-ibmcloud-cluster-api-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ibmcloud-machine-controllers
+  delivery_repo_name: openshift4/ose-ibmcloud-machine-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-image-customization-controller
+  delivery_repo_name: openshift4/ose-image-customization-controller-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-insights-operator.yml
+++ b/images/ose-insights-operator.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-insights-operator
+  delivery_repo_name: openshift4/ose-insights-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-insights-runtime-exporter.yml
+++ b/images/ose-insights-runtime-exporter.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: insights-runtime-exporter
+  delivery_repo_name: openshift4/insights-runtime-exporter-rhel9
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-insights-runtime-extractor.yml
+++ b/images/ose-insights-runtime-extractor.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: insights-runtime-extractor
+  delivery_repo_name: openshift4/insights-runtime-extractor-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-installer-artifacts
+  delivery_repo_name: openshift4/ose-installer-artifacts-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -19,17 +19,18 @@ content:
         src:
           requests:
             cpu: "3"
-            memory: 5Gi        
+            memory: 5Gi
         installer-altinfra:
           requests:
             cpu: "3"
-            memory: 5Gi            
+            memory: 5Gi
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-installer-container
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-installer
+  delivery_repo_name: openshift4/ose-installer-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-kube-metrics-server.yml
+++ b/images/ose-kube-metrics-server.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: kube-metrics-server
+  delivery_repo_name: openshift4/kube-metrics-server-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-kube-storage-version-migrator.yml
+++ b/images/ose-kube-storage-version-migrator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-kube-storage-version-migrator
+  delivery_repo_name: openshift4/ose-kube-storage-version-migrator-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-kubevirt-cloud-controller-manager.yml
+++ b/images/ose-kubevirt-cloud-controller-manager.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-kubevirt-cloud-controller-manager
+  delivery_repo_name: openshift4/ose-kubevirt-cloud-controller-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: kubevirt-csi-driver
+  delivery_repo_name: openshift4/kubevirt-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -26,6 +26,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-libvirt-machine-controllers
+  delivery_repo_name: openshift4/ose-libvirt-machine-controllers-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-machine-api-operator
+  delivery_repo_name: openshift4/ose-machine-api-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-machine-api-provider-aws
+  delivery_repo_name: openshift4/ose-machine-api-provider-aws-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-machine-api-provider-azure
+  delivery_repo_name: openshift4/ose-machine-api-provider-azure-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-machine-api-provider-gcp
+  delivery_repo_name: openshift4/ose-machine-api-provider-gcp-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-machine-api-provider-openstack
+  delivery_repo_name: openshift4/ose-machine-api-provider-openstack-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-machine-config-operator
+  delivery_repo_name: openshift4/ose-machine-config-rhel9-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -15,6 +15,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-machine-os-images
+  delivery_repo_name: openshift4/ose-machine-os-images-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-multus-admission-controller.yml
+++ b/images/ose-multus-admission-controller.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-multus-admission-controller
+  delivery_repo_name: openshift4/ose-multus-admission-controller-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-multus-route-override-cni
+  delivery_repo_name: openshift4/ose-multus-route-override-cni-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-multus-whereabouts-ipam-cni
+  delivery_repo_name: openshift4/ose-multus-whereabouts-ipam-cni-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-must-gather
+  delivery_repo_name: openshift4/ose-must-gather-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-network-interface-bond-cni
+  delivery_repo_name: openshift4/ose-network-interface-bond-cni-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-network-metrics-daemon.yml
+++ b/images/ose-network-metrics-daemon.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-network-metrics-daemon
+  delivery_repo_name: openshift4/ose-network-metrics-daemon-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: network-tools
+  delivery_repo_name: openshift4/network-tools-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-nutanix-cloud-controller-manager.yml
+++ b/images/ose-nutanix-cloud-controller-manager.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-nutanix-cloud-controller-manager
+  delivery_repo_name: openshift4/ose-nutanix-cloud-controller-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-nutanix-machine-controllers
+  delivery_repo_name: openshift4/ose-nutanix-machine-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-oauth-apiserver.yml
+++ b/images/ose-oauth-apiserver.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-oauth-apiserver
+  delivery_repo_name: openshift4/ose-oauth-apiserver-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-olm-catalogd
+  delivery_repo_name: openshift4/ose-olm-catalogd-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-olm-operator-controller
+  delivery_repo_name: openshift4/ose-olm-operator-controller-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-openshift-apiserver.yml
+++ b/images/ose-openshift-apiserver.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-openshift-apiserver
+  delivery_repo_name: openshift4/ose-openshift-apiserver-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-openshift-controller-manager.yml
+++ b/images/ose-openshift-controller-manager.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-openshift-controller-manager
+  delivery_repo_name: openshift4/ose-openshift-controller-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-openstack-cinder-csi-driver-operator.yml
+++ b/images/ose-openstack-cinder-csi-driver-operator.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-openstack-cinder-csi-driver-operator
+  delivery_repo_name: openshift4/ose-openstack-cinder-csi-driver-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-openstack-cinder-csi-driver
+  delivery_repo_name: openshift4/ose-openstack-cinder-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-openstack-cloud-controller-manager
+  delivery_repo_name: openshift4/ose-openstack-cloud-controller-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-operator-framework-tools
+  delivery_repo_name: openshift4/ose-operator-framework-tools-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ovirt-csi-driver
+  delivery_repo_name: openshift4/ovirt-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ovn-kubernetes
+  delivery_repo_name: openshift4/ose-ovn-kubernetes-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-powervs-block-csi-driver-operator
+  delivery_repo_name: openshift4/ose-powervs-block-csi-driver-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-powervs-block-csi-driver
+  delivery_repo_name: openshift4/ose-powervs-block-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-powervs-cloud-controller-manager.yml
+++ b/images/ose-powervs-cloud-controller-manager.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-powervs-cloud-controller-manager
+  delivery_repo_name: openshift4/ose-powervs-cloud-controller-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-powervs-machine-controllers
+  delivery_repo_name: openshift4/ose-powervs-machine-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-route-controller-manager.yml
+++ b/images/ose-route-controller-manager.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: openshift-route-controller-manager
+  delivery_repo_name: openshift4/openshift-route-controller-manager-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -21,6 +21,7 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-secrets-store-csi-driver-operator
   bundle_delivery_repo_name: openshift4/ose-secrets-store-csi-driver-operator-bundle
+  delivery_repo_name: openshift4/ose-secrets-store-csi-driver-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-secrets-store-csi-driver
+  delivery_repo_name: openshift4/ose-secrets-store-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -18,6 +18,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-secrets-store-csi-mustgather
+  delivery_repo_name: openshift4/ose-secrets-store-csi-mustgather-rhel9
 for_payload: false
 name_in_bundle: secrets-store-csi-mustgather
 from:

--- a/images/ose-service-ca-operator.yml
+++ b/images/ose-service-ca-operator.yml
@@ -16,6 +16,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-service-ca-operator
+  delivery_repo_name: openshift4/ose-service-ca-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -20,7 +20,8 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-smb-csi-driver-operator
-  bundle_delivery_repo_name: openshift4/ose-smb-csi-driver-rhel9-operator-bundle
+  bundle_delivery_repo_name: openshift4/ose-smb-csi-driver-operator-bundle
+  delivery_repo_name: openshift4/ose-smb-csi-driver-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-smb-csi-driver
+  delivery_repo_name: openshift4/ose-smb-csi-driver-rhel9
 dependents:
 - ose-smb-csi-driver-operator
 enabled_repos:

--- a/images/ose-sriov-network-metrics-exporter.yml
+++ b/images/ose-sriov-network-metrics-exporter.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-sriov-network-metrics-exporter
+  delivery_repo_name: openshift4/ose-sriov-network-metrics-exporter-rhel9
 for_payload: false
 from:
   builder:

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -26,6 +26,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-sriov-rdma-cni
+  delivery_repo_name: openshift4/ose-sriov-rdma-cni-rhel9
 for_payload: false
 from:
   builder:

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-tools
+  delivery_repo_name: openshift4/ose-tools-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/ose-vmware-vsphere-csi-driver-operator.yml
+++ b/images/ose-vmware-vsphere-csi-driver-operator.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-vsphere-csi-driver-operator
+  delivery_repo_name: openshift4/ose-vsphere-csi-driver-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-vsphere-csi-driver
+  delivery_repo_name: openshift4/ose-vsphere-csi-driver-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-vsphere-cloud-controller-manager
+  delivery_repo_name: openshift4/ose-vsphere-cloud-controller-manager-rhel9
 for_payload: true
 name: openshift/ose-vsphere-cloud-controller-manager-rhel9
 payload_name: vsphere-cloud-controller-manager

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -19,6 +19,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-vsphere-cluster-api-controllers
+  delivery_repo_name: openshift4/ose-vsphere-cluster-api-controllers-rhel9
 for_payload: true
 from:
   builder:

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -25,6 +25,7 @@ delivery:
 # Generally doozer scan-sources will detect all possible change factors automatically and trigger rebuilds.
 # However, certain images may consume RPMs in unexpected way that make it programmatically impossible to
 # detect they were used.
+  delivery_repo_name: openshift4/ose-ovn-kubernetes-microshift-rhel9
 scan_sources:
   # ovn-kubernetes uses pins in the Dockerfile.
   # We should configure exemptions for those known pins to avoid meaningless rebuild.

--- a/images/pf-status-relay.yml
+++ b/images/pf-status-relay.yml
@@ -11,13 +11,14 @@ content:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 dependents:
-- pf-status-relay-operator    
+- pf-status-relay-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: pf-status-relay-container
 delivery:
   # Maps to honeybadger repo_name
   repo_name: pf-status-relay
+  delivery_repo_name: openshift4/pf-status-relay-rhel9
 for_payload: false
 from:
   builder:

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-prom-label-proxy
+  delivery_repo_name: openshift4/ose-prom-label-proxy-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-prometheus-config-reloader
+  delivery_repo_name: openshift4/ose-prometheus-config-reloader-rhel9
 for_payload: true
 from:
   builder:

--- a/images/prometheus-operator-admission-webhook.yml
+++ b/images/prometheus-operator-admission-webhook.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-prometheus-operator-admission-webhook
+  delivery_repo_name: openshift4/ose-prometheus-operator-admission-webhook-rhel9
 for_payload: true
 from:
   builder:

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -24,6 +24,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-prometheus-operator
+  delivery_repo_name: openshift4/ose-prometheus-rhel9-operator
 for_payload: true
 from:
   builder:

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ptp-must-gather
+  delivery_repo_name: openshift4/ptp-must-gather-rhel9
 for_payload: false
 from:
   builder:

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -23,6 +23,7 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ptp-operator
   bundle_delivery_repo_name: openshift4/ose-ptp-operator-bundle
+  delivery_repo_name: openshift4/ose-ptp-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: sriov-cni
+  delivery_repo_name: openshift4/sriov-cni-rhel9
 dependents:
 - sriov-network-operator
 for_payload: false

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-sriov-dp-admission-controller
+  delivery_repo_name: openshift4/ose-sriov-dp-admission-controller-rhel9
 for_payload: false
 from:
   builder:

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-sriov-network-config-daemon
+  delivery_repo_name: openshift4/ose-sriov-network-config-daemon-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-sriov-network-device-plugin
+  delivery_repo_name: openshift4/ose-sriov-network-device-plugin-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-sriov-network-webhook
+  delivery_repo_name: openshift4/ose-sriov-network-webhook-rhel9
 for_payload: false
 from:
   builder:

--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-telemeter
+  delivery_repo_name: openshift4/ose-telemeter-rhel9
 for_payload: true
 from:
   builder:

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -23,6 +23,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-thanos
+  delivery_repo_name: openshift4/ose-thanos-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -20,6 +20,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-vertical-pod-autoscaler
+  delivery_repo_name: openshift4/ose-vertical-pod-autoscaler-rhel9
 for_payload: false
 from:
   builder:

--- a/images/vmware-vsphere-syncer.yml
+++ b/images/vmware-vsphere-syncer.yml
@@ -22,6 +22,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-vsphere-csi-driver-syncer
+  delivery_repo_name: openshift4/ose-vsphere-csi-driver-syncer-rhel9
 for_payload: true
 from:
   builder:

--- a/images/vsphere-problem-detector.yml
+++ b/images/vsphere-problem-detector.yml
@@ -21,6 +21,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-vsphere-problem-detector
+  delivery_repo_name: openshift4/ose-vsphere-problem-detector-rhel9
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
Historically, we have derived the delivery repo names (name in comet) from the `name` field in comet and its not a straightforward one (some have `ose-` prefixes, `-rhel9` suffixes and some have not). HoneyBadger(HB) was assumed to be the source of truth for the delivery repo names, but that doesn't seem the case (ref [thread](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1750882110551069)).

In the Konflux world, HB is slated to be deprecated and its planned to be replaced by Cicada.

Proposing to keep the delivery repo names in the image config explicitly, for these reasons:
- 1-1 mapping between image config and its delivery repo name, for easy debugging
- Can easily onbaord components to Konflux ReleasePlanAdmission(RPA), since thats necessary in the future. 
- Can be used by future automation as the source of truth

Change in current workflow:
- After an image is onboarded through HB/Cicada, add in the delivery repo name in the image config, as part of the image add.