### PR TITLE
use rhel-9-golang-1.25 builder for ose-agent-installer images - 4.22

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -26,7 +26,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9
 maintainer:
   component: Installer

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -25,7 +25,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 maintainer:
   component: Installer

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -25,7 +25,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 maintainer:
   component: Installer

--- a/images/ose-agent-installer-orchestrator.yml
+++ b/images/ose-agent-installer-orchestrator.yml
@@ -21,7 +21,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 maintainer:
   component: Installer


### PR DESCRIPTION
PRs that upgrade to golang 1.25:

https://github.com/openshift/assisted-service/pull/8769 
https://github.com/openshift/assisted-installer-agent/pull/1289 
https://github.com/openshift/assisted-installer/pull/1466

jobs were failing due to :
`go: go.mod requires go >= 1.25.0 (running go 1.24.11; GOTOOLCHAIN=local)`
