### PR TITLE
now disabling cluster-nfd-operator using for_release flag

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -43,7 +43,7 @@ releases:
         images:
           - distgit_key: cluster-nfd-operator
             metadata:
-              mode: disabled
+              for_release: false
             why: yaml file for the component is not correct
   4.16.46:
     assembly:


### PR DESCRIPTION
cluster-nfd-operator has got an invalid yaml
to disable it in release 4.16.47, we are going to now use for_release property instead of mode