### PR TITLE
4.17: Set network_mode to hermetic for some

### DIFF
--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -36,5 +36,3 @@ name: openshift/ose-docker-builder-rhel9
 payload_name: docker-builder
 owners:
 - openshift-build-api@redhat.com
-konflux:
-  network_mode: open

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -30,5 +30,3 @@ labels:
 name: openshift/ose-egress-dns-proxy-rhel9
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  network_mode: open

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -28,5 +28,3 @@ labels:
 name: openshift/ose-egress-router-rhel9
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  network_mode: open

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -30,5 +30,3 @@ name: openshift/ose-haproxy-router-rhel9
 payload_name: haproxy-router
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  network_mode: open

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -31,5 +31,3 @@ name: openshift/ose-keepalived-ipfailover-rhel9
 payload_name: keepalived-ipfailover
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  network_mode: open

--- a/images/openshift-enterprise-operator-sdk.yml
+++ b/images/openshift-enterprise-operator-sdk.yml
@@ -34,5 +34,3 @@ owners:
 - jlanford@redhat.com
 - fabian@redhat.com
 - cmacedo@redhat.com
-konflux:
-  network_mode: open

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -40,5 +40,3 @@ name: openshift/ose-pod-rhel9
 payload_name: pod
 owners:
 - aos-pod@redhat.com
-konflux:
-  network_mode: open

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -35,5 +35,3 @@ name: openshift/ose-docker-registry-rhel9
 payload_name: docker-registry
 owners:
 - openshift-image-registry@redhat.com
-konflux:
-  network_mode: open

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -42,5 +42,3 @@ payload_name: tests
 owners:
 - aos-master@redhat.com
 - openshift-technical-release-staff@redhat.com
-konflux:
-  network_mode: open


### PR DESCRIPTION
Proposing to stop the network_mode trick for some images in 4.17. 4.17, because we're not producing a zstream release in the next week. Aim is to either have things work, or to create errors that are fixable.

When fixing an error, please try and see if this fix could/should be applied to other ystreams. As an overview:

| image                                          | 4.12 | 4.13 | 4.14 | 4.15 | 4.16 | 4.17 | 4.18 | 4.19   | 4.20   | 4.21   |
| ---------------------------------------------- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ------ | ------ | ------ |
| openshift-enterprise-builder.yml               | open | open | open | open | open | open | open | closed | closed | closed |
| openshift-enterprise-egress-dns-proxy.yml      | open | open | open | open | open | open | open | closed | closed | closed |
| openshift-enterprise-egress-router.yml         | open | open | open | open | open | open | open | closed | closed | closed |
| openshift-enterprise-haproxy-router.yml        | open | open | open | open | open | open | open | closed | closed | closed |
| openshift-enterprise-keepalived-ipfailover.yml | open | open | open | open | open | open | open | closed | closed | closed |
| openshift-enterprise-operator-sdk.yml          | open | open | open | open | open | open | open | closed | closed | closed |
| openshift-enterprise-pod.yml                   | open | open | open | open | open | open | open | open   | closed | closed |
| openshift-enterprise-registry.yml              | open | open | open | open | open | open | open | closed | closed | closed |
| openshift-enterprise-tests.yml                 | open | open | open | open | open | open | open | closed | closed | closed |