### PR TITLE
Re-enable clusterresourceoverride-operator

### DIFF
--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled # Until https://issues.redhat.com/browse/OCPBUGS-57969 is fixed
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
Since this is fixed hence reverting the change : https://issues.redhat.com/browse/OCPBUGS-57969