### PR TITLE
Revert "update golang to 1.25"

### DIFF
--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -29,7 +29,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang-1.25
+  - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-version-rhel9-operator
 payload_name: cluster-version-operator


### PR DESCRIPTION
This reverts commit 301d10a57d587e84879368cc11cdb21bc046de99.

For 4.22, we made a custom change to use Go1.25 with https://github.com/openshift-eng/ocp-build-data/pull/8583 and  https://github.com/openshift-eng/ocp-build-data/pull/8606 

The 4.23 branch is cut between those two pulls and inherited only the former.

This pull moves back 4.23 to default config.