### PR TITLE
4.12.80 - revert to earlier advisory ids for rpm and rhcos

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -36,13 +36,6 @@ releases:
       members:
         rpms: []
         images: []
-      issues:
-        exclude:
-          - id: OCPBUGS-58902 # shipped in 4.12.80 advisory 154211
-          - id: OCPBUGS-57378 # shipped in 4.12.80 advisory 154211
-          - id: OCPBUGS-59189 # shipped in 4.12.80 advisory 154211
-          - id: OCPBUGS-57878 # shipped in 4.12.80 advisory 154211
-          - id: OCPBUGS-58107 # shipped in 4.12.80 advisory 154211
   4.12.79:
     assembly:
       type: standard

--- a/releases.yml
+++ b/releases.yml
@@ -8,8 +8,8 @@ releases:
           x86_64: 4.12.0-0.nightly-2025-09-03-073735
       group:
         advisories:
-          rpm: 154218
-          rhcos: 154219
+          rpm: 154210
+          rhcos: 154211
         release_jira: ART-14074
         shipment:
           advisories:
@@ -36,6 +36,13 @@ releases:
       members:
         rpms: []
         images: []
+      issues:
+        exclude:
+          - id: OCPBUGS-58902 # shipped in 4.12.80 advisory 154211
+          - id: OCPBUGS-57378 # shipped in 4.12.80 advisory 154211
+          - id: OCPBUGS-59189 # shipped in 4.12.80 advisory 154211
+          - id: OCPBUGS-57878 # shipped in 4.12.80 advisory 154211
+          - id: OCPBUGS-58107 # shipped in 4.12.80 advisory 154211
   4.12.79:
     assembly:
       type: standard


### PR DESCRIPTION
revert to earlier advisory ids for rpm and rhcos