### PR TITLE
Update group.yml with download.devel.redhat.com

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -43,10 +43,10 @@ repos:
         # this repo provides complete RHEL 8 build env; we just want the go-toolset content
         includepkgs: module-build-macros golang*
       baseurl:
-        aarch64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
-        ppc64le: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
-        s390x: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
-        x86_64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
+        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
+        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
+        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
+        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
@@ -65,10 +65,10 @@ repos:
         # to that content.
         includepkgs: goversioninfo gpgme-devel libassuan-devel mingw* golang*
       baseurl:
-        aarch64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
-        ppc64le: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
-        s390x: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
-        x86_64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
+        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
+        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
+        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
+        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
 
     # These content sets are not used, so just putting something here
     content_set:


### PR DESCRIPTION
When doing golang bumps 

 rhel-8-golang-rpms-x86_64                       0.0  B/s |   0  B     00:00
2026-01-27 16:25:08,939 - atomic_reactor.tasks.binary_container_build - INFO - Errors during downloading metadata for repository 'rhel-8-golang-rpms-x86_64':
2026-01-27 16:25:08,939 - atomic_reactor.tasks.binary_container_build - INFO -   - Curl error (6): Couldn't resolve host name for https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-4.18-rhel-8-build/latest/x86_64/repodata/repomd.xml [Could not resolve host: download-node-02.eng.bos.redhat.com]
2026-01-27 16:25:08,943 - atomic_reactor.tasks.binary_container_build - INFO - Error: Failed to download metadata for repo 'rhel-8-golang-rpms-x86_64': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried hence changing to correct url.