### PR TITLE
AUTOSCALE-286: opt clusterresourceoverride into auto_label for merge

### DIFF
--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -9,6 +9,9 @@ content:
       web: https://github.com/openshift/cluster-resource-override-admission-operator
     ci_alignment:
       streams_prs:
+        auto_label:
+        - approved
+        - lgtm
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -8,6 +8,9 @@ content:
       web: https://github.com/openshift/cluster-resource-override-admission
     ci_alignment:
       streams_prs:
+        auto_label:
+        - approved
+        - lgtm
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 dependents:


### PR DESCRIPTION
Opt `clusterresourceoverride` and `clusterresourceoverride-operator` into auto merging for ART PRs.

We are trying this out for some of the autoscaling teams repos for a few releases, and we'll see how if it's something we want for all our repos.