### PR TITLE
add timestamp for 4.19.7

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -37,6 +37,7 @@ releases:
     assembly:
       type: standard
       basis:
+        time: "2025-07-30T07:50:47.014390+00:00"
         brew_event: 64802925
         reference_releases:
           aarch64: 4.19.0-0.nightly-arm64-2025-07-30-083404


### PR DESCRIPTION
```
$print(koji_api.getEvent(64802925))
{'id': 64802925, 'ts': 1753861847.01439}

python3 -c "import datetime; print(datetime.datetime.fromtimestamp(1753861847.01439, tz=datetime.timezone.utc).isoformat())"
2025-07-30T07:50:47.014390+00:00
```