### PR TITLE
bump(k8s): bump 4.21 builder image to etcd version 3.6.4

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -31,7 +31,7 @@ RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
     export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
-    /tmp/install_etcd.sh "3.5.16"
+    /tmp/install_etcd.sh "3.6.4"
 
 RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build" && \
     dnf install -y $INSTALL_PKGS && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -31,7 +31,7 @@ RUN set -euxo pipefail && \
     chmod +x /tmp/*.sh && \
     export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     /tmp/install_protoc.sh "23.4" && \
-    /tmp/install_etcd.sh "3.5.16"
+    /tmp/install_etcd.sh "3.6.4"
 
 RUN INSTALL_PKGS="glibc libatomic libsemanage annobin go-srpm-macros kernel-srpm-macros libstdc++ llvm-libs qt5-srpm-macros redhat-rpm-config bc procps-ng util-linux bind-utils bsdtar createrepo_c device-mapper device-mapper-persistent-data e2fsprogs ethtool file findutils gcc git glib2-devel gpgme gpgme-devel hostname iptables jq krb5-devel libassuan libassuan-devel libseccomp-devel lsof make nmap-ncat openssl rsync socat systemd-devel tar tree wget which xfsprogs zip goversioninfo gettext python3 iproute rpm-build rpmdevtools selinux-policy-devel" && \
     dnf install -y $INSTALL_PKGS && \


### PR DESCRIPTION
Per [kube update](https://github.com/kubernetes/kubernetes/blob/master/go.mod#L61-L63), a new etcd version is needed.