### PR TITLE
Remove add modification for ose-sriov-rdma-cni in 4.20

### DIFF
--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -10,10 +10,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/rdma-cni.git
       web: https://github.com/openshift/rdma-cni
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.19.0/ginkgo/build/build_command.go"
-      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
The modification was necessary because of upstream inconsistency between vendor and go.mod which has been fixed in https://github.com/openshift/rdma-cni/commit/1027bef35f5aa7c3ee417cbbf2d8db53c2fbaca2 