### PR TITLE
ART-13260: Replace add modifications with disabling cachi2 in 4.19

### DIFF
--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/coredns.git
       web: https://github.com/openshift/coredns
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.13.0/ginkgo/build/build_command.go"
-      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -31,3 +27,6 @@ name: openshift/ose-coredns-rhel9
 payload_name: coredns
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -9,10 +9,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/aws-ebs-csi-driver.git
       web: https://github.com/openshift/aws-ebs-csi-driver
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/mistifyio/go-zfs/f784269be439d704d3dfa1906f45dd848fed2beb/Vagrantfile"
-      path: "vendor/github.com/mistifyio/go-zfs/Vagrantfile"
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
@@ -43,3 +39,5 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -5,10 +5,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-baremetal-operator.git
       web: https://github.com/openshift/cluster-baremetal-operator
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/go-errors/errors/refs/tags/v1.0.1/cover.out"
-      path: "vendor/github.com/go-errors/errors/cover.out"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -30,3 +26,6 @@ name: openshift/ose-cluster-baremetal-rhel9-operator
 payload_name: cluster-baremetal-operator
 owners:
 - metal-platform@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-libvirt.git
       web: https://github.com/openshift/cluster-api-provider-libvirt
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/go-errors/errors/refs/tags/v1.0.1/cover.out"
-      path: "vendor/github.com/go-errors/errors/cover.out"
     ci_alignment:
       streams_prs:
         auto_label:  # Enable PR merging as quickly as possible by pre-approving it.
@@ -43,3 +39,5 @@ owners:
 - pkrupa@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-provider-openstack.git
       web: https://github.com/openshift/machine-api-provider-openstack
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/refs/tags/v1.7.2/api/v1beta1/zz_generated.openapi.go"
-      path: "vendor/sigs.k8s.io/cluster-api/api/v1beta1/zz_generated.openapi.go"
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: openshift: "
@@ -34,3 +30,5 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -10,10 +10,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/rdma-cni.git
       web: https://github.com/openshift/rdma-cni
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.19.0/ginkgo/build/build_command.go"
-      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -43,3 +39,5 @@ owners:
 - sscheink@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -8,82 +8,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-vsphere.git
       web: https://github.com/openshift/cluster-api-provider-vsphere
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/cel/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/cel/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/checker/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/checker/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/checker/decls/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/checker/decls/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/ast/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/ast/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/containers/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/containers/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/debug/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/debug/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/decls/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/decls/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/functions/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/functions/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/operators/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/operators/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/overloads/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/overloads/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/runes/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/runes/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/stdlib/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/stdlib/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/types/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/types/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/types/pb/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/types/pb/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/types/ref/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/types/ref/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/common/types/traits/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/types/traits/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/ext/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/ext/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/interpreter/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/interpreter/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/interpreter/functions/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/interpreter/functions/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/parser/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/parser/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.20.1/parser/gen/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/parser/gen/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/refs/tags/v2.20.0/internal/httprule/BUILD.bazel"
-      path: "vendor/github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/refs/tags/v2.20.0/runtime/BUILD.bazel"
-      path: "vendor/github.com/grpc-ecosystem/grpc-gateway/v2/runtime/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/refs/tags/v2.20.0/utilities/BUILD.bazel"
-      path: "vendor/github.com/grpc-ecosystem/grpc-gateway/v2/utilities/BUILD.bazel"
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
@@ -109,3 +33,6 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
Remove modifications fixing vendor inconsistency errors during Konflux builds and instead disable cachi2 for these images. This is so that all such images have an identical way of fixing these issues. Further details are in [ART-13345](https://issues.redhat.com/browse/ART-13345)