### PR TITLE
[openshift-4.23] ART-14479: use rhel-9-golang-1.25 builder for hypershift

### DIFF
--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -21,7 +21,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-hypershift-rhel9
 payload_name: hypershift


### PR DESCRIPTION
cherry-pick of https://github.com/openshift-eng/ocp-build-data/pull/8825

[OCP test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/25157/)
[OKD test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fokd4/674/)