### PR TITLE
CNTRLPLANE-2763: bump 4.22 golang builders to 1.25

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -13,8 +13,8 @@ vars:
   #               aliases:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
-  GO_LATEST: "1.24"
-  GO_EXTRA: "1.24"  # There is no extra version at this time, so just duplicate latest.
+  GO_LATEST: "1.25"
+  GO_EXTRA: "1.25"  # There is no extra version at this time, so just duplicate latest.
   MAJOR: 4
   MINOR: 19
 

--- a/streams.yml
+++ b/streams.yml
@@ -5,7 +5,7 @@ ose-cli:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.11-202601061056.ge8e5642.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.3-202511260833.g5015a16.el9
 
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163


### PR DESCRIPTION
- Update builders to golang 1.25
- Related thread: https://redhat-internal.slack.com/archives/C0144ECKUJ0/p1771360276935739?thread_ts=1771231996.903379&cid=C0144ECKUJ0