### PR TITLE
ART-13260: Disable cachi2 in Konflux for openshift-kubernetes-nmstate-handler and ose-metallb in 4.14

### DIFF
--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -35,6 +35,8 @@ owners:
 - yboaron@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-kubernetes-nmstate-handler-rhel9

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -26,3 +26,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/metallb-rhel9
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
Both of these images are failing to build due to cachi2 issues:
- [ose-metallb failed build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-metallb-jqfch/logs?task=prefetch-dependencies)
- [openshift-kubernetes-nmstate-handler failed build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-openshift-kubernetes-nmstate-handler-2jsdp/logs?task=prefetch-dependencies)