### PR TITLE
[openshift-4.12] CORENET-5975: ovn-kubernetes: Remove exemptions for now unpinned OVS rpms.

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -23,9 +23,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 
 for_payload: true
 from:

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -27,9 +27,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 
 for_payload: false
 for_release: false

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -26,9 +26,7 @@ scan_sources:
   # We should configure exemptions for those known pins to avoid meaningless rebuild.
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
-  - openvswitch*
   - ovn*
-  - python3-openvswitch*
 
 for_payload: true
 from:


### PR DESCRIPTION
openvswitch* RPMs are no longer pinned in ovn-kubernetes images in order to facilitate timely CVE and bug fix delivery.  Remove from exemptions.

4.12 ovn-k PR that removed the OVS pin: https://github.com/openshift/ovn-kubernetes/pull/2698