### PR TITLE
4.18 - Update streams.yml with go1.23 and go1.24 nvr's

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -46,7 +46,7 @@ rhel-8-golang:
 rhel-9-golang-1.23:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: openshift/golang-builder:v1.23.9-202506111225.g6c23478.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202602100938.gd0321dd.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -59,7 +59,7 @@ rhel-9-golang-1.23:
 rhel-8-golang-1.23:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: openshift/golang-builder:v1.23.9-202506111440.gdd3c620.el8
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202602061820.gdc331c7.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -70,14 +70,14 @@ rhel-8-golang-1.23:
     - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.24:
-  image: openshift/golang-builder:v1.24.4-202507171054.g2f6f49f.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.11-202601061056.ge8e5642.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-{MAJOR}.{MINOR}
 
 rhel-8-golang-1.24:
-  image: openshift/golang-builder:v1.24.4-202507171054.g35b6b0c.el8
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.11-202601072254.g1f0d617.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
Since, some of the images are using go1.24 and go1.23 hence this PR is for updating those images. 