### PR TITLE
microshift-bootc hermetic - 4.22

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -37,10 +37,5 @@ canonical_builders_from_upstream: false
 owners:
 - microshift-devel@redhat.com
 konflux:
-  network_mode: open
-  cachi2:
-    # For them, vendor modifications are necessary
-    # https://redhat-internal.slack.com/archives/C06Q309QUDV/p1745508906683839
-    enabled: false
   sast:
     enabled: true


### PR DESCRIPTION
fixed in main upstream https://github.com/openshift/microshift/pull/5824

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-microshift-bootc-d5pxp)