### PR TITLE
pin drivertoolkit to matching version of RHCOS

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1260,6 +1260,11 @@ releases:
           component: '*'
       members:
         images:
+          - distgit_key: driver-toolkit
+            why: Pinning last build matching rhcos
+            metadata:
+              is:
+                nvr: driver-toolkit-container-v4.19.0-202509301225.p2.g686fdac.assembly.stream.el9
           - distgit_key: '*'
             why: Exclude rpm updates that should not cause mass rebuilds
             metadata:


### PR DESCRIPTION
driver-toolkit-container-v4.19.0-202509301225.p2.g686fdac.assembly.stream.el9 has 570.49.1.el9_6 which is the same as latest availabe rhcos at the moment: RHCOSBuild:x86_64:9.6.20250925-0 has kernel-headers-5.14.0-570.49.1.el9_6

https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/packages?nvr=driver-toolkit-container-v4.19.0-202509301225.p2.g686fdac.assembly.stream.el9

https://releases-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com/?arch=x86_64&release=9.6.20250925-0&stream=prod%2Fstreams%2Frhel-9.6#9.6.20250925-0