### PR TITLE
Re-enable openshift-kubernetes-nmstate-operator, ose-metallb-operator.yml, pf-status-relay-operator.yml

### DIFF
--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled # Until https://issues.redhat.com/browse/OCPBUGS-57974 is fixed
 content:
   source:
     dockerfile: build/Dockerfile.operator.openshift

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled # until metallb is on supported go1.24 builder image
 content:
   source:
     git:

--- a/images/pf-status-relay-operator.yml
+++ b/images/pf-status-relay-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled  # until https://issues.redhat.com/browse/OCPBUGS-57971 is fixed
 content:
   source:
     dockerfile: Dockerfile.openshift


### PR DESCRIPTION
As part of 

Based on Slack conversation : https://redhat-internal.slack.com/archives/CB95J6R4N/p1751978092274309?thread_ts=1751899967.141159&cid=CB95J6R4N


Pf status-relay operator :  https://issues.redhat.com/browse/OCPBUGS-57971
https://github.com/openshift/pf-status-relay-operator/pull/39

Bug https://issues.redhat.com/browse/OCPBUGS-57974 is fixed with : https://github.com/openshift/kubernetes-nmstate/pull/631/files




