### PR TITLE
[openshift-4.18] CORENET-5975: ovn-kubernetes: Remove exemptions for now unpinned OVS rpms.

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -37,9 +37,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 for_payload: true
 from:
   builder:

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -28,9 +28,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 for_payload: false
 for_release: false
 from:

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -37,9 +37,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
openvswitch* RPMs are no longer pinned in ovn-kubernetes images in order to facilitate timely CVE and bug fix delivery.  Remove from exemptions.

Manual cherry-pick of https://github.com/openshift-eng/ocp-build-data/pull/6716.

4.18 ovn-k PR that removed the OVS pin: https://github.com/openshift/ovn-kubernetes/pull/2646 ([relevant diff](https://github.com/openshift/ovn-kubernetes/pull/2646/files#diff-8f5e5cdf9d8c402d512a6f0cc8b414617cd93c533d36b90ea46def15909f28af))