### PR TITLE
Re-enable openshift-kubernetes-nmstate-operator.yml

### DIFF
--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled # Until https://issues.redhat.com/browse/OCPBUGS-57974 is fixed
 content:
   source:
     dockerfile: build/Dockerfile.operator.openshift


### PR DESCRIPTION
Bug https://issues.redhat.com/browse/OCPBUGS-57974  is fixed with : https://github.com/openshift/kubernetes-nmstate/pull/631/files

We can reenable it now.