### PR TITLE
Add new labels to ART PRs in storage repos

### DIFF
--- a/images/azure-file-csi-driver-operator.yml
+++ b/images/azure-file-csi-driver-operator.yml
@@ -16,6 +16,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
     pkg_managers: []
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -17,6 +17,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-file-csi-driver-container

--- a/images/cluster-storage-operator.yml
+++ b/images/cluster-storage-operator.yml
@@ -12,6 +12,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-storage-operator-container

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -14,6 +14,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-attacher-container

--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -16,6 +16,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-driver-manila-operator-container

--- a/images/csi-external-snapshot-metadata.yml
+++ b/images/csi-external-snapshot-metadata.yml
@@ -14,6 +14,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-external-snapshot-metadata-container

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -14,6 +14,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -14,6 +14,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -14,6 +14,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -13,6 +13,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 dependents:
 - local-storage-operator
 distgit:

--- a/images/local-storage-mustgather.yml
+++ b/images/local-storage-mustgather.yml
@@ -13,6 +13,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-local-storage-mustgather-container

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -13,6 +13,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   bundle_component: local-storage-operator-metadata-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9

--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -16,6 +16,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-ebs-csi-driver-operator-container

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -17,6 +17,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-ebs-csi-driver-container

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -16,6 +16,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-efs-csi-driver-operator-container

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -17,6 +17,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 dependents:
 - ose-aws-efs-csi-driver-operator
 distgit:

--- a/images/ose-azure-disk-csi-driver-operator.yml
+++ b/images/ose-azure-disk-csi-driver-operator.yml
@@ -16,6 +16,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-disk-csi-driver-operator-container

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -17,6 +17,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-disk-csi-driver-container

--- a/images/ose-azure-storage-azcopy-base.yml
+++ b/images/ose-azure-storage-azcopy-base.yml
@@ -18,6 +18,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-storage-azcopy-base-container

--- a/images/ose-cluster-csi-snapshot-controller-operator.yml
+++ b/images/ose-cluster-csi-snapshot-controller-operator.yml
@@ -13,6 +13,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-csi-snapshot-controller-operator-container

--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -14,6 +14,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-external-resizer-container

--- a/images/ose-csi-external-snapshotter.yml
+++ b/images/ose-csi-external-snapshotter.yml
@@ -14,6 +14,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-external-snapshotter-container

--- a/images/ose-csi-snapshot-controller.yml
+++ b/images/ose-csi-snapshot-controller.yml
@@ -14,6 +14,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-snapshot-controller-container

--- a/images/ose-gcp-filestore-csi-driver-operator.yml
+++ b/images/ose-gcp-filestore-csi-driver-operator.yml
@@ -17,6 +17,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-filestore-csi-driver-operator-container

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -18,6 +18,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-filestore-csi-driver-container

--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -17,6 +17,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-pd-csi-driver-operator-container

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -18,6 +18,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-pd-csi-driver-container

--- a/images/ose-ibm-vpc-block-csi-driver-operator.yml
+++ b/images/ose-ibm-vpc-block-csi-driver-operator.yml
@@ -15,6 +15,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibm-vpc-block-csi-driver-operator-container

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -17,6 +17,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibm-vpc-block-csi-driver-container

--- a/images/ose-openstack-cinder-csi-driver-operator.yml
+++ b/images/ose-openstack-cinder-csi-driver-operator.yml
@@ -13,6 +13,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cinder-csi-driver-operator-container

--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -16,6 +16,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-block-csi-driver-operator-container

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -16,6 +16,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-block-csi-driver-container

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -13,6 +13,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-smb-csi-driver-operator-container

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -14,6 +14,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-smb-csi-driver-container

--- a/images/ose-vmware-vsphere-csi-driver-operator.yml
+++ b/images/ose-vmware-vsphere-csi-driver-operator.yml
@@ -15,6 +15,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vmware-vsphere-csi-driver-operator-container

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -16,6 +16,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vmware-vsphere-csi-driver-container

--- a/images/vmware-vsphere-syncer.yml
+++ b/images/vmware-vsphere-syncer.yml
@@ -16,6 +16,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: vmware-vsphere-syncer-container

--- a/images/volume-data-source-validator.yml
+++ b/images/volume-data-source-validator.yml
@@ -11,6 +11,11 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: volume-data-source-validator-container

--- a/images/vsphere-problem-detector.yml
+++ b/images/vsphere-problem-detector.yml
@@ -15,6 +15,8 @@ content:
         auto_label:
         - approved
         - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vsphere-problem-detector-container


### PR DESCRIPTION
Add `verified` and `valid-reference` labels to PRs in repos managed by the storage team. We want the PRs to merge automatically if CI succeeds.