### PR TITLE
(4.22)[config]: update RHCOS to 9.8 for OpenShift 4.22

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -12,7 +12,7 @@ vars:
   IMPACT: Low
   CVES: None
   RHCOS_EL_MAJOR: 9
-  RHCOS_EL_MINOR: 6
+  RHCOS_EL_MINOR: 8
 
   # The go versions used by the various CI builder images.
   # WARNING: When updating GO_* vars, update streams.yml so that streams referencing
@@ -95,17 +95,15 @@ cachito:
 rhcos:
   payload_tags:
     - name: rhel-coreos
-      # once rhel-coreos 4.22 exists this line has to be updated to 4.22
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
-      rhel_version: 9.6
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.22-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.22-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
+      rhel_version: 9.8
       meta_type: commitmeta
       primary: true
     - name: rhel-coreos-extensions
-      # once rhel-coreos-extensions 4.22 exists this line has to be updated to 4.22
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image-extensions
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
-      rhel_version: 9.6
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.22-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image-extensions
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.22-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
+      rhel_version: 9.8
       meta_type: meta
     - name: rhel-coreos-10
       rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.1-node-image
@@ -118,10 +116,9 @@ rhcos:
       rhel_version: 10.1
       meta_type: meta
   enabled_repos:
-  - rhel-9-baseos-rpms
-  - rhel-9-appstream-rpms
-  - rhel-9-fast-datapath-rpms
-  - rhel-9-server-ose-rpms
+  - rhel-98-baseos
+  - rhel-98-appstream
+  - rhel-98-fast-datapath
   require_consistency:
     driver-toolkit:
     - kernel  # since 9.3, kernel-rt is merged into the kernel package.

--- a/group.yml
+++ b/group.yml
@@ -116,6 +116,7 @@ rhcos:
       rhel_version: 10.1
       meta_type: meta
   enabled_repos:
+  - rhel-9-server-ose-rpms
   - rhel-98-baseos
   - rhel-98-appstream
   - rhel-98-fast-datapath

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -4,7 +4,7 @@ content:
     modifications:
     - action: replace
       match: "ARG RHEL_VERSION=''"
-      replacement: "ARG RHEL_VERSION='9.6'"
+      replacement: "ARG RHEL_VERSION='9.8'"
     # Uncomment the following sections to pin specific kernel versions
     # - action: replace
     #   match: "ARG KERNEL_VERSION=''"
@@ -27,11 +27,10 @@ delivery:
   - openshift4/driver-toolkit-rhel9
 enabled_repos:
 - rhel-9-server-ose-rpms-embargoed
-- rhel-9-minimal-baseos-rpms
-- rhel-9-minimal-appstream-rpms
-- rhel-9-rt-rpms
-- rhel-9-nfv
-- rhel-9-highavailability
+- rhel-98-baseos
+- rhel-98-appstream
+- rhel-98-nfv
+- rhel-98-highavailability
 for_payload: true
 from:
   member: openshift-enterprise-base-rhel9-minimal


### PR DESCRIPTION
## Summary
Update RHCOS to 9.8 for OpenShift 4.22

## Changes
Updates Red Hat Enterprise Linux CoreOS base from 9.6 to 9.8 across build configurations. This includes updating the RHCOS index tags from 4.21 to 4.22 versioning and consolidating repository configurations to use the new rhel-98-* naming scheme.