### PR TITLE
ART-13429: ci-openshift-build-root*: Stop building in Konflux

### DIFF
--- a/images/ci-openshift-build-root-latest.rhel8.yml
+++ b/images/ci-openshift-build-root-latest.rhel8.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true


### PR DESCRIPTION
Disabling Konflux builds of ci-build-root images until [ART-13429](https://issues.redhat.com//browse/ART-13429) is solved