### PR TITLE
Enable hermetic mode with updated blocking issue documentation

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -44,4 +44,6 @@ payload_name: driver-toolkit
 owners:
 - edge-sro@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -36,7 +36,7 @@ payload_name: agent-installer-api-server
 owners:
 - ocp-agent-team@redhat.com
 konflux:
-  network_mode: open # lockfile
+  network_mode: open  # modular metadata issue with postgresql packages - see ART-14111
   cachi2:
     lockfile:
       inspect_parent: false

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -31,7 +31,7 @@ payload_name: machine-os-images
 owners:
 - metal-platform@redhat.com
 konflux:
-  network_mode: open # lockfile generator
+  network_mode: open  # fetch_image.sh script requires network access to download images in hermetic env - ART-14122
   vm_override:
     # ref thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1743022042311039
     # can be removed after whilelist is in


### PR DESCRIPTION
## Summary
Updated documentation for images with blocking issues following the GPG check fix in https://github.com/openshift-eng/art-tools/pull/2030. Most images already in hermetic mode in 4.19.

## Problem
**Before:** Images had generic comments for blocking issues  
**After:** Updated with specific technical details and JIRA ticket references

## Changes
Updated blocking issue documentation:
- images/driver-toolkit.yml - Added konflux cachi2 configuration for hermetic compatibility
- images/ose-machine-os-images.yml - Updated comment: fetch_image.sh requires network access (ART-14122)
- images/ose-agent-installer-api-server.yml - Updated comment: postgresql modular metadata issues (ART-14111)

**Technical Notes**
OpenShift 4.19 branch already has most images in hermetic mode. This PR ensures consistent documentation and preparation for the GPG fix benefits while maintaining proper blocking issue tracking for the 2 images that cannot be converted.