### PR TITLE
Bump 4.18 ovn images to go1.24

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -42,8 +42,8 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang-1.23
-  - stream: rhel-8-golang-1.23
+  - stream: rhel-9-golang-1.24
+  - stream: rhel-8-golang-1.24
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -42,7 +42,7 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang-1.23
+  - stream: rhel-9-golang-1.24
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+

--- a/streams.yml
+++ b/streams.yml
@@ -69,6 +69,24 @@ rhel-8-golang-1.23:
   upstream_image_mirror:
     - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
 
+rhel-9-golang-1.24:
+  aliases:
+    - rhel-9-golang-1.24
+  image: openshift/golang-builder:v1.24.4-202507171054.g2f6f49f.el9
+  mirror: false
+  # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
+  # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-{MAJOR}.{MINOR}
+
+rhel-8-golang-1.24:
+  aliases:
+    - rhel-8-golang-1.24
+  image: openshift/golang-builder:v1.24.4-202507171054.g35b6b0c.el8
+  mirror: false
+  # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
+  # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-{MAJOR}.{MINOR}
+
 partner-rhel-8-golang-1.22:
   image: openshift/golang-builder:v1.22.12-202507011013.g20d2fa9.el8
   mirror: true


### PR DESCRIPTION
Since https://github.com/openshift/ovn-kubernetes/pull/2777, 4.18 ovn images depend on go1.24. In CI, this works by using the 4.20 go1.24 images. In 4.19, we made it work by making GO_EXTRA point to 1.24.

In 4.18, GO_EXTRA is already used by go1.23. Proposing to do the minimal thing, and just make the images available in 4.18 prodution build context, without making them available explicitly in CI.