### PR TITLE
added missing component

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -920,6 +920,8 @@ bug_mapping:
       issue_component: Performance Addon Operator
     pf-status-relay-container:
       issue_component: Networking / SR-IOV
+    pf-status-relay-operator-container:
+      issue_component: Networking / SR-IOV
     pivot:
       issue_component: RHCOS
     podman:


### PR DESCRIPTION
we have an [image](https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.21/images/pf-status-relay-operator.yml) **pf-status-relay-operator** which is not listed in product.yml