### PR TITLE
added exclude

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -38,6 +38,10 @@ releases:
       members:
         rpms: []
         images: []
+      issues:
+        exclude:
+          -id: OCPBUGS-64913
+          # why: no new podman build required
   4.17.47:
     assembly:
       type: standard


### PR DESCRIPTION
exclude bug since the required podman versions
* podman-5.2.2-12.rhaos4.17.el8
* podman-5.2.2-12.rhaos4.17.el9
are already attached and shipped https://errata.devel.redhat.com/advisory/158035 (previous release 4.17.47)
