### PR TITLE
build(konflux): convert 3 images from network_mode open to hermetic

### DIFF
--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -41,4 +41,6 @@ payload_name: hyperkube
 owners:
 - aos-master@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      inspect_parent: false

--- a/images/openstack-resource-controller.yml
+++ b/images/openstack-resource-controller.yml
@@ -27,5 +27,3 @@ name: openshift/openstack-resource-controller-rhel9
 payload_name: openstack-resource-controller
 owners:
 - emacchi@redhat.com, maandre@redhat.com, pprinett@redhat.com, mdbooth@redhat.com@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-insights-runtime-extractor.yml
+++ b/images/ose-insights-runtime-extractor.yml
@@ -33,32 +33,32 @@ name: openshift/insights-runtime-extractor-rhel9
 owners:
 - jmesnil@redhat.com
 konflux:
-  network_mode: open # lockfile
   cachi2:
     lockfile:
       inspect_parent: false
       rpms:
       - binutils
       - binutils-gold
+      - cargo
       - cpp
       - elfutils-debuginfod-client
       - gcc
-      - gcc-c++
-      - libstdc++-devel
-      - glibc
-      - glibc-headers
       - glibc-devel
+      - glibc-headers
       - kernel-headers
       - libasan
       - libatomic
+      - libedit
       - libmpc
+      - libpkgconf
       - libubsan
       - libxcrypt-devel
+      - llvm-libs
       - make
-      - rust-toolset
-      - rustfmt
-      - cargo
+      - pkgconf
+      - pkgconf-m4
+      - pkgconf-pkg-config
       - rust
       - rust-std-static
-      - llvm-compat-libs
-      - llvm-libs
+      - rust-toolset
+      - rustfmt


### PR DESCRIPTION
## Summary
Convert 3 images from network_mode: open to hermetic mode by removing konflux network_mode configuration, allowing them to use the default hermetic build isolation.

## Problem
**Before:** Three images (openshift-enterprise-hyperkube, ose-insights-runtime-extractor, and openstack-resource-controller) were configured with network_mode: open in their konflux section, allowing network access during builds.
**After:** Images now use the default hermetic mode, providing build isolation and improved security by preventing network access during container builds.

## Changes
- images/openshift-enterprise-hyperkube.yml - Removed network_mode: open, added basic cachi2 lockfile config
- images/ose-insights-runtime-extractor.yml - Removed network_mode: open, updated RPM lockfile with proper package list
- images/openstack-resource-controller.yml - Completely removed konflux section with network_mode: open

**Technical Notes**
This change enables build isolation for these components, improving security posture and aligning with the project's goal of converting all images to hermetic builds.