### PR TITLE
ART-14479: Port 4.22 OKD configs to 4.23

### DIFF
--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -29,3 +29,7 @@ name: openshift/ose-operator-marketplace-rhel9
 payload_name: operator-marketplace
 owners:
 - aos-marketplace@redhat.com
+okd:
+  content:
+    source:
+      dockerfile: Dockerfile.okd

--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -50,3 +50,8 @@ konflux:
   cachito:
     mode: emulation
   network_mode: open
+okd:
+  content:
+    source:
+      dockerfile: Dockerfile
+      modifications: []

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -51,3 +51,8 @@ konflux:
   cachito:
     mode: emulation
   network_mode: open # Bunch of yarn dependencies, not sure how to fix
+okd:
+  content:
+    source:
+      dockerfile: Dockerfile
+      modifications: []

--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -41,3 +41,7 @@ owners:
 konflux:
   cachito:
     mode: removal
+okd:
+  content:
+    source:
+      dockerfile: images/cli/Dockerfile.ci

--- a/images/okd-only-upi-installer.yml
+++ b/images/okd-only-upi-installer.yml
@@ -45,3 +45,6 @@ owners:
 - aos-install@redhat.com
 konflux:
   network_mode: open
+  no_shell: true  # Image uses minimal base images (govc, pwsh, yq) without /bin/sh
+okd:
+  mode: enabled

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -36,3 +36,7 @@ name: openshift/ose-pod-rhel9
 payload_name: pod
 owners:
 - aos-pod@redhat.com
+okd:
+  content:
+    source:
+      dockerfile: Dockerfile.Rhel

--- a/images/ose-cluster-samples-operator.yml
+++ b/images/ose-cluster-samples-operator.yml
@@ -28,3 +28,7 @@ name: openshift/ose-cluster-samples-rhel9-operator
 payload_name: cluster-samples-operator
 owners:
 - openshift-build-api@redhat.com
+okd:
+  content:
+    source:
+      dockerfile: Dockerfile.okd

--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -31,3 +31,7 @@ name: openshift/ose-cluster-update-keys-rhel9
 payload_name: cluster-update-keys
 owners:
 - aos-team-art@redhat.com
+okd:
+  content:
+    source:
+      dockerfile: Dockerfile

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -14,7 +14,7 @@ cachito:
     - path: tools/mod
 content:
   source:
-    dockerfile: Dockerfile.art
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
@@ -58,7 +58,11 @@ owners:
 - melbeher@redhat.com
 maintainer:
   component: "Etcd"
-konflux:
+okd:
   content:
     source:
-      dockerfile: Dockerfile.rhel
+      modifications:
+      - action: replace
+        match: "RUN GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh"
+        replacement: |-
+          RUN export GOTOOLCHAIN="go${GO_VERSION#v}" && GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh

--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -15,7 +15,7 @@ cachito:
     - path: tools/mod
 content:
   source:
-    dockerfile: Dockerfile.installer.art
+    dockerfile: Dockerfile.installer.art-cachi2
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
@@ -60,7 +60,12 @@ external_scanners:
   sast_scanning:
     jira_integration:
       enabled: false
-konflux:
+okd:
   content:
     source:
-      dockerfile: Dockerfile.installer.art-cachi2
+      modifications:
+      - action: replace
+        match: |-
+          RUN export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
+        replacement: |-
+          RUN export GOTOOLCHAIN="go${GO_VERSION#v}" && export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \


### PR DESCRIPTION
Port OKD-related configs from 4.22 to 4.23. These were added to 4.22 after 4.23 branching

- https://github.com/openshift-eng/ocp-build-data/pull/8608
- https://github.com/openshift-eng/ocp-build-data/pull/8684
- https://github.com/openshift-eng/ocp-build-data/pull/8681
- https://github.com/openshift-eng/ocp-build-data/pull/8719
- https://github.com/openshift-eng/ocp-build-data/pull/8663
- https://github.com/openshift-eng/ocp-build-data/pull/8770