### PR TITLE
Enable vertical-pod-autoscaler-operator.yml

### DIFF
--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled # Until https://issues.redhat.com/browse/OCPBUGS-57966 is fixed
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
Since, Bug : https://issues.redhat.com/browse/OCPBUGS-57966# is fixed with below PR hence we can reenable it: 

https://github.com/openshift/vertical-pod-autoscaler-operator/pull/206


