### PR TITLE
[openshift-4.16] CORENET-5975: ovn-kubernetes: Remove exemptions for now unpinned OVS rpms.

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -33,9 +33,7 @@ scan_sources:
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
   - libreswan*
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ovn-kubernetes

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -29,9 +29,7 @@ scan_sources:
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
   - libreswan
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 for_payload: false
 for_release: false
 from:

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -33,9 +33,7 @@ scan_sources:
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
   - libreswan
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ovn-kubernetes-microshift


### PR DESCRIPTION
openvswitch* RPMs are no longer pinned in ovn-kubernetes images in order to facilitate timely CVE and bug fix delivery.  Remove from exemptions.

Manual cherry-pick of https://github.com/openshift-eng/ocp-build-data/pull/7227 due to conflicts on the `delivery:` section.

4.16 ovn-k PR that removed the OVS pin: https://github.com/openshift/ovn-kubernetes/pull/2648.