### PR TITLE
fix support-log-gather-operator build

### DIFF
--- a/images/ose-support-log-gather-operator.yml
+++ b/images/ose-support-log-gather-operator.yml
@@ -39,3 +39,5 @@ update-csv:
   manifests-dir: bundle/manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+konflux:
+  network_mode: open


### PR DESCRIPTION
fix lockfile 'rpms.lock.yaml' missing issue https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-20/pipelineruns/ose-4-20-ose-support-log-gather-operator-l5xrf

test job https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-20/pipelineruns/ose-4-20-ose-support-log-gather-operator-js2n6