### PR TITLE
[4.18] Set canonical_builders_from_upstream to false for all images - 4.18

### DIFF
--- a/images/openshift-base-nodejs.rhel9.yml
+++ b/images/openshift-base-nodejs.rhel9.yml
@@ -41,4 +41,3 @@ labels:
 name: openshift/base-nodejs-rhel9
 owners:
 - aos-team-art@redhat.com
-canonical_builders_from_upstream: false

--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -41,4 +41,3 @@ from:
 name: openshift/base-rhel9
 owners:
 - aos-team-art@redhat.com
-canonical_builders_from_upstream: false

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -14,7 +14,6 @@ cachito:
     - path: server
     - path: tests
     - path: tools/mod
-canonical_builders_from_upstream: true
 content:
   source:
     dockerfile: Dockerfile.art

--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -15,7 +15,6 @@ cachito:
     - path: server
     - path: tests
     - path: tools/mod
-canonical_builders_from_upstream: true
 content:
   source:
     dockerfile: Dockerfile.installer.art

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -25,4 +25,3 @@ name: openshift/ose-network-interface-bond-cni-rhel9
 payload_name: network-interface-bond-cni
 owners:
 - carlosg@redhat.com
-canonical_builders_from_upstream: true

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -52,4 +52,3 @@ name: openshift/ose-ovn-kubernetes-rhel9
 payload_name: ovn-kubernetes
 owners:
 - aos-networking-staff@redhat.com
-canonical_builders_from_upstream: true

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -40,4 +40,3 @@ labels:
 name: openshift/ose-ovn-kubernetes-base
 owners:
 - aos-networking-staff@redhat.com
-canonical_builders_from_upstream: true

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -51,4 +51,3 @@ name: openshift/ose-ovn-kubernetes-microshift-rhel9
 payload_name: ovn-kubernetes-microshift
 owners:
 - aos-networking-staff@redhat.com
-canonical_builders_from_upstream: true


### PR DESCRIPTION
Ensure all images use canonical_builders_from_upstream: false by relying on the default value in group.yml. This change removes explicit overrides that were setting it to true, ensuring consistent behavior across all images.

Changes:
- Removed canonical_builders_from_upstream: true from 6 images:
  * ose-etcd
  * ose-ovn-kubernetes
  * ose-installer-etcd-artifacts
  * ovn-kubernetes-microshift
  * ose-network-interface-bond-cni
  * ovn-kubernetes-base

- Removed redundant canonical_builders_from_upstream: false from non-ci images (openshift-base-rhel9, openshift-base-nodejs.rhel9) to rely on group.yml default

- Kept explicit canonical_builders_from_upstream: false in ci-* images