### PR TITLE
scan-sources:noop Set network_mode to open

### DIFF
--- a/images/openshift-base-nodejs.rhel9.yml
+++ b/images/openshift-base-nodejs.rhel9.yml
@@ -42,3 +42,5 @@ name: openshift/base-nodejs-rhel9
 owners:
 - aos-team-art@redhat.com
 canonical_builders_from_upstream: false
+konflux:
+  network_mode: open # Lockfile related error

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -31,3 +31,5 @@ name: openshift/ose-keepalived-ipfailover-rhel9
 payload_name: keepalived-ipfailover
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open # Lockfile related error

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -28,3 +28,5 @@ labels:
 name: openshift/ose-egress-http-proxy-rhel9
 owners:
 - aos-network-edge@redhat.com
+konflux:
+  network_mode: open # Lockfile related error


### PR DESCRIPTION
Set `network_mode` to `open` to fix lockfile-related Konflux build errors

Error logs:
- https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-openshift-enterprise-keepalived-ipfailover-d7x84
- https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-egress-http-proxy-ccw66
- https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-openshift-base-nodejs-rhel9-8gjx4

