### PR TITLE
add basis.time

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -462,6 +462,7 @@ releases:
   4.18.11:
     assembly:
       basis:
+        time: "2025-04-25T23:11:57+00:00"
         brew_event: 63525016
         reference_releases:
           x86_64: 4.18.0-0.nightly-2025-04-26-080749


### PR DESCRIPTION
```
(asdas) asdas-mac:asdas$ python3 -c "import datetime; print(datetime.datetime.fromtimestamp(1745622717.51316, tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S+00:00'))"
2025-04-25T23:11:57+00:00
```