### PR TITLE
NO-JIRA: add verified auto label to clusterresourceoverride art PRs

### DIFF
--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -11,6 +11,7 @@ content:
         auto_label:
         - approved
         - lgtm
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -11,6 +11,7 @@ content:
         auto_label:
         - approved
         - lgtm
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 dependents:


### PR DESCRIPTION
Related JIRA: https://issues.redhat.com//browse/AUTOSCALE-286
Related PR: https://github.com/openshift-eng/ocp-build-data/pull/7099

With those new verified label requirements, I'm assuming it's okay for us to add it as an auto_label config for our existing automerge setup for these repos.