### PR TITLE
Disable cachi2 for ose-installer 4.19

### DIFF
--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -45,3 +45,5 @@ owners:
 - aos-install@redhat.com
 konflux:
   network_mode: open
+  cachi2:
+    enabled: false


### PR DESCRIPTION
Disable cachi2 to unblock 4.19 nightlies ([build-sync issues](https://redhat-internal.slack.com/archives/C07SC1XAKMX/p1757079617499439?thread_ts=1757079617.274989&cid=C07SC1XAKMX))

[Test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/16587/)