### PR TITLE
Get 4.15 to build

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,7 +4,7 @@
 #   - weekdays: always allow manual builds; forbid scheduled builds from Monday to Friday
 #   - no|false: always allow builds
 # Note that ocp4 builds are always permitted  for non-stream assemblies
-freeze_automation: weekdays
+freeze_automation: false
 
 vars:
   MAJOR: 4

--- a/images/openshift-enterprise-base-rhel9.yml
+++ b/images/openshift-enterprise-base-rhel9.yml
@@ -57,3 +57,5 @@ labels:
 name: openshift/openshift-enterprise-base-rhel9
 owners:
 - lmeyer@redhat.com
+konflux:
+  network_mode: open

--- a/images/openshift-enterprise-base.yml
+++ b/images/openshift-enterprise-base.yml
@@ -57,3 +57,5 @@ labels:
 name: openshift/ose-base
 owners:
 - lmeyer@redhat.com
+konflux:
+  network_mode: open

--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: openshift/golang-builder:v1.20.12-202504121010.g92d4921.el8
+  image: openshift/golang-builder:v1.20.12-202507041122.g92d4921.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -33,7 +33,7 @@ golang:
 golang-1.21:
   aliases:
     - rhel-8-golang-1.21
-  image: openshift/golang-builder:v1.21.13-202504100942.g1ac3e39.el8
+  image: openshift/golang-builder:v1.20.12-202507041122.g92d4921.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -45,7 +45,7 @@ golang-1.21:
 
 ibm-rhel-8-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.20.12-202504121010.g92d4921.el8
+  image: openshift/golang-builder:v1.20.12-202507041122.g92d4921.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
@@ -53,7 +53,7 @@ ibm-rhel-8-golang-1.20:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: openshift/golang-builder:v1.20.12-202504121010.g5488123.el9
+  image: openshift/golang-builder:v1.20.12-202507041122.g5488123.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -66,7 +66,7 @@ rhel-9-golang:
 rhel-9-golang-1.21:
   aliases:
     - rhel-9-golang-1.21
-  image: openshift/golang-builder:v1.21.13-202504100942.g5ebadc3.el9
+  image: openshift/golang-builder:v1.21.13-202507041112.g5ebadc3.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -78,7 +78,7 @@ rhel-9-golang-1.21:
 
 ibm-rhel-9-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: openshift/golang-builder:v1.20.12-202504121010.g5488123.el9
+  image: openshift/golang-builder:v1.20.12-202507041122.g5488123.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
@@ -114,7 +114,7 @@ rhel-9-golang-ci-build-root-1.21:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-{MAJOR}.{MINOR}
 
 etcd_rhel9_golang:
-  image: openshift/golang-builder:v1.19.13-202408070451.g3172d57.el9
+  image: openshift/golang-builder:v1.19.13-202507041126.g3172d57.el9
   mirror: true
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
- Build in normal times
- Set network_mode to "open" because hermeto cannot deal with module_hotfixes
- Update golang references to latest available