### PR TITLE
build(konflux): convert 3 CSI/networking images to hermetic mode

### DIFF
--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -38,6 +38,8 @@ payload_name: aws-ebs-csi-driver
 owners:
 - aos-storage-staff@redhat.com
 konflux:
+  # 2025-09-26 16:17:57,069 ERROR [mode:STRICT] vendor directory changed after vendoring:
+  # A	vendor/github.com/mistifyio/go-zfs/Vagrantfile
   network_mode: open
   cachi2:
     enabled: false # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -36,5 +36,3 @@ name: openshift/ose-aws-efs-csi-driver-container-rhel9
 name_in_bundle: aws-efs-csi-driver-container-rhel8
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -35,4 +35,6 @@ scan_sources:
   exempt_rpms:
   - frr
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      inspect_parent: false


### PR DESCRIPTION
## Summary
Convert ose-aws-ebs-csi-driver, ose-aws-efs-csi-driver, and ose-frr from network_mode: open to hermetic builds.