### PR TITLE
Add dependents: to mustgather

### DIFF
--- a/images/oadp-mustgather.yml
+++ b/images/oadp-mustgather.yml
@@ -34,3 +34,5 @@ owners:
 - rjohnson@redhat.com
 konflux:
   network_mode: open
+dependents:
+  - oadp-operator


### PR DESCRIPTION
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Foadp/82/console

```
2025-09-18 12:43:17,152 doozerlib.cli.images_konflux ERROR Failed to
rebase oadp-operator: Related image contains oadp-mustgather but this
does not have oadp-operator in dependents
```