### PR TITLE
ART-13260: Disable cachi2 for several images in 4.15

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -32,3 +32,6 @@ owners:
 - rbryant@redhat.com
 - dhellman@redhat.com
 - mhrivnak@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -27,3 +27,6 @@ name: openshift/ose-coredns-rhel9
 payload_name: coredns
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -34,3 +34,6 @@ name: openshift/ose-sriov-infiniband-cni-rhel9
 name_in_bundle: sriov-infiniband-cni
 owners:
 - multus-dev@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ibm-vpc-node-label-updater.yml
+++ b/images/ibm-vpc-node-label-updater.yml
@@ -38,3 +38,5 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -29,3 +29,6 @@ name: openshift/ose-node-feature-discovery-rhel9
 name_in_bundle: node-feature-discovery
 owners:
 - edge-kmm@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -33,3 +33,5 @@ owners:
 konflux:
   cachito:
     mode: removal
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -29,3 +29,6 @@ owners:
 - bpeterse@redhat.com
 - spadgett@redhat.com
 - jforrest@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -42,3 +42,5 @@ owners:
 - aos-master@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -40,3 +40,5 @@ owners:
 - yboaron@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-alibaba-cloud-csi-driver.yml
+++ b/images/ose-alibaba-cloud-csi-driver.yml
@@ -43,3 +43,5 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -34,3 +34,6 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -34,3 +34,6 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -26,3 +26,6 @@ name: openshift/ose-cluster-baremetal-rhel9-operator
 payload_name: cluster-baremetal-operator
 owners:
 - kni-devel-deployment@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -35,3 +35,6 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -39,3 +39,5 @@ owners:
 - aos-storage-staff@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -33,3 +33,6 @@ payload_name: ibmcloud-cluster-api-controllers
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -39,3 +39,5 @@ owners:
 - pkrupa@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -30,3 +30,5 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -33,3 +33,6 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -33,3 +33,6 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
Disable cachi2 for 4.15 images which are failing to build in Konflux because of cachi2-related issues.