### PR TITLE
(4.22)[images]: convert node-feature-discovery to hermetic build

### DIFF
--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -29,8 +29,3 @@ name: openshift/ose-node-feature-discovery-rhel9
 name_in_bundle: node-feature-discovery
 owners:
 - edge-kmm@redhat.com
-konflux:
-  # New issue, need to investigate
-  cachi2:
-    enabled: false
-  network_mode: open


### PR DESCRIPTION
## Summary
Convert node-feature-discovery to hermetic build

## Changes
Remove konflux network_mode override to use default hermetic configuration from group.yml. This eliminates the need for network access during build and improves build reliability through dependency pre-caching.

Part of the broader hermetic build conversion initiative for OCP 4.21+.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/26606/
Konflux build: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-node-feature-discovery-ktfpd