### PR TITLE
ART-13429: ci-openshift-build-root*: Stop building in Konflux

### DIFF
--- a/images/ci-openshift-build-root-latest.rhel8.yml
+++ b/images/ci-openshift-build-root-latest.rhel8.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-build-root-latest.rhel9.yml
+++ b/images/ci-openshift-build-root-latest.rhel9.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they


### PR DESCRIPTION
Disabling Konflux builds of ci-build-root images until [ART-13429](https://issues.redhat.com//browse/ART-13429) is solved