### PR TITLE
fix nmstate-console-plugin

### DIFF
--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -56,3 +56,9 @@ owners:
 konflux:
   cachito:
     mode: emulation
+  cachi2:
+    artifact_lockfile:
+      resources:
+      - https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
+      - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
+  network_mode: open # Bunch of yarn dependencies, not sure how to fix, signed @lgarciaa


### PR DESCRIPTION
fix error
2025-08-28 00:15:06,455 doozerlib.cli.images_konflux ERROR Failed to rebase nmstate-console-plugin: Hermetic build requires yarn artifact definition in image metadata. Add yarn resource URL to konflux.cachi2.artifact_lockfile.resources in nmstate-console-plugin. Expected URL pattern: yarn-v
2025-08-28 00:15:08,186 pyartcd.pipelines.ocp4_konflux WARNING Following images failed to rebase and won't be built: nmstate-console-plugin