### PR TITLE
Confirm older container-selinux build in builder image

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -35,6 +35,9 @@ releases:
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8736fd65c5a253ed5e8f5ecea7b329af8f54b909127ea78e56b3b0dc2d540326
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ceb6e0ff6747846d89041a018e7be327d994826003c3bbc5a8fef9befa1f382f
             x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5fdbbb5d45437afd5afef69c8389d560b98447c0c2167156e6cc9fc47df860b5
+      permits:
+      - code: CONFLICTING_INHERITED_DEPENDENCY
+        component: '*'
       members:
         rpms: []
         images: []


### PR DESCRIPTION
openshift-enterprise-builder did not pick up on a container-selinux rpm update. This is of no consequence, as the selinux rules of the host are being taken, and the presence in the container image is irrelevant.

https://redhat-internal.slack.com/archives/CB95J6R4N/p1757581133456869?thread_ts=1757580733.309619&cid=CB95J6R4N