### PR TITLE
build(konflux): convert 1 image from network_mode open to hermetic

### DIFF
--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -41,6 +41,6 @@ payload_name: hyperkube
 owners:
 - aos-master@redhat.com
 konflux:
-  network_mode: open
   cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
+    lockfile:
+      inspect_parent: false


### PR DESCRIPTION
## Summary
Convert 1 image from network_mode: open to hermetic mode by removing konflux network_mode configuration, allowing it to use the default hermetic build isolation.

## Problem
**Before:** openshift-enterprise-hyperkube was configured with network_mode: open in its konflux section, allowing network access during builds.
**After:** Image now uses the default hermetic mode, providing build isolation and improved security by preventing network access during container builds.

## Changes
- images/openshift-enterprise-hyperkube.yml - Removed network_mode: open, enabled cachi2 lockfile config (was previously disabled)

**Technical Notes**
This change enables build isolation for this component, improving security posture and aligning with the project's goal of converting all images to hermetic builds.

Backport from openshift-4.21 to openshift-4.16.
Note: ose-insights-runtime-extractor and openstack-resource-controller do not exist in this version.