### PR TITLE
(4.23)[docs]: standardize console comments with JIRA reference

### DIFF
--- a/images/agent-installer-ui.yml
+++ b/images/agent-installer-ui.yml
@@ -44,4 +44,4 @@ konflux:
     mode: emulation
   vm_override:
     x86_64: linux-d160-c4xlarge/amd64
-  network_mode: open # Bunch of yarn dependencies, not sure how to fix
+  network_mode: open # Bunch of yarn dependencies, Jira: ART-14311

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -50,7 +50,7 @@ payload_name: networking-console-plugin
 konflux:
   cachito:
     mode: emulation
-  network_mode: open # Bunch of yarn dependencies, not sure how to fix
+  network_mode: open # Bunch of yarn dependencies, Jira: ART-14311
 okd:
   content:
     source:

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -56,4 +56,4 @@ owners:
 konflux:
   cachito:
     mode: emulation
-  network_mode: open # https://issues.redhat.com/browse/ART-14311
+  network_mode: open # Bunch of yarn dependencies, Jira: ART-14311

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -59,4 +59,4 @@ konflux:
     mode: emulation
   cachi2:
     enabled: true
-  network_mode: open
+  network_mode: open # Bunch of yarn dependencies, Jira: ART-14311


### PR DESCRIPTION
## Summary
Standardize network_mode open comments across console images with proper JIRA reference

## Changes
Updates comments across console-related images to consistently explain why 
network_mode: open is required (yarn dependencies) and properly reference 
tracking ticket ART-14311.