### PR TITLE
4.16.49 - removing cluster-nfd-operator as its yaml file is incorrect

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -41,7 +41,11 @@ releases:
             aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6aa268aec7db7d2f858a4d6a154820ab82586a9c7e3120325f9abb1736105d48
       members:
         rpms: []
-        images: []
+        images:
+          - distgit_key: cluster-nfd-operator
+            metadata:
+              for_release: false
+            why: yaml file for the component is not correct
   4.16.48:
     assembly:
       type: standard


### PR DESCRIPTION
4.16.49 - removing cluster-nfd-operator as its yaml file is incorrect