### PR TITLE
use rhel-9-golang-1.25 builder for hypershift - 4.22

### DIFF
--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -21,7 +21,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-hypershift-rhel9
 payload_name: hypershift


### PR DESCRIPTION
Following https://github.com/openshift/hypershift/pull/7592 jobs were failing with

`go: go.mod requires go >= 1.25.3 (running go 1.24.11; GOTOOLCHAIN=local)
`

[test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/fgallott/job/ocp4-konflux/63)