### PR TITLE
Change Dockerfile used for cluster-logging-operator

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -1,5 +1,6 @@
 content:
   source:
+    dockerfile: Dockerfile.art
     git:
       branch:
         target: release-6.3


### PR DESCRIPTION
Refs [LOG-8584](https://issues.redhat.com//browse/LOG-8584)

Depends on openshift/cluster-logging-operator#3194

Questions:

- [x] I noticed that the `Dockerfile` does install RPM packages during build, but unlike in the `vector.yml` I don't see a lockfile configuration for RPMs. Is this maybe missing from the `cluster-logging-operator.yml` file?

/cc @rayfordj @ashwindasr 
/label tide/merge-method-squash