### PR TITLE
scan-sources-konflux:noop revert OKD 4.22 to centos10

### DIFF
--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -20,7 +20,7 @@ content:
       upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:base-rhel9
     okd_alignment:
       resolve_as:
-        stream: centos_stream10
+        stream: centos_stream9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-base-rhel9-container

--- a/streams.yml
+++ b/streams.yml
@@ -128,7 +128,7 @@ centos_stream9:
 
 centos_stream10:
   # Mirror the centos images so that okd_alignment can reference them in app.ci
-  image: quay.io/centos/centos:stream10-minimal
+  image: quay.io/centos/centos:stream10
   upstream_image: registry.ci.openshift.org/ocp/builder:stream10
   mirror: true
   mirror_manifest_list: true


### PR DESCRIPTION
Reverts https://github.com/openshift-eng/ocp-build-data/pull/8851/

This needs to be refined further because of missing `centos-release-openstack-zed` RPM in centos10.