### PR TITLE
Revert "ART-14167: remove cluster-kube-cluster-api-operator image"

### DIFF
--- a/images/ose-cluster-kube-cluster-api-operator.yml
+++ b/images/ose-cluster-kube-cluster-api-operator.yml
@@ -1,0 +1,33 @@
+content:
+  source:
+    dockerfile: openshift/Dockerfile.openshift
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/cluster-api-operator.git
+      web: https://github.com/openshift/cluster-api-operator
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          member: ci-openshift-build-root-latest.rhel9
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ose-cluster-kube-cluster-api-operator-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-kube-cluster-api-operator
+  delivery_repo_names:
+  - openshift4/ose-cluster-kube-cluster-api-rhel9-operator
+for_payload: true
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-cluster-kube-cluster-api-rhel9-operator
+payload_name: cluster-kube-cluster-api-operator
+owners:
+- mfedosin@redhat.com
+- jspeed@redhat.com
+- elmiko@redhat.com
+- dmoiseev@redhat.com


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#8633

The missing operator is preventing ART from promoting 
https://redhat-internal.slack.com/archives/GDBRP5YJH/p1769625110816919?thread_ts=1769557415.970279&cid=GDBRP5YJH
