### PR TITLE
Bump golang to 1.25 for ovn-kubernetes

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -45,8 +45,8 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
-  - stream: rhel-8-golang
+  - stream: rhel-9-golang-{GO_EXTRA}
+  - stream: rhel-8-golang-{GO_EXTRA}
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -36,7 +36,7 @@ scan_sources:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-{GO_EXTRA}
   member: ovn-kubernetes-base
 labels:
   License: GPLv2+


### PR DESCRIPTION
Requires https://github.com/openshift-eng/ocp-build-data/pull/8281 and needs conformation from the networking team.