### PR TITLE
Enable auto-merge for ART PRs in monitoring repos

### DIFF
--- a/images/cluster-monitoring-operator.yml
+++ b/images/cluster-monitoring-operator.yml
@@ -12,10 +12,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/configmap-reload.yml
+++ b/images/configmap-reload.yml
@@ -12,10 +12,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -11,10 +11,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -11,10 +11,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -11,10 +11,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -12,10 +12,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/openshift-state-metrics.yml
+++ b/images/openshift-state-metrics.yml
@@ -12,10 +12,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/ose-kube-metrics-server.yml
+++ b/images/ose-kube-metrics-server.yml
@@ -11,10 +11,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -11,10 +11,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -11,10 +11,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/prometheus-operator-admission-webhook.yml
+++ b/images/prometheus-operator-admission-webhook.yml
@@ -11,10 +11,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -12,10 +12,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -11,10 +11,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -11,10 +11,11 @@ content:
         auto_label:
         - approved
         - backport-risk-assessed
-        - bugzilla/valid-bug
         - cherry-pick-approved
         - lgtm
         - staff-eng-approved
+        - jira/valid-reference
+        - verified
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:


### PR DESCRIPTION
This commit ensures that ART pull requests bumping the build image versions in monitoring repositories are automatically merged provided that the CI jobs succeed.

Given the existing tests, auto-merging avoids unnecessary toil for the team.