### PR TITLE
Revert "oadp-1.4: operator use dev branch"

### DIFF
--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: konflux/rdj2/oa1dp4
+        target: oadp-1.4
       url: git@github.com:openshift-priv/oadp-operator.git
       web: https://github.com/openshift/oadp-operator
 distgit:


### PR DESCRIPTION
This reverts commit 2743d7a251367d1929a340cb2d06e712afe3caf2.

Depends-On: https://github.com/openshift/oadp-operator/pull/1966