### PR TITLE
Add ose-cli to oadp-mustgather

### DIFF
--- a/images/oadp-mustgather.yml
+++ b/images/oadp-mustgather.yml
@@ -25,7 +25,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 from:
   builder:
-    - stream: rhel-9-golang
+    - member: ose-cli
+  stream: rhel-9-golang
   stream: rhel9
 name: oadp/oadp-mustgather-rhel9
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -1,4 +1,7 @@
 ---
+ose-cli:
+  image: openshift/ose-cli-rhel9:v4.19.0-202508260738.p2.g298429b.assembly.stream.el9
+
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}


### PR DESCRIPTION
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Foadp/51/console

```
2025-09-15 16:58:29,230 doozerlib.cli.images_konflux ERROR Failed to
rebase oadp-mustgather: Build metadata for oadp-mustgather expected 2
parent images, but found 3 in Dockerfile
```