### PR TITLE
OCPBUGS-48709: Allow ovnk 4.19 to build with go1.24

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -41,8 +41,8 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
-  - stream: rhel-8-golang
+  - stream: rhel-9-golang-1.24
+  - stream: rhel-8-golang-1.24
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+
@@ -55,3 +55,5 @@ owners:
 - aos-networking-staff@redhat.com
 konflux:
   network_mode: open
+canonical_builders_from_upstream: true
+

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -43,3 +43,4 @@ owners:
 - aos-networking-staff@redhat.com
 konflux:
   network_mode: open
+canonical_builders_from_upstream: true

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -36,7 +36,7 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.24
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+
@@ -49,3 +49,4 @@ owners:
 - aos-networking-staff@redhat.com
 konflux:
   network_mode: open
+canonical_builders_from_upstream: true


### PR DESCRIPTION
openshift/ovn-kubernetes is keeping it's 4.19 branch in complete sync with 4.20. 4.20 has recently received image bumps to use go1.24. this will allow ovnk images to build with that expected go version