### PR TITLE
[openshift-4.18] Libreswan adjustments

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -100,8 +100,8 @@ rhcos:
   require_consistency:
     driver-toolkit:
     - kernel  # since 9.3, kernel-rt is merged into the kernel package.
-  exempt_rpms: # skip check these rpms as they will aligned with rhel base image in rhcos
-  - libreswan
+    ose-ovn-kubernetes:
+    - libreswan
   allow_missing_brew_rpms: false
 
 check_external_packages:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -37,7 +37,6 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - libreswan*
   - openvswitch*
   - ovn*
   - python3-openvswitch*

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -28,7 +28,6 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - libreswan
   - openvswitch*
   - ovn*
   - python3-openvswitch*

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -37,7 +37,6 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - libreswan
   - openvswitch*
   - ovn*
   - python3-openvswitch*


### PR DESCRIPTION
Manual port of the https://github.com/openshift-eng/ocp-build-data/pull/6490 due to conflicting previously merged PRs:
  * https://github.com/openshift-eng/ocp-build-data/pull/6940
  * https://github.com/openshift-eng/ocp-build-data/pull/6736

This change aims to do two things:
- Start listening for changs when libreswan sees an update This can happen now libreswan is not pinned anymore
- Get an annotation in the consistency checks if rhcos and ovn have different versions for libreswan. ovn-miicroshift is not yet needed

(cherry-picked from commit 48c1d3aaae945bdea13b9b7bc729d1a814c96831)

The libreswan package was un-pinned in 4.18 ovn-k via https://github.com/openshift/ovn-kubernetes/pull/2593 ([relevant diff](https://github.com/openshift/ovn-kubernetes/pull/2593/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557)).

CC: @joepvd 