### PR TITLE
[4.14] Set canonical_builders_from_upstream to false for all images

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -47,7 +47,6 @@ konflux:
   cachi2:
     enabled: false
   network_mode: open
-canonical_builders_from_upstream: true
 delivery:
   delivery_repo_names:
   - openshift4/ose-ovn-kubernetes


### PR DESCRIPTION
Ensure all images use canonical_builders_from_upstream: false by relying on the default value in group.yml. This change removes explicit overrides that were setting it to true, ensuring consistent behavior across all images.

Changes:
- Removed canonical_builders_from_upstream: true from ose-ovn-kubernetes