### PR TITLE
(4.19)[build-data]: convert golang builder to hermetic builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -11,8 +11,11 @@ vars:
   MINOR: 19
 
 konflux:
+  network_mode: hermetic
   cachi2:
     enabled: true
+    lockfile:
+      force: true
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -43,7 +43,6 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
-  network_mode: open
   content:
     source:
       modifications:


### PR DESCRIPTION
## Summary
build(konflux): convert golang builder to hermetic builds

## Changes
Enable hermetic build mode for openshift-golang-builder by setting 
global default network_mode in group.yml and removing the open 
network override from the golang builder image config. This enforces
dependency isolation and improves build security and reproducibility.

Changes include forcing cachi2 lockfile usage for consistent
dependency management across all hermetic builds.