### PR TITLE
build: network_mode to open for images failing to build

### DIFF
--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -34,3 +34,5 @@ name: openshift/ose-baremetal-runtimecfg-rhel9
 payload_name: baremetal-runtimecfg
 owners:
 - asegurap@redhat.com
+konflux:
+  network_mode: open # lockfile generation related

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -35,3 +35,5 @@ name: openshift/ose-cluster-node-tuning-rhel9-operator
 payload_name: cluster-node-tuning-operator
 owners:
 - openshift-psap@redhat.com
+konflux:
+  network_mode: open # lockfile generation related

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -28,3 +28,5 @@ labels:
 name: openshift/ose-egress-router-rhel9
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open # lockfile generation related

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -36,3 +36,5 @@ owners:
 - rgolan@redhat.com
 - nargaman@redhat.com
 - dvossel@redhat.com
+konflux:
+  network_mode: open # lockfile generation related

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -39,3 +39,5 @@ payload_name: tools
 owners:
 - aos-master@redhat.com
 name_in_bundle: ose-tools-rhel9
+konflux:
+  network_mode: open # lockfile generation related

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -36,3 +36,5 @@ name: openshift/ose-sriov-network-config-daemon-rhel9
 name_in_bundle: sriov-network-config-daemon
 owners:
 - multus-dev@redhat.com
+konflux:
+  network_mode: open # lockfile generation related


### PR DESCRIPTION
Disable hermetic until properly fixed

Affects baremetal-runtimecfg, cluster-node-tuning-operator, openshift-enterprise-egress-router, ose-kubevirt-csi-driver-rhel8, ose-tools, and sriov-network-config-daemon images.