### PR TITLE
ART-13260: Disable cachi2 for several images in 4.14

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -26,3 +26,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-baremetal-machine-controllers
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -21,3 +21,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-network-operator
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -27,3 +27,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-csi-driver-manila-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -28,3 +28,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-sriov-infiniband-cni
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ibm-vpc-node-label-updater.yml
+++ b/images/ibm-vpc-node-label-updater.yml
@@ -30,6 +30,8 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibm-vpc-node-label-updater-rhel8

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -23,3 +23,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-node-feature-discovery
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -23,3 +23,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-console-operator
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -28,6 +28,8 @@ owners:
 - ocp-agent-team@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-agent-installer-api-server-rhel8

--- a/images/ose-alibaba-cloud-csi-driver.yml
+++ b/images/ose-alibaba-cloud-csi-driver.yml
@@ -35,6 +35,8 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-alibaba-cloud-csi-driver-container-rhel8

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -28,3 +28,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-aws-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -28,3 +28,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-azure-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -22,3 +22,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-api-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -22,3 +22,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-baremetal-operator-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -32,6 +32,8 @@ owners:
 - dcbw@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-container-networking-plugins-rhel8

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -29,3 +29,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-gcp-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -30,6 +30,8 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibm-vpc-block-csi-driver-rhel8

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -27,3 +27,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibmcloud-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -29,6 +29,8 @@ owners:
 - pkrupa@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-libvirt-machine-controllers

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -21,6 +21,8 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-openstack-rhel8

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -27,6 +27,8 @@ owners:
 - mfedosin@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-openstack-cinder-csi-driver-rhel8

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -33,3 +33,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-openstack-cloud-controller-manager-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -25,3 +25,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-powervs-machine-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -27,3 +27,6 @@ from:
 delivery:
   delivery_repo_names:
   - openshift4/ose-vsphere-cloud-controller-manager-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -27,3 +27,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-vsphere-cluster-api-controllers-rhel8
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -35,3 +35,6 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-ptp-operator-bundle
   delivery_repo_names:
   - openshift4/ose-ptp-operator
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
Disable cachi2 for images which are failing to build in Konflux due to cachi2-related issues