### PR TITLE
[openshift-4.18] Re-add exemptions for Libreswan as it was pinned back in 4.18 ovn-k.

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -102,6 +102,8 @@ rhcos:
     - kernel  # since 9.3, kernel-rt is merged into the kernel package.
     ose-ovn-kubernetes:
     - libreswan
+  exempt_rpms: # skip check these rpms as they will aligned with rhel base image in rhcos
+  - libreswan
   allow_missing_brew_rpms: false
 
 check_external_packages:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -37,6 +37,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
+  - libreswan*
   - ovn*
 for_payload: true
 from:

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -28,6 +28,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
+  - libreswan
   - ovn*
 for_payload: false
 for_release: false

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -37,6 +37,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
+  - libreswan
   - ovn*
 for_payload: true
 from:


### PR DESCRIPTION
Cleaning up some mess, as Libreswan was unpinned and the pinned back:
* https://github.com/openshift/ovn-kubernetes/pull/2678
* https://github.com/openshift/os/pull/1849

Not a full revert of https://github.com/openshift-eng/ocp-build-data/pull/7182 as we're keeping the consistency requirement between ovn-k and rhcos.

CC: @joepvd