### PR TITLE
4.17.38: Exclude bug

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -9,6 +9,10 @@ releases:
           s390x: 4.17.0-0.nightly-s390x-2025-08-20-175012
           aarch64: 4.17.0-0.nightly-arm64-2025-08-20-175013
           x86_64: 4.17.0-0.nightly-2025-08-20-184658
+      issues:
+        exclude:
+          - id: OCPBUGS-55598
+            # why: not managed by ART
       group:
         advisories:
           rpm: 153615


### PR DESCRIPTION
The listed bug is not managed by ART. Exclude it in assembly definition before we update the filter in automation.