### PR TITLE
csv_namespace is required in group.yaml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,5 @@
 name: oadp-1.5
+csv_namespace: openshift-adp
 
 vars:
   # The go versions used by the various CI builder images.


### PR DESCRIPTION
> csv_namespace is required in group.yaml when any image defines update-csv

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Foadp/34/console

```
2025-09-12 12:43:33,364 doozerlib.cli.images_konflux ERROR Failed to
rebase oadp-operator: csv_namespace is required in group.yaml when any
image defines update-csv

2025-09-12 12:43:34,238 pyartcd      ERROR build-oadp pipeline
encountered error: Process ['doozer', '--assembly=test',
'--data-path=https://github.com/openshift-eng/ocp-build-data',
'--build-system=konflux', '--group=oadp-1.5', '--latest-parent-version',
'--images=oadp-operator', 'beta:images:konflux:rebase',
'--version=1.5.1', '--release=202509121241.p?', "--message='Updating
Dockerfile version and release 1.5.1-202509121241.p?'", '--push'] exited
with code 1.
```