### PR TITLE
ART-13260: Disable cachi2 for several images in 4.13

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -26,3 +26,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-baremetal-machine-controllers
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -21,3 +21,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-network-operator
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -27,3 +27,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-csi-driver-manila-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ibm-vpc-node-label-updater.yml
+++ b/images/ibm-vpc-node-label-updater.yml
@@ -29,6 +29,8 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibm-vpc-node-label-updater-rhel8

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -23,3 +23,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-node-feature-discovery
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -23,3 +23,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-console-operator
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -34,6 +34,8 @@ owners:
 - aos-master@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-hyperkube

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -33,6 +33,8 @@ owners:
 - yboaron@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-kubernetes-nmstate-handler-rhel8

--- a/images/ose-alibaba-cloud-csi-driver.yml
+++ b/images/ose-alibaba-cloud-csi-driver.yml
@@ -34,6 +34,8 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-alibaba-cloud-csi-driver-container-rhel8

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -28,3 +28,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-aws-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -28,3 +28,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-azure-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -22,3 +22,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-api-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -22,3 +22,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-baremetal-operator-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -29,3 +29,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-gcp-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -25,3 +25,6 @@ labels:
 name: openshift/ose-haproxy-router-base
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -29,6 +29,8 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibm-vpc-block-csi-driver-rhel8

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -27,3 +27,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibmcloud-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -23,3 +23,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibmcloud-machine-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -29,6 +29,8 @@ owners:
 - pkrupa@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-libvirt-machine-controllers

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -20,6 +20,8 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-operator

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -23,6 +23,8 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-azure-rhel8

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -24,6 +24,8 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-gcp-rhel8

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -21,6 +21,8 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-openstack-rhel8

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -30,3 +30,6 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-metallb-operator-bundle
   delivery_repo_names:
   - openshift4/metallb-rhel8-operator
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -22,3 +22,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-nutanix-machine-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -27,6 +27,8 @@ owners:
 - mfedosin@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-openstack-cinder-csi-driver-rhel8

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -33,3 +33,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-openstack-cloud-controller-manager-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -25,3 +25,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-powervs-machine-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -27,3 +27,6 @@ from:
 delivery:
   delivery_repo_names:
   - openshift4/ose-vsphere-cloud-controller-manager-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -27,3 +27,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-vsphere-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -35,3 +35,6 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-ptp-operator-bundle
   delivery_repo_names:
   - openshift4/ose-ptp-operator
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -29,6 +29,8 @@ owners:
 - multus-dev@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-sriov-network-config-daemon

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -31,3 +31,6 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-sriov-network-operator-bundle
   delivery_repo_names:
   - openshift4/ose-sriov-network-operator
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -27,3 +27,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-sriov-network-webhook
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
Disable cachi2 for images which are failing to build in Konflux because of cachi2-related issues.