### PR TITLE
Remove add modification for ib-sriov-cni in 4.19

### DIFF
--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -10,10 +10,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ib-sriov-cni.git
       web: https://github.com/openshift/ib-sriov-cni
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.19.0/ginkgo/build/build_command.go"
-      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
The modification was necessary because of upstream inconsistency between vendor and go.mod which has since been fixed (https://github.com/openshift/ib-sriov-cni/pull/94)