### PR TITLE
build(konflux): convert 2 CSI/networking images to hermetic mode

### DIFF
--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -37,5 +37,3 @@ name: openshift/ose-aws-ebs-csi-driver-rhel9
 payload_name: aws-ebs-csi-driver
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -34,4 +34,6 @@ scan_sources:
   exempt_rpms:
   - frr
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      inspect_parent: false


### PR DESCRIPTION
## Summary
Convert ose-aws-ebs-csi-driver and ose-frr from network_mode: open to hermetic builds.

## Changes
- ose-aws-ebs-csi-driver: Remove network_mode override
- ose-frr: Remove network_mode override

Note: ose-aws-efs-csi-driver was already in hermetic mode.