### PR TITLE
Update group.yml with download.devel.redhat.com

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -44,10 +44,10 @@ repos:
       # golang-1.21.3-4.el8_9
       # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2770478
       baseurl:
-        aarch64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
-        ppc64le: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/
-        s390x: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/s390x/
-        x86_64: https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/x86_64/
+        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
+        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/
+        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/s390x/
+        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/x86_64/
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms


### PR DESCRIPTION
Because of this error messages :

2026-01-27 16:25:08,939 - atomic_reactor.tasks.binary_container_build - INFO - Errors during downloading metadata for repository 'rhel-8-golang-rpms-x86_64':
2026-01-27 16:25:08,939 - atomic_reactor.tasks.binary_container_build - INFO -   - Curl error (6): Couldn't resolve host name for https://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-4.18-rhel-8-build/latest/x86_64/repodata/repomd.xml [Could not resolve host: download-node-02.eng.bos.redhat.com]