### PR TITLE
ART-13260: Replace add modifications with disabling cachi2 in 4.20

### DIFF
--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/coredns.git
       web: https://github.com/openshift/coredns
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.13.0/ginkgo/build/build_command.go"
-      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -31,3 +27,6 @@ name: openshift/ose-coredns-rhel9
 payload_name: coredns
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -5,10 +5,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-baremetal-operator.git
       web: https://github.com/openshift/cluster-baremetal-operator
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/go-errors/errors/refs/tags/v1.0.1/cover.out"
-      path: "vendor/github.com/go-errors/errors/cover.out"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -30,3 +26,6 @@ name: openshift/ose-cluster-baremetal-rhel9-operator
 payload_name: cluster-baremetal-operator
 owners:
 - metal-platform@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-libvirt.git
       web: https://github.com/openshift/cluster-api-provider-libvirt
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/go-errors/errors/refs/tags/v1.0.1/cover.out"
-      path: "vendor/github.com/go-errors/errors/cover.out"
     ci_alignment:
       streams_prs:
         auto_label:  # Enable PR merging as quickly as possible by pre-approving it.
@@ -43,3 +39,5 @@ owners:
 - pkrupa@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
Remove modifications fixing vendor inconsistency errors during Konflux builds and instead disable cachi2 for these images. This is so that all such images have an identical way of fixing these issues. Further details are in [ART-13345](https://issues.redhat.com/browse/ART-13345)