### PR TITLE
ART-13260: Replace add modifications with disabling cachi2 in 4.18

### DIFF
--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/coredns.git
       web: https://github.com/openshift/coredns
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.13.0/ginkgo/build/build_command.go"
-      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -30,3 +26,6 @@ name: openshift/ose-coredns-rhel9
 payload_name: coredns
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -9,19 +9,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-openstack.git
       web: https://github.com/openshift/cloud-provider-openstack
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/google/gnostic-models/refs/tags/v0.6.8/jsonschema/schema.json"
-      path: "vendor/github.com/google/gnostic-models/jsonschema/schema.json"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/gnostic-models/refs/tags/v0.6.8/openapiv2/openapi-2.0.json"
-      path: "vendor/github.com/google/gnostic-models/openapiv2/openapi-2.0.json"
-    - action: add
-      source: "https://raw.githubusercontent.com/open-telemetry/opentelemetry-go/refs/tags/v1.28.0/renovate.json"
-      path: "vendor/go.opentelemetry.io/otel/renovate.json"
-    - action: add
-      source: "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.31.6/test/e2e/testing-manifests/kubectl/agnhost-primary-service.json"
-      path: "vendor/k8s.io/kubernetes/test/e2e/testing-manifests/kubectl/agnhost-primary-service.json"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -45,3 +32,6 @@ name: openshift/ose-csi-driver-manila-rhel9
 payload_name: csi-driver-manila
 owners:
 - shiftstack-team@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -5,10 +5,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-baremetal-operator.git
       web: https://github.com/openshift/cluster-baremetal-operator
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/go-errors/errors/refs/tags/v1.0.1/cover.out"
-      path: "vendor/github.com/go-errors/errors/cover.out"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -29,3 +25,6 @@ name: openshift/ose-cluster-baremetal-rhel9-operator
 payload_name: cluster-baremetal-operator
 owners:
 - metal-platform@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/metallb.git
       web: https://github.com/openshift/metallb
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/onsi/ginkgo/refs/tags/v2.20.2/ginkgo/build/build_command.go"
-      path: "vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -32,3 +28,6 @@ name: openshift/metallb-rhel9
 name_in_bundle: metallb-rhel9
 owners:
 - metallb-dev@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -6,19 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-openstack.git
       web: https://github.com/openshift/cloud-provider-openstack
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/google/gnostic-models/refs/tags/v0.6.8/jsonschema/schema.json"
-      path: "vendor/github.com/google/gnostic-models/jsonschema/schema.json"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/gnostic-models/refs/tags/v0.6.8/openapiv2/openapi-2.0.json"
-      path: "vendor/github.com/google/gnostic-models/openapiv2/openapi-2.0.json"
-    - action: add
-      source: "https://raw.githubusercontent.com/open-telemetry/opentelemetry-go/refs/tags/v1.28.0/renovate.json"
-      path: "vendor/go.opentelemetry.io/otel/renovate.json"
-    - action: add
-      source: "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.31.6/test/e2e/testing-manifests/kubectl/agnhost-primary-service.json"
-      path: "vendor/k8s.io/kubernetes/test/e2e/testing-manifests/kubectl/agnhost-primary-service.json"
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -48,3 +35,5 @@ owners:
 - mfedosin@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -8,25 +8,6 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
     dockerfile: openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/emicklei/go-restful/refs/tags/v3.12.0/coverage.sh"
-      path: "vendor/github.com/emicklei/go-restful/v3/coverage.sh"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/gnostic-models/refs/tags/v0.6.8/jsonschema/schema.json"
-      path: "vendor/github.com/google/gnostic-models/jsonschema/schema.json"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/gnostic-models/refs/tags/v0.6.8/openapiv2/openapi-2.0.json"
-      path: "vendor/github.com/google/gnostic-models/openapiv2/openapi-2.0.json"
-    - action: add
-      source: "https://raw.githubusercontent.com/open-telemetry/opentelemetry-go/refs/tags/v1.28.0/renovate.json"
-      path: "vendor/go.opentelemetry.io/otel/renovate.json"
-    - action: add
-      source: "https://raw.githubusercontent.com/golang/text/refs/tags/v0.17.0/internal/language/coverage.go"
-      path: "vendor/golang.org/x/text/internal/language/coverage.go"
-    - action: add
-      source: "https://raw.githubusercontent.com/golang/text/refs/tags/v0.17.0/language/coverage.go"
-      path: "vendor/golang.org/x/text/language/coverage.go"
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
@@ -51,3 +32,6 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -8,82 +8,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-vsphere.git
       web: https://github.com/openshift/cluster-api-provider-vsphere
-    modifications:
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/cel/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/cel/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/checker/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/checker/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/checker/decls/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/checker/decls/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/ast/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/ast/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/containers/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/containers/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/debug/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/debug/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/decls/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/decls/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/functions/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/functions/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/operators/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/operators/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/overloads/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/overloads/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/runes/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/runes/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/stdlib/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/stdlib/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/types/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/types/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/types/pb/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/types/pb/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/types/ref/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/types/ref/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/common/types/traits/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/common/types/traits/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/ext/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/ext/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/interpreter/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/interpreter/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/interpreter/functions/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/interpreter/functions/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/parser/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/parser/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/google/cel-go/refs/tags/v0.17.8/parser/gen/BUILD.bazel"
-      path: "vendor/github.com/google/cel-go/parser/gen/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/refs/tags/v2.16.0/internal/httprule/BUILD.bazel"
-      path: "vendor/github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/refs/tags/v2.16.0/runtime/BUILD.bazel"
-      path: "vendor/github.com/grpc-ecosystem/grpc-gateway/v2/runtime/BUILD.bazel"
-    - action: add
-      source: "https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/refs/tags/v2.16.0/utilities/BUILD.bazel"
-      path: "vendor/github.com/grpc-ecosystem/grpc-gateway/v2/utilities/BUILD.bazel"
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
@@ -108,3 +32,6 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
Remove modifications fixing vendor inconsistency errors during Konflux builds and instead disable cachi2 for these images. This is so that all such images have an identical way of working arround these issues. Further details are in [ART-13345](https://issues.redhat.com/browse/ART-13345)