### PR TITLE
oadp-1.5: operator use release-branch

### DIFF
--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: konflux/rdj2/oa1dp5
+        target: oadp-1.5
       url: git@github.com:openshift-priv/oadp-operator.git
       web: https://github.com/openshift/oadp-operator
 distgit:


### PR DESCRIPTION
This reverts commit 48d8f58316ad3b3419bb895e7feead4609abb85d.

Related-to / Depends-on: https://github.com/openshift/oadp-operator/pull/1962