### PR TITLE
Use full pullspec for ose-cli

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -1,6 +1,6 @@
 ---
 ose-cli:
-  image: openshift/ose-cli-rhel9:v4.19.0-202508260738.p2.g298429b.assembly.stream.el9
+  image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.19.0-202508260738.p2.g298429b.assembly.stream.el9
 
 rhel-9-golang:
   aliases:


### PR DESCRIPTION
https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/oadp-1-5/pipelineruns/oadp-1-5-oadp-mustgather-mcs6q/logs?task=build-images
```
Error: creating build container: internal error: unable to copy from
source
docker://brew.registry.redhat.io/openshift/ose-cli-rhel9:v4.19.0-202508260738.p2.g298429b.assembly.stream.el9:
initializing source
docker://brew.registry.redhat.io/openshift/ose-cli-rhel9:v4.19.0-202508260738.p2.g298429b.assembly.stream.el9:
reading manifest v4.19.0-202508260738.p2.g298429b.assembly.stream.el9 in
brew.registry.redhat.io/openshift/ose-cli-rhel9: unauthorized: access to
the requested resource is not authorized
```

https://github.com/openshift-priv/oadp-must-gather/blob/9b022de4edb4f0b40cd873c6f2364a75518d1caa/Dockerfile#L2