### PR TITLE
Update configuration for loki-operator

### DIFF
--- a/images/loki-operator.yml
+++ b/images/loki-operator.yml
@@ -1,5 +1,6 @@
 content:
   source:
+    dockerfile: Dockerfile.art
     path: operator
     git:
       branch:
@@ -20,7 +21,7 @@ from:
   member: base-rhel9
 name: openshift-logging/loki-rhel9-operator
 owners:
-- jcantril@redhat.com
+- rojacob@redhat.com
 update-csv:
   bundle-dir: openshift/manifests/
   manifests-dir: bundle/


### PR DESCRIPTION
Points the build to use the newly-created `Dockerfile.art` instead of the default one and updates the owner.

This needs openshift/loki#469 to work.

/cc @ashwindasr @rayfordj 
/label tide/merge-method-squash