### PR TITLE
Re-enable pf-status-relay-operator.yml

### DIFF
--- a/images/pf-status-relay-operator.yml
+++ b/images/pf-status-relay-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled  # until https://issues.redhat.com/browse/OCPBUGS-57971 is fixed
 content:
   source:
     dockerfile: Dockerfile.openshift


### PR DESCRIPTION
It was disabled because of. : https://issues.redhat.com/browse/OCPBUGS-57971

Since it is fixed now, It can be enabled : 

https://github.com/openshift/pf-status-relay-operator/pull/39