### PR TITLE
Move from eus to e4s for 9.2 content

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -324,20 +324,20 @@ repos:
       extra_options:
         module_hotfixes: 1
       baseurl:
-        aarch64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/aarch64/baseos/os/"
-        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/ppc64le/baseos/os/"
-        s390x: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/s390x/baseos/os/"
-        x86_64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/x86_64/baseos/os/"
+        aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/aarch64/baseos/os/"
+        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/ppc64le/baseos/os/"
+        s390x: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/s390x/baseos/os/"
+        x86_64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/x86_64/baseos/os/"
       ci_alignment:
         profiles:
         - el9
         localdev:
           enabled: true
     content_set:
-      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_2
-      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_2
-      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_2
-      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_2
+      default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_2
+      aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_2
+      ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_2
+      s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_2
     reposync:
       enabled: false
 
@@ -346,20 +346,20 @@ repos:
       extra_options:
         module_hotfixes: 1
       baseurl:
-        aarch64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/aarch64/appstream/os/"
-        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/ppc64le/appstream/os/"
-        s390x: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/s390x/appstream/os/"
-        x86_64: "https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/x86_64/appstream/os/"
+        aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/aarch64/appstream/os/"
+        ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/ppc64le/appstream/os/"
+        s390x: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/s390x/appstream/os/"
+        x86_64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/x86_64/appstream/os/"
       ci_alignment:
         profiles:
         - el9
         localdev:
           enabled: true
     content_set:
-      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
-      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_2
-      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2
-      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
+      default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_2
+      aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_2
+      ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_2
+      s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_2
     reposync:
       enabled: false
 


### PR DESCRIPTION
9.2 EUS ended July 1, need to move to e4s