### PR TITLE
Add new-style repo config files

### DIFF
--- a/group.ext.yml
+++ b/group.ext.yml
@@ -1,0 +1,6 @@
+---
+# Additional group configs
+# Options in this file are merged into group.yml
+plashet: !include plashet.yml
+# We already have repos in group.yml. Use a different name for new-style repo configs
+all_repos: !include repos/*.yml

--- a/plashet.yml
+++ b/plashet.yml
@@ -1,0 +1,12 @@
+# Global plashet config
+# Full dir: $MAJOR.$MINOR/$runtime_assembly/$slug/$yyyy-$mm/$revision/$arch/os
+# e.g. 4.20/stream/el10-embargoed/2025-08/202508272328/x86_64/os
+# Symlink is created at 4.20/stream/el10-embargoed/latest
+base_dir: "{MAJOR}.{MINOR}/$runtime_assembly/$slug"
+plashet_dir: "$yyyy-$MM/$revision"
+create_symlinks: true
+symlink_name: "latest"
+create_repo_subdirs: true
+repo_subdir: "os"
+arches: ["x86_64", "s390x", "ppc64le", "aarch64"]
+download_url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/$runtime_assembly/$slug/latest/$arch/os/

--- a/repos/openstack-17-for-rhel-9-rpms.yml
+++ b/repos/openstack-17-for-rhel-9-rpms.yml
@@ -1,0 +1,16 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17.1/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17.1/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17.1/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/openstack/17.1/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+  content_set:
+    default: openstack-17.1-for-rhel-9-x86_64-rpms
+    optional: true
+  name: openstack-17-for-rhel-9-rpms
+  type: external

--- a/repos/rhel-10-appstream.yml
+++ b/repos/rhel-10-appstream.yml
@@ -1,0 +1,14 @@
+- conf:
+    baseurl:
+      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/
+      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/
+      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/
+      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    optional: true
+  name: rhel-10-appstream
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-10-baseos.yml
+++ b/repos/rhel-10-baseos.yml
@@ -1,0 +1,14 @@
+- conf:
+    baseurl:
+      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/aarch64/os/
+      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/ppc64le/os/
+      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/s390x/os/
+      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    optional: true
+  name: rhel-10-baseos
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-10-highavailability.yml
+++ b/repos/rhel-10-highavailability.yml
@@ -1,0 +1,14 @@
+- conf:
+    baseurl:
+      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/HighAvailability/aarch64/os/
+      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/HighAvailability/ppc64le/os/
+      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/HighAvailability/s390x/os/
+      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/HighAvailability/x86_64/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    optional: true
+  name: rhel-10-highavailability
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-10-nfv.yml
+++ b/repos/rhel-10-nfv.yml
@@ -1,0 +1,14 @@
+- conf:
+    baseurl:
+      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/NFV/x86_64/os/
+      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/NFV/x86_64/os/
+      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/NFV/x86_64/os/
+      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.0/compose/NFV/x86_64/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    optional: true
+  name: rhel-10-nfv
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-10-server-ose-rpms-embargoed.yml
+++ b/repos/rhel-10-server-ose-rpms-embargoed.yml
@@ -1,0 +1,41 @@
+- conf:
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhocp-4.21-for-rhel-10-aarch64-rpms
+    default: rhocp-4.21-for-rhel-10-x86_64-rpms
+    optional: true
+    ppc64le: rhocp-4.21-for-rhel-10-ppc64le-rpms
+    s390x: rhocp-4.21-for-rhel-10-s390x-rpms
+  name: rhel-10-server-ose-rpms-embargoed
+  plashet:
+    assembly_aware: true
+    embargo_aware: true
+    include_embargoed: true
+    include_previous_packages:
+    - conmon
+    - cri-o
+    - cri-tools
+    - crun
+    - haproxy
+    - ignition
+    - kernel
+    - kernel-rt
+    - libreswan
+    - nmstate
+    - openshift
+    - openvswitch
+    - ovn
+    - podman
+    - python3-openvswitch
+    - spdlog
+    slug: el10-embargoed
+    source:
+      embargoed_tags:
+      - rhaos-{MAJOR}.{MINOR}-rhel-10-embargoed
+      from_tags:
+      - name: rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
+        product_version: OSE-{MAJOR}.{MINOR}-RHEL-10
+        release_tag: rhaos-{MAJOR}.{MINOR}-rhel-10
+      type: brew
+  type: plashet

--- a/repos/rhel-10-server-ose-rpms.yml
+++ b/repos/rhel-10-server-ose-rpms.yml
@@ -1,0 +1,43 @@
+- conf:
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el10
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    optional: true
+  name: rhel-10-server-ose-rpms
+  plashet:
+    assembly_aware: true
+    embargo_aware: true
+    include_previous_packages:
+    - conmon
+    - cri-o
+    - cri-tools
+    - crun
+    - haproxy
+    - ignition
+    - kernel
+    - kernel-rt
+    - libreswan
+    - nmstate
+    - openshift
+    - openvswitch
+    - ovn
+    - podman
+    - python3-openvswitch
+    - spdlog
+    slug: el10
+    source:
+      embargoed_tags:
+      - rhaos-{MAJOR}.{MINOR}-rhel-10-embargoed
+      from_tags:
+      - name: rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
+        product_version: OSE-{MAJOR}.{MINOR}-RHEL-10
+        release_tag: rhaos-{MAJOR}.{MINOR}-rhel-10
+      type: brew
+  reposync:
+    latest_only: false
+  type: plashet

--- a/repos/rhel-8-appstream-rpms.yml
+++ b/repos/rhel-8-appstream-rpms.yml
@@ -1,0 +1,20 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el8
+    extra_options:
+      excludepkgs: containernetworking-plugins
+  content_set:
+    aarch64: rhel-8-for-aarch64-appstream-rpms__8
+    default: rhel-8-for-x86_64-appstream-rpms__8
+    ppc64le: rhel-8-for-ppc64le-appstream-rpms__8
+    s390x: rhel-8-for-s390x-appstream-rpms__8
+  name: rhel-8-appstream-rpms
+  type: external

--- a/repos/rhel-8-baseos-rpms.yml
+++ b/repos/rhel-8-baseos-rpms.yml
@@ -1,0 +1,18 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el8
+  content_set:
+    aarch64: rhel-8-for-aarch64-baseos-rpms__8
+    default: rhel-8-for-x86_64-baseos-rpms__8
+    ppc64le: rhel-8-for-ppc64le-baseos-rpms__8
+    s390x: rhel-8-for-s390x-baseos-rpms__8
+  name: rhel-8-baseos-rpms
+  type: external

--- a/repos/rhel-8-fast-datapath-rpms.yml
+++ b/repos/rhel-8-fast-datapath-rpms.yml
@@ -1,0 +1,21 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/fast-datapath/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/s390x/fast-datapath/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/fast-datapath/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el8
+  content_set:
+    aarch64: fast-datapath-for-rhel-8-aarch64-rpms
+    default: fast-datapath-for-rhel-8-x86_64-rpms
+    optional: true
+    ppc64le: fast-datapath-for-rhel-8-ppc64le-rpms
+    s390x: fast-datapath-for-rhel-8-s390x-rpms
+  name: rhel-8-fast-datapath-rpms
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-8-server-ose-rpms-embargoed.yml
+++ b/repos/rhel-8-server-ose-rpms-embargoed.yml
@@ -1,0 +1,41 @@
+- conf:
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhocp-4.21-for-rhel-8-aarch64-rpms
+    default: rhocp-4.21-for-rhel-8-x86_64-rpms
+    optional: true
+    ppc64le: rhocp-4.21-for-rhel-8-ppc64le-rpms
+    s390x: rhocp-4.21-for-rhel-8-s390x-rpms
+  name: rhel-8-server-ose-rpms-embargoed
+  plashet:
+    assembly_aware: true
+    embargo_aware: true
+    include_embargoed: true
+    include_previous_packages:
+    - conmon
+    - cri-o
+    - cri-tools
+    - crun
+    - haproxy
+    - ignition
+    - kernel
+    - kernel-rt
+    - libreswan
+    - nmstate
+    - openshift
+    - openvswitch
+    - ovn
+    - podman
+    - python3-openvswitch
+    - spdlog
+    slug: el8-embargoed
+    source:
+      embargoed_tags:
+      - rhaos-{MAJOR}.{MINOR}-rhel-8-embargoed
+      from_tags:
+      - name: rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
+        product_version: OSE-{MAJOR}.{MINOR}-RHEL-8
+        release_tag: rhaos-{MAJOR}.{MINOR}-rhel-8
+      type: brew
+  type: plashet

--- a/repos/rhel-8-server-ose-rpms.yml
+++ b/repos/rhel-8-server-ose-rpms.yml
@@ -1,0 +1,43 @@
+- conf:
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el8
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    optional: true
+  name: rhel-8-server-ose-rpms
+  plashet:
+    assembly_aware: true
+    embargo_aware: true
+    include_previous_packages:
+    - conmon
+    - cri-o
+    - cri-tools
+    - crun
+    - haproxy
+    - ignition
+    - kernel
+    - kernel-rt
+    - libreswan
+    - nmstate
+    - openshift
+    - openvswitch
+    - ovn
+    - podman
+    - python3-openvswitch
+    - spdlog
+    slug: el8
+    source:
+      embargoed_tags:
+      - rhaos-{MAJOR}.{MINOR}-rhel-8-embargoed
+      from_tags:
+      - name: rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
+        product_version: OSE-{MAJOR}.{MINOR}-RHEL-8
+        release_tag: rhaos-{MAJOR}.{MINOR}-rhel-8
+      type: brew
+  reposync:
+    latest_only: false
+  type: plashet

--- a/repos/rhel-9-appstream-rpms.yml
+++ b/repos/rhel-9-appstream-rpms.yml
@@ -1,0 +1,20 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4
+    default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4
+    ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4
+    s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4
+  name: rhel-9-appstream-rpms
+  type: external

--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -1,0 +1,20 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_4
+    default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4
+    ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_4
+    s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_4
+  name: rhel-9-baseos-rpms
+  type: external

--- a/repos/rhel-9-codeready-builder-rpms.yml
+++ b/repos/rhel-9-codeready-builder-rpms.yml
@@ -1,0 +1,18 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/codeready-builder/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/codeready-builder/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/codeready-builder/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/codeready-builder/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+  content_set:
+    aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_4
+    default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_4
+    ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_4
+    s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_4
+  name: rhel-9-codeready-builder-rpms
+  type: external

--- a/repos/rhel-9-fast-datapath-rpms.yml
+++ b/repos/rhel-9-fast-datapath-rpms.yml
@@ -1,0 +1,21 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+  content_set:
+    aarch64: fast-datapath-for-rhel-9-aarch64-rpms
+    default: fast-datapath-for-rhel-9-x86_64-rpms
+    optional: true
+    ppc64le: fast-datapath-for-rhel-9-ppc64le-rpms
+    s390x: fast-datapath-for-rhel-9-s390x-rpms
+  name: rhel-9-fast-datapath-rpms
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-9-rt-rpms.yml
+++ b/repos/rhel-9-rt-rpms.yml
@@ -1,0 +1,13 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/os/
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    default: rhel-9-for-x86_64-rt-e4s-rpms__9_DOT_4
+    optional: true
+  name: rhel-9-rt-rpms
+  type: external

--- a/repos/rhel-9-server-ironic-rpms.yml
+++ b/repos/rhel-9-server-ironic-rpms.yml
@@ -1,0 +1,34 @@
+- conf:
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhocp-ironic-4.21-for-rhel-9-aarch64-rpms
+    default: rhocp-ironic-4.21-for-rhel-9-x86_64-rpms
+    optional: true
+    ppc64le: rhocp-ironic-4.21-for-rhel-9-ppc64le-rpms
+    s390x: rhocp-ironic-4.21-for-rhel-9-s390x-rpms
+  name: rhel-9-server-ironic-rpms
+  plashet:
+    assembly_aware: true
+    embargo_aware: true
+    include_previous_packages:
+    - openstack-ironic
+    - openstack-ironic-inspector
+    - openstack-ironic-python-agent
+    - python-ironic-lib
+    - python-sushy
+    slug: ironic-el9
+    source:
+      from_tags:
+      - name: rhaos-{MAJOR}.{MINOR}-ironic-rhel-9-candidate
+        product_version: OSE-IRONIC-4.21-RHEL-9
+        release_tag: rhaos-{MAJOR}.{MINOR}-ironic-rhel-9
+      type: brew
+  reposync:
+    latest_only: false
+  type: plashet

--- a/repos/rhel-9-server-microshift-rpms.yml
+++ b/repos/rhel-9-server-microshift-rpms.yml
@@ -1,0 +1,25 @@
+- conf:
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+    extra_options:
+      includepkgs: microshift* openshift-clients cri-tools cri-o
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhocp-4.21-for-rhel-9-aarch64-rpms
+    default: rhocp-4.21-for-rhel-9-x86_64-rpms
+    optional: true
+  name: rhel-9-server-microshift-rpms
+  plashet:
+    assembly_aware: true
+    embargo_aware: true
+    slug: microshift-el9
+    source:
+      from_tags:
+      - name: rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+        product_version: OSE-{MAJOR}.{MINOR}-RHEL-9
+        release_tag: rhaos-{MAJOR}.{MINOR}-rhel-9
+      type: brew
+  type: plashet

--- a/repos/rhel-9-server-ose-rpms-embargoed.yml
+++ b/repos/rhel-9-server-ose-rpms-embargoed.yml
@@ -1,0 +1,41 @@
+- conf:
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhocp-4.21-for-rhel-9-aarch64-rpms
+    default: rhocp-4.21-for-rhel-9-x86_64-rpms
+    optional: true
+    ppc64le: rhocp-4.21-for-rhel-9-ppc64le-rpms
+    s390x: rhocp-4.21-for-rhel-9-s390x-rpms
+  name: rhel-9-server-ose-rpms-embargoed
+  plashet:
+    assembly_aware: true
+    embargo_aware: true
+    include_embargoed: true
+    include_previous_packages:
+    - conmon
+    - cri-o
+    - cri-tools
+    - crun
+    - haproxy
+    - ignition
+    - kernel
+    - kernel-rt
+    - libreswan
+    - nmstate
+    - openshift
+    - openvswitch
+    - ovn
+    - podman
+    - python3-openvswitch
+    - spdlog
+    slug: el9-embargoed
+    source:
+      embargoed_tags:
+      - rhaos-{MAJOR}.{MINOR}-rhel-9-embargoed
+      from_tags:
+      - name: rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+        product_version: OSE-{MAJOR}.{MINOR}-RHEL-9
+        release_tag: rhaos-{MAJOR}.{MINOR}-rhel-9
+      type: brew
+  type: plashet

--- a/repos/rhel-9-server-ose-rpms.yml
+++ b/repos/rhel-9-server-ose-rpms.yml
@@ -1,0 +1,43 @@
+- conf:
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    optional: true
+  name: rhel-9-server-ose-rpms
+  plashet:
+    assembly_aware: true
+    embargo_aware: true
+    include_previous_packages:
+    - conmon
+    - cri-o
+    - cri-tools
+    - crun
+    - haproxy
+    - ignition
+    - kernel
+    - kernel-rt
+    - libreswan
+    - nmstate
+    - openshift
+    - openvswitch
+    - ovn
+    - podman
+    - python3-openvswitch
+    - spdlog
+    slug: el9
+    source:
+      embargoed_tags:
+      - rhaos-{MAJOR}.{MINOR}-rhel-9-embargoed
+      from_tags:
+      - name: rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+        product_version: OSE-{MAJOR}.{MINOR}-RHEL-9
+        release_tag: rhaos-{MAJOR}.{MINOR}-rhel-9
+      type: brew
+  reposync:
+    latest_only: false
+  type: plashet

--- a/repos/rhel-96-appstream.yml
+++ b/repos/rhel-96-appstream.yml
@@ -1,0 +1,17 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_6
+    s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_6
+  name: rhel-96-appstream
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-96-baseos.yml
+++ b/repos/rhel-96-baseos.yml
@@ -1,0 +1,17 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
+    ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_6
+    s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_6
+  name: rhel-96-baseos
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-96-highavailability.yml
+++ b/repos/rhel-96-highavailability.yml
@@ -1,0 +1,17 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/highavailability/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/highavailability/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/highavailability/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/highavailability/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    aarch64: rhel-9-for-aarch64-highavailability-eus-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-highavailability-eus-rpms__9_DOT_6
+    ppc64le: rhel-9-for-ppc64le-highavailability-eus-rpms__9_DOT_6
+    s390x: rhel-9-for-s390x-highavailability-eus-rpms__9_DOT_6
+  name: rhel-96-highavailability
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-96-nfv.yml
+++ b/repos/rhel-96-nfv.yml
@@ -1,0 +1,14 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/nfv/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/nfv/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/nfv/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/nfv/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    default: rhel-9-for-x86_64-nfv-e4s-rpms__9_DOT_6
+  name: rhel-96-nfv
+  reposync:
+    enabled: true
+  type: external


### PR DESCRIPTION
Those repos will replace current repo definitions in group.yml.

`group.ext.yml` will be used to tell art-tools which additional files to load with group.yml.

Because old-style repo configs are not removed in this PR, merging this won't break things.