### PR TITLE
4.16.57: added CONFLICTING_INHERITED_DEPENDENCY for 5 components

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -22,6 +22,17 @@ releases:
             - kind: fbc
         release_date: 2026-Feb-18
         upgrades: 4.15.18,4.15.19,4.15.20,4.15.21,4.15.22,4.15.23,4.15.24,4.15.25,4.15.26,4.15.27,4.15.28,4.15.29,4.15.30,4.15.31,4.15.32,4.15.33,4.15.34,4.15.35,4.15.36,4.15.37,4.15.38,4.15.39,4.15.40,4.15.41,4.15.42,4.15.43,4.15.44,4.15.45,4.15.46,4.15.47,4.15.48,4.15.49,4.15.50,4.15.51,4.15.52,4.15.53,4.15.54,4.15.55,4.15.56,4.15.57,4.15.58,4.15.59,4.15.60,4.15.61,4.16.0,4.16.1,4.16.2,4.16.3,4.16.4,4.16.5,4.16.6,4.16.7,4.16.8,4.16.9,4.16.10,4.16.11,4.16.12,4.16.13,4.16.14,4.16.15,4.16.16,4.16.17,4.16.18,4.16.19,4.16.20,4.16.21,4.16.23,4.16.24,4.16.25,4.16.26,4.16.27,4.16.28,4.16.29,4.16.30,4.16.32,4.16.33,4.16.34,4.16.35,4.16.36,4.16.37,4.16.38,4.16.39,4.16.40,4.16.41,4.16.42,4.16.43,4.16.44,4.16.45,4.16.46,4.16.47,4.16.48,4.16.49,4.16.50,4.16.51,4.16.52,4.16.53,4.16.54,4.16.55,4.16.56
+      permits:
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: 'cluster-node-tuning-operator'
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: 'openshift-enterprise-operator-sdk'
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: 'openshift-enterprise-tests'
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: 'ose-network-tools'
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: 'ose-tools'
       rhcos:
         rhel-coreos:
           images:


### PR DESCRIPTION
4.16.57: added CONFLICTING_INHERITED_DEPENDENCY for 5 components
This should stop build-sync-konflux from failing with these errors:

09:14:04  assembly_issues:
09:14:04    cluster-node-tuning-operator:
09:14:04    - code: CONFLICTING_INHERITED_DEPENDENCY
09:14:04      msg: Expected image to contain assembly override dependencies NVR kernel-5.14.0-427.110.1.el9_4
09:14:04        but found kernel-5.14.0-427.109.1.el9_4 installed
09:14:04      permitted: false
09:14:04    openshift-enterprise-operator-sdk:
09:14:04    - code: CONFLICTING_INHERITED_DEPENDENCY
09:14:04      msg: Expected image to contain assembly override dependencies NVR kernel-5.14.0-427.110.1.el9_4
09:14:04        but found kernel-5.14.0-427.109.1.el9_4 installed
09:14:04      permitted: false
09:14:04    openshift-enterprise-tests:
09:14:04    - code: CONFLICTING_INHERITED_DEPENDENCY
09:14:04      msg: Expected image to contain assembly override dependencies NVR kernel-5.14.0-427.110.1.el9_4
09:14:04        but found kernel-5.14.0-427.109.1.el9_4 installed
09:14:04      permitted: false
09:14:04    ose-network-tools:
09:14:04    - code: CONFLICTING_INHERITED_DEPENDENCY
09:14:04      msg: Expected image to contain assembly override dependencies NVR kernel-5.14.0-427.110.1.el9_4
09:14:04        but found kernel-5.14.0-427.109.1.el9_4 installed
09:14:04      permitted: false
09:14:04    ose-tools:
09:14:04    - code: CONFLICTING_INHERITED_DEPENDENCY
09:14:04      msg: Expected image to contain assembly override dependencies NVR kernel-5.14.0-427.110.1.el9_4
09:14:04        but found kernel-5.14.0-427.109.1.el9_4 installed
09:14:04      permitted: false