### PR TITLE
4.22: Fix dtk build

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -27,6 +27,11 @@ delivery:
   - openshift4/driver-toolkit-rhel9
 enabled_repos:
 - rhel-9-server-ose-rpms-embargoed
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-nfv
+- rhel-9-highavailability
+- rhel-9-rt-rpms
 - rhel-98-baseos
 - rhel-98-appstream
 - rhel-98-nfv


### PR DESCRIPTION
Since including 9.8 repos in rhcos, dtk builds have been failing like this:

```
error: Could not depsolve transaction; 1 problem detected:
 Problem: problem with installed package gcc-11.5.0-14.el9.x86_64
  - package redhat-rpm-config-210-1.el9.noarch from hermeto-525902 requires (annobin if (gcc or clang)), but none of the providers can be installed
  - package kernel-rpm-macros-185-14.el9.noarch from hermeto-525902 requires redhat-rpm-config >= 13, but none of the providers can be installed
  - package annobin-12.98-2.el9.x86_64 from hermeto-525902 requires libLLVM.so.21.1()(64bit), but none of the providers can be installed
  - package annobin-12.98-2.el9.x86_64 from hermeto-525902 requires libLLVM.so.21.1(LLVM_21.1)(64bit), but none of the providers can be installed
  - conflicting requests
  - nothing provides llvm-filesystem(x86-64) = 21.1.7-1.el9 needed by llvm-libs-21.1.7-1.el9.x86_64 from hermeto-525902
 ```

This configuration works in 4.23, so trying it out in 4.22