### PR TITLE
Pin dpu-operator in stream

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -790,3 +790,8 @@ releases:
                   - "libxml2*"
                   - libgcrypt
                   - "openssl*"
+          - distgit_key: dpu-operator
+            why: Pin to be built from the same upstream commit as last successful dpu-intel-ipu-vsp
+            metadata:
+              is:
+                nvr: dpu-operator-container-v4.19.0-202507011209.p0.gd7bbf4c.assembly.stream.el9


### PR DESCRIPTION
Pin dpu-operator in stream so that it uses the same upstream commit as the last successful build of dpu-intel-ipu-vsp (which is currently failing to build)

[Pinned dpu-operator](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=dpu-operator-container-v4.19.0-202507011209.p0.gd7bbf4c.assembly.stream.el9&outcome=success&type=image)
[Last successful dpu-intel-ipu-vsp](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=dpu-intel-ipu-vsp-container-v4.19.0-202507011209.p0.gd7bbf4c.assembly.stream.el9&outcome=success&type=image)