### PR TITLE
add missing delivery repo name

### DIFF
--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -16,6 +16,8 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: metallb
+  delivery_repo_names:
+  - openshift4/metallb-rhel9
 dependents:
 - ose-metallb-operator
 for_payload: false


### PR DESCRIPTION
same as 4.19: https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.19/images/ose-metallb.yml#L20