### PR TITLE
ART-13260: Disable Konflux cachi2 for sriov-cni in 4.13

### DIFF
--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -30,3 +30,6 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/sriov-cni-rhel9
+konflux:
+  cachi2:
+    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
`sriov-cni` is failing to build in Konflux due to cachi2 issues

[Failed build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-sriov-cni-f4ccc/logs?task=prefetch-dependencies)