### PR TITLE
Remove konflux network mode configuration from haproxy-router YAML

### DIFF
--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -30,5 +30,3 @@ name: openshift/ose-haproxy-router-rhel9
 payload_name: haproxy-router
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  network_mode: open


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ART-13482
Passing jenkins job(fails for s390x due timeout, not related): https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/lgarciaa/job/build%252Focp4-konflux/38/ 
Passing build: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-openshift-enterprise-haproxy-router-j2qs8