### PR TITLE
prep for oadp-1.5.5

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,7 +1,7 @@
 name: oadp-1.5
 csv_namespace: oadp
 product: oadp
-version: 1.5.4
+version: 1.5.5
 
 vars:
   # The go versions used by the various CI builder images.


### PR DESCRIPTION
prep for oadp-1.5.5 now that golang 1.25.7 is the builder :) 