### PR TITLE
Update coreos repositories for rhel9 from eus to e4s group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -345,40 +345,40 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/s390x/baseos/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el9
         localdev:
           enabled: true
     content_set:
-      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_2
-      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_2
-      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_2
-      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_2
+      default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_2
+      aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_2
+      ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_2
+      s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_2
     reposync:
       enabled: false
 
   rhel-9-appstream-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/s390x/appstream/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.2/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el9
         localdev:
           enabled: true
     content_set:
-      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
-      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_2
-      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2
-      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
+      default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_2
+      aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_2
+      ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_2
+      s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_2
     reposync:
       enabled: false
 


### PR DESCRIPTION
Update coreos repositories for rhel9 from eus to e4s group.yml

Following this change:

https://gitlab.cee.redhat.com/coreos/redhat-coreos/-/commit/2f71a39c3338479151d17f15456e39a7ec6d87d7