### PR TITLE
Add new labels to ART PRs in AWS EFS utils

### DIFF
--- a/images/ose-aws-efs-utils.yml
+++ b/images/ose-aws-efs-utils.yml
@@ -16,6 +16,16 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/aws-efs-utils.git
       web: https://github.com/openshift/aws-efs-utils
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - lgtm
+        - jira/valid-reference
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-efs-utils-container


### PR DESCRIPTION
Add `verified`, `lgtm`, `approved`, and valid-reference labels to PRs in AWS EFS utils. We want the PRs to merge automatically if CI succeeds. 

Continuation of https://github.com/openshift-eng/ocp-build-data/pull/7572