### PR TITLE
Fix ci-buildroot build failures

### DIFF
--- a/ci_transforms/rhel-8/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-8/ci-build-root/Dockerfile
@@ -50,7 +50,7 @@ RUN GOFLAGS='' go install golang.org/x/tools/cmd/cover@latest && \
     GOFLAGS='' go install golang.org/x/tools/cmd/goimports@latest && \
     GOFLAGS='' go install github.com/tools/godep@latest && \
     GOFLAGS='' go install golang.org/x/lint/golint@latest && \
-    GOFLAGS='' go install gotest.tools/gotestsum@latest && \
+    GOFLAGS='' go install gotest.tools/gotestsum@v1.12.2 && \
     GOFLAGS='' go install github.com/openshift/release/tools/gotest2junit@latest && \
     GOFLAGS='' go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
     mv $GOPATH/bin/* /usr/bin/ && \

--- a/ci_transforms/rhel-9/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-9/ci-build-root/Dockerfile
@@ -49,7 +49,7 @@ RUN GOFLAGS='' GO111MODULE=on go install golang.org/x/tools/cmd/cover@latest && 
     GOFLAGS='' GO111MODULE=on go install golang.org/x/tools/cmd/goimports@latest && \
     GOFLAGS='' GO111MODULE=on go install github.com/tools/godep@latest && \
     GOFLAGS='' GO111MODULE=on go install golang.org/x/lint/golint@latest && \
-    GOFLAGS='' GO111MODULE=on go install gotest.tools/gotestsum@latest && \
+    GOFLAGS='' GO111MODULE=on go install gotest.tools/gotestsum@v1.12.2 && \
     GOFLAGS='' GO111MODULE=on go install github.com/openshift/release/tools/gotest2junit@latest && \
     GOFLAGS='' GO111MODULE=on go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
     mv $GOPATH/bin/* /usr/bin/ && \


### PR DESCRIPTION
gotestsum@v1.12.3 started to depend on go1.23, which is not available in the go1.22 image. Pinning.