### PR TITLE
Renable dpu-operator, sriov-network-operator, clusterresource override operator

### DIFF
--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -21,6 +21,8 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-clusterresourceoverride-operator
   bundle_delivery_repo_name: openshift4/ose-clusterresourceoverride-operator-bundle
+  delivery_repo_names:
+  - openshift4/ose-clusterresourceoverride-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled # Until https://issues.redhat.com/browse/OCPBUGS-57969 is fixed
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/dpu-operator.yml
+++ b/images/dpu-operator.yml
@@ -18,6 +18,8 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-dpu-operator
   bundle_delivery_repo_name: openshift4/ose-dpu-rhel9-operator-bundle
+  delivery_repo_names:
+  - openshift4/ose-dpu-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/dpu-operator.yml
+++ b/images/dpu-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled #Until https://issues.redhat.com/browse/OCPBUGS-57962 is fixed
 content:
   source:
     dockerfile: Dockerfile.rhel

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -22,6 +22,8 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-sriov-network-operator
   bundle_delivery_repo_name: openshift4/ose-sriov-network-operator-bundle
+  delivery_repo_names:
+  - openshift4/ose-sriov-network-rhel9-operator
 for_payload: false
 from:
   builder:

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled # Until https://issues.redhat.com/browse/OCPBUGS-57973 is fixed
 arches:
 - x86_64
 - aarch64


### PR DESCRIPTION
Since below bugs are fixed we can renable these operators.

https://issues.redhat.com/browse/OCPBUGS-57973
https://issues.redhat.com/browse/OCPBUGS-57962
https://issues.redhat.com/browse/OCPBUGS-57969
