### PR TITLE
ART-13260: Disable cachi2 for ptp-operator in 4.15

### DIFF
--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -40,3 +40,6 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-ptp-operator-bundle
   delivery_repo_names:
   - openshift4/ose-ptp-rhel9-operator
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
Disable cachi2 for ptp-operator to prevent Konflux build failures due to cachi2-related errors.