### PR TITLE
build(konflux): convert 3 CSI/networking images to hermetic mode

### DIFF
--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -37,5 +37,3 @@ name: openshift/ose-aws-ebs-csi-driver-rhel9
 payload_name: aws-ebs-csi-driver
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -35,4 +35,6 @@ scan_sources:
   exempt_rpms:
   - frr
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      inspect_parent: false


### PR DESCRIPTION
## Summary
Convert ose-aws-ebs-csi-driver, ose-aws-efs-csi-driver, and ose-frr from network_mode: open to hermetic builds.