### PR TITLE
Add 4.21.0 GA assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,6 +1,16 @@
 releases:
-  # WARNING: do not use this assembly for GA
-  # see https://redhat-internal.slack.com/archives/CB95J6R4N/p1765837022676159
+  4.21.0:
+    assembly:
+      type: standard
+      basis:
+        assembly: rc.2
+        reference_releases!: {}
+      group:
+        operator_index_mode: ga
+        release_date: 2026-Feb-3
+        upgrades: 4.20.12,4.20.13,4.21.0-ec.0,4.21.0-ec.2,4.21.0-ec.3,4.21.0-rc.0,4.21.0-rc.1,4.21.0-rc.2
+        advisories!: {}
+        shipment!: {}
   rc.2:
     assembly:
       type: candidate


### PR DESCRIPTION
Add new standard assembly 4.21.0 that inherits from rc.2 with:
- Type set to standard for GA release
- operator_index_mode set to ga
- Release date: 2026-Feb-3
- Upgrades list updated to reflect minor_min 4.20.12 constraint (4.20.12+)
- Includes 4.20.13 (current in-flight z-stream)
- Includes all preview/candidate releases through rc.2
- Advisories and shipment fields cleared for fresh configuration