### PR TITLE
Revert "[4.21] unfreeze automation"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,7 +4,7 @@
 #   - weekdays: always allow manual builds; forbid scheduled builds from Monday to Friday
 #   - no|false: always allow builds
 # Note that ocp4 builds are always permitted  for non-stream assemblies
-freeze_automation: false
+freeze_automation: scheduled
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#7385
There are several issues with 4.21
- scan will fail if rhcos tag does not exist in imagestream, there is a workaround https://github.com/openshift-eng/art-tools/pull/1924/files , but without it scan will fail
- rpms cannot be built on 4.21 buildroot
- images need careful manual fixing.
- So we need a successful ocp4-konflux job + build-sync job 

Until then keeping automation on scheduled