### PR TITLE
ART-13260: Disable cachi2 for openshift-enterprise-haproxy-router

### DIFF
--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -23,6 +23,8 @@ owners:
 - aos-network-edge@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-haproxy-router


### PR DESCRIPTION
Disable cachi2 for `openshift-enterprise-haproxy-router` in Konflux because it's failing to build due to go.mod inconsistency