### PR TITLE
build(konflux): convert 3 CSI/networking images to hermetic mode

### DIFF
--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -39,5 +39,3 @@ name: openshift/ose-aws-ebs-csi-driver-rhel9
 payload_name: aws-ebs-csi-driver
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -38,5 +38,3 @@ name: openshift/ose-aws-efs-csi-driver-container-rhel9
 name_in_bundle: aws-efs-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -30,9 +30,11 @@ name_in_bundle: metallb-frr-rhel9
 payload_name: metallb-frr
 owners:
 - metallb-dev@redhat.com
-konflux:
-  network_mode: open
 scan_sources:
   # Gets temporarily pinned, see https://github.com/openshift/frr/pull/87/files and backports
   exempt_rpms:
   - frr
+konflux:
+  cachi2:
+    lockfile:
+      inspect_parent: false


### PR DESCRIPTION
## Summary
Convert ose-aws-ebs-csi-driver, ose-aws-efs-csi-driver, and ose-frr from network_mode: open to hermetic builds.