### PR TITLE
Add security_reviewer to boilerplates [4.12]

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -194,6 +194,7 @@ boilerplates:
         For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
         https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
+      security_reviewer: sfowler@redhat.com
     rhba:
       synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} extras update
       topic: Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
@@ -234,6 +235,7 @@ boilerplates:
          https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes
 
         Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-within-minor.
+      security_reviewer: sfowler@redhat.com
     rhba:
       synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} OLM Operators metadata update
       topic: |


### PR DESCRIPTION
We are getting the following error in the prepare-release job when it tries to convert the RHBA to RHSA.


```
2025-07-30 19:53:43,931 elliottlib.cli.attach_cve_flaws_cli INFO Advisory type is RHBA, converting it to RHSA
2025-07-30 19:53:43,932 elliottlib.cli.attach_cve_flaws_cli ERROR Traceback (most recent call last):
  File "/mnt/jenkins-workspace/d-builds_build_prepare-release_2/art-tools/elliott/elliottlib/cli/attach_cve_flaws_cli.py", line 249, in handle_brew_cve_flaws
    self.update_advisory_brew(advisory, self.advisory_kind, flaw_bugs, flaw_bug_tracker, self.noop)
  File "/mnt/jenkins-workspace/d-builds_build_prepare-release_2/art-tools/elliott/elliottlib/cli/attach_cve_flaws_cli.py", line 271, in update_advisory_brew
    advisory, updated = self.get_updated_advisory_rhsa(cve_boilerplate, advisory, flaw_bugs)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/jenkins-workspace/d-builds_build_prepare-release_2/art-tools/elliott/elliottlib/cli/attach_cve_flaws_cli.py", line 354, in get_updated_advisory_rhsa
    security_reviewer=cve_boilerplate['security_reviewer'],
                      ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
KeyError: 'security_reviewer'
```

This will need to be fixed in 4.12 and 4.13.