### PR TITLE
Revert "docs advisory template update"

### DIFF
--- a/config/advisory_templates.yml
+++ b/config/advisory_templates.yml
@@ -20,7 +20,7 @@ boilerplates:
 
         This advisory contains the container images for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the RPM packages for this release:
 
-        https://access.redhat.com/errata/{RPM_ADVISORY}
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
 
         Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
 
@@ -72,7 +72,7 @@ boilerplates:
 
         This advisory contains the container images for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the RPM packages for this release:
 
-        https://access.redhat.com/errata/{RPM_ADVISORY}
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
 
         Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
 
@@ -118,7 +118,7 @@ boilerplates:
 
         This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
 
-        https://access.redhat.com/errata/{IMAGE_ADVISORY}
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
 
         Security Fix(es):
 
@@ -140,7 +140,7 @@ boilerplates:
 
         This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
 
-        https://access.redhat.com/errata/{IMAGE_ADVISORY}
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
 
         All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at
 
@@ -165,7 +165,7 @@ boilerplates:
 
         This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
 
-        https://access.redhat.com/errata/{IMAGE_ADVISORY}
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
 
         Security Fix(es):
 
@@ -188,7 +188,7 @@ boilerplates:
         This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for
         this release:
 
-        https://access.redhat.com/errata/{IMAGE_ADVISORY}
+        https://access.redhat.com/errata/RH[X]A-[YYYY:NNNN]
 
         All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate
         release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#7779

prepare-release is breaking because
```
  File "/mnt/jenkins-workspace/ds_build_prepare-release-konflux/art-tools/elliott/elliottlib/cli/attach_cve_flaws_cli.py", line 248, in update_release_notes
    release_notes.description = cve_boilerplate['description'].format(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'RPM_ADVISORY'
```