### PR TITLE
4.20: Stop signing

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -772,7 +772,7 @@ reconciliation_prs:
 # - 'release': for post GA time
 # - 'eol': For when a release will not formally ship anymore
 software_lifecycle:
-  phase: signing
+  phase: pre-release
 
 external_scanners:
   sast_scanning:

--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -12,6 +12,8 @@ owners:
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
 - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+- rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
 hotfix_targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
 - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+- rhaos-{MAJOR}.{MINOR}-rhel-10-hotfix

--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -17,6 +17,8 @@ owners:
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
 - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+- rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
 hotfix_targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
 - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+- rhaos-{MAJOR}.{MINOR}-rhel-10-hotfix


### PR DESCRIPTION
In order to have signed rpms, we need to have rhel10 set up in errata tool. We're waiting on https://issues.redhat.com/browse/CLOUDDST-29483