### PR TITLE
Don't inspect parent for lockfile generation for several images in 4.19

### DIFF
--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -35,4 +35,6 @@ payload_name: baremetal-runtimecfg
 owners:
 - asegurap@redhat.com
 konflux:
-  network_mode: open # https://issues.redhat.com/browse/ART-13869
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/container-networking-plugins-microshift.yml
+++ b/images/container-networking-plugins-microshift.yml
@@ -42,4 +42,6 @@ owners:
 - dosmith@redhat.com
 - microshift-devel@redhat.com
 konflux:
-  network_mode: open # reason: rpm lockfile
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/multus-cni-container-microshift.yml
+++ b/images/multus-cni-container-microshift.yml
@@ -42,4 +42,6 @@ owners:
 - dosmith@redhat.com
 - microshift-devel@redhat.com
 konflux:
-  network_mode: open # reason: rpm lockfile
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -39,4 +39,6 @@ payload_name: multus-cni
 owners:
 - multus-dev@redhat.com
 konflux:
-  network_mode: open # reason: rpm lockfile
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/openshift-base-nodejs.rhel9.yml
+++ b/images/openshift-base-nodejs.rhel9.yml
@@ -43,4 +43,6 @@ owners:
 - aos-team-art@redhat.com
 canonical_builders_from_upstream: false
 konflux:
-  network_mode: open # Lockfile related error
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -29,4 +29,6 @@ name: openshift/ose-egress-router-rhel9
 owners:
 - aos-network-edge@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -32,4 +32,6 @@ payload_name: keepalived-ipfailover
 owners:
 - aos-network-edge@redhat.com
 konflux:
-  network_mode: open # Lockfile related error
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -36,4 +36,6 @@ payload_name: docker-registry
 owners:
 - openshift-image-registry@redhat.com
 konflux:
-  network_mode: open # reason: rpm lockfile
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -29,4 +29,6 @@ name: openshift/ose-egress-http-proxy-rhel9
 owners:
 - aos-network-edge@redhat.com
 konflux:
-  network_mode: open # Lockfile related error
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -37,4 +37,6 @@ owners:
 - nargaman@redhat.com
 - dvossel@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      inspect_parent: false


### PR DESCRIPTION
Set `inspect_parent` to `false` and re-enable hermetic mode for several images. Hermetic mode was previously disabled due to errors with lockfiles. This has been fixed in https://github.com/openshift-eng/art-tools/pull/1831 with the introduction of `cachi2.lockfile. inspect_parent`.