### PR TITLE
4.19 - Update streams.yml with go1.24 nvr's

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -38,7 +38,7 @@ rhel-8-golang:
 rhel-9-golang-1.24:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: openshift/golang-builder:v1.24.4-202507171054.g2f6f49f.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.11-202601061056.ge8e5642.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -47,7 +47,7 @@ rhel-9-golang-1.24:
 rhel-8-golang-1.24:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: openshift/golang-builder:v1.24.4-202507171054.g35b6b0c.el8
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.11-202601072254.g1f0d617.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
Since, some of the images uses go1.24 hence this PR would update it.