### PR TITLE
Enable hermetic mode for 11 images after GPG fix resolution

### DIFF
--- a/images/dpu-intel-ipu-vsp.yml
+++ b/images/dpu-intel-ipu-vsp.yml
@@ -52,7 +52,6 @@ owners:
 - sdaniele@redhat.com
 - vpunj@redhat.com
 konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo
   cachi2:
     lockfile:
       rpms:

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -44,4 +44,6 @@ payload_name: driver-toolkit
 owners:
 - edge-sro@redhat.com
 konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -37,5 +37,3 @@ name: openshift/ose-ptp-rhel9
 name_in_bundle: ptp
 owners:
 - multus-dev@redhat.com
-konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo

--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -23,7 +23,6 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-server-ose-rpms-embargoed
 konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo
   cachi2:
     lockfile:
       inspect_parent: false

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -30,5 +30,3 @@ name: openshift/ose-haproxy-router-rhel9
 payload_name: haproxy-router
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -38,5 +38,3 @@ owners:
 - mko@redhat.com
 - phoracek@redhat.com
 - yboaron@redhat.com
-konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -36,7 +36,6 @@ payload_name: agent-installer-api-server
 owners:
 - ocp-agent-team@redhat.com
 konflux:
-  network_mode: open  # lockfile
   cachi2:
     lockfile:
       inspect_parent: false
@@ -59,3 +58,4 @@ konflux:
       - libxcrypt-devel
       - make
       - nmstate-devel
+  network_mode: open  # modular metadata issue with postgresql packages - see ART-14111

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -34,5 +34,3 @@ name: openshift/ose-agent-installer-csr-approver-rhel9
 payload_name: agent-installer-csr-approver
 owners:
 - ocp-agent-team@redhat.com
-konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -34,5 +34,3 @@ name: openshift/ose-agent-installer-node-agent-rhel9
 payload_name: agent-installer-node-agent
 owners:
 - ocp-agent-team@redhat.com
-konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -33,5 +33,3 @@ name: openshift/ose-image-customization-controller-rhel9
 payload_name: machine-image-customization-controller
 owners:
 - metal-platform@redhat.com
-konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -44,5 +44,3 @@ owners:
 - jkyros@redhat.com
 - skumari@redhat.com
 - zzlotnik@redhat.com
-konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -35,4 +35,4 @@ konflux:
     # ref thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1743022042311039
     # can be removed after whilelist is in
     x86_64: linux/amd64
-  network_mode: open # lockfile
+  network_mode: open  # fetch_image.sh script requires network access to download images in hermetic env - ART-14122

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -41,5 +41,3 @@ labels:
 name: openshift/ose-ovn-kubernetes-base
 owners:
 - aos-networking-staff@redhat.com
-konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo


### PR DESCRIPTION
## Summary
Converted 11 images to hermetic mode following the GPG check fix in https://github.com/openshift-eng/art-tools/pull/2030. Two images remain in open mode due to specific technical constraints with active tickets tracking resolution.

## Problem
**Before:** Images blocked from hermetic conversion due to GPG check failures with unsigned RPMs
**After:** 11 images successfully converted to hermetic mode, 2 remain blocked with documented issues

## Changes
Successfully converted to hermetic mode (removed network_mode: open):
- images/dpu-intel-ipu-vsp.yml
- images/driver-toolkit.yml (+ added konflux cachi2 config)
- images/linuxptp-daemon.yml
- images/openshift-enterprise-builder.yml
- images/openshift-enterprise-haproxy-router.yml
- images/openshift-kubernetes-nmstate-handler.yml
- images/ose-agent-installer-csr-approver.yml
- images/ose-agent-installer-node-agent.yml
- images/ose-image-customization-controller.yml
- images/ose-machine-config-operator.yml
- images/ovn-kubernetes-base.yml

Remain in open mode with documented blocking issues:
- images/ose-machine-os-images.yml - fetch_image.sh requires network access ([ART-14122](https://issues.redhat.com//browse/ART-14122))
- images/ose-agent-installer-api-server.yml - postgresql modular metadata issues ([ART-14120](https://issues.redhat.com//browse/ART-14120))

**Technical Notes**
Major progress on hermetic conversion initiative. 11 images now building successfully in hermetic mode thanks to the GPG fix. Remaining blockers have specific technical constraints documented in JIRA tickets.