### PR TITLE
fix ose-metallb-operator build errors

### DIFF
--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -14,7 +14,7 @@ dependents:
 - ptp-operator
 - cluster-nfd-operator
 - ose-aws-efs-csi-driver-operator
-# - ose-metallb-operator
+- ose-metallb-operator
 - local-storage-operator
 - ingress-node-firewall-operator
 - ose-gcp-filestore-csi-driver-operator

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -19,8 +19,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-server-ose-rpms-embargoed
 for_payload: true
-# dependents:
-# - ose-metallb-operator
+dependents:
+ - ose-metallb-operator
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
```
doozerlib.exceptions.DoozerFatalError: Related image contains ose-frr but this does not have ose-metallb-operator in dependents
```
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4/22743/consoleText