### PR TITLE
sriov: bump golang to 1.25

### DIFF
--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -27,8 +27,8 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-8-golang
-  - stream: rhel-9-golang
+  - stream: rhel-8-golang-1.25
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-sriov-infiniband-cni-rhel9
 name_in_bundle: sriov-infiniband-cni

--- a/images/ose-sriov-network-metrics-exporter.yml
+++ b/images/ose-sriov-network-metrics-exporter.yml
@@ -27,7 +27,7 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-sriov-network-metrics-exporter-rhel9
 name_in_bundle: sriov-network-metrics-exporter

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -27,8 +27,8 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-8-golang
-  - stream: rhel-9-golang
+  - stream: rhel-8-golang-1.25
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-sriov-rdma-cni-rhel9
 name_in_bundle: rdma-cni

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -27,8 +27,8 @@ dependents:
 for_payload: false
 from:
   builder:
-  - stream: rhel-8-golang
-  - stream: rhel-9-golang
+  - stream: rhel-8-golang-1.25
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/sriov-cni-rhel9
 name_in_bundle: sriov-cni

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -27,7 +27,7 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-sriov-dp-admission-controller-rhel9
 name_in_bundle: sriov-dp-admission-controller

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -30,7 +30,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-sriov-network-config-daemon-rhel9
 name_in_bundle: sriov-network-config-daemon

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -30,7 +30,7 @@ enabled_repos:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-sriov-network-device-plugin-rhel9
 name_in_bundle: sriov-network-device-plugin

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -27,7 +27,7 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-sriov-network-rhel9-operator
 name_in_bundle: sriov-network-operator

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -27,7 +27,7 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-sriov-network-webhook-rhel9
 name_in_bundle: sriov-network-webhook


### PR DESCRIPTION
Image stream `rhel-9-golang` ships go.124  by default. SR-IOV projects have been bumped to go1.25 upstream.

Move builder images to `rhel-9-golang-1.25` in the openshift-4.22 branch. Newer branches don't need any change, as the `GO_LATEST` version is already > 1.25

Links:
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/1002
- https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/690

sample failed builds:
- https://github.com/openshift/sriov-cni/pull/169 / [ci/prow/images](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_sriov-cni/169/pull-ci-openshift-sriov-cni-main-images/2016292745789837312)