### PR TITLE
ART-14516: add image aws-node-termination-handler

### DIFF
--- a/images/aws-node-termination-handler.yml
+++ b/images/aws-node-termination-handler.yml
@@ -1,0 +1,27 @@
+content:
+  source:
+    dockerfile: Dockerfile.ocp
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/aws-node-termination-handler.git
+      web: https://github.com/openshift/aws-node-termination-handler
+    ci_alignment:
+      streams_prs:
+        ci_build_root:
+          member: ci-openshift-build-root-latest.rhel9
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: aws-node-termination-handler-container
+delivery:
+  delivery_repo_names:
+  - openshift4/aws-kms-encryption-provider-rhel9
+for_payload: true
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/aws-node-termination-handler-rhel9
+owners:
+- hypershift-team@redhat.com@redhat.com
+payload_name: aws-node-termination-handler


### PR DESCRIPTION
* hermetic [test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/26738/console)
    Run the first time with network_mode: open
* [konflux pipeline](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-aws-node-termination-handler-zrpf7)
 * [ART history](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=aws-node-termination-handler-container-v4.22.0-202602191442.p2.gd70e446.assembly.test.el9&record_id=597eea7f-7c3f-d3ee-26cc-409fd25d4411&group=openshift-4.22&outcome=success&type=image)