### PR TITLE
build(konflux): convert 2 images to hermetic mode

### DIFF
--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -37,5 +37,3 @@ name: openshift/ose-aws-ebs-csi-driver-rhel9
 payload_name: aws-ebs-csi-driver
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -28,4 +28,9 @@ name_in_bundle: metallb-frr-rhel9
 owners:
 - metallb-dev@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      inspect_parent: false
+      rpms:
+      - podman-catatonit
+      - podman-2:4.2.0-11.el9_1


### PR DESCRIPTION
## Summary
Convert ose-aws-ebs-csi-driver and ose-frr from network_mode: open to hermetic builds.