### PR TITLE
openshift-logging: Initial configuration for Logging 6.5

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -13,16 +13,16 @@ vars:
   #               aliases:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
-  GO_LATEST: "1.24"
-  GO_EXTRA: "1.24"  # There is no extra version at this time, so just duplicate latest.
+  GO_LATEST: "1.25"
+  GO_EXTRA: "1.25"  # There is no extra version at this time, so just duplicate latest.
   MAJOR: 4
-  MINOR: 17
+  MINOR: 21
 
 OCP_TARGET_VERSIONS: [
-  "4.17",
-  "4.18",
   "4.19",
   "4.20",
+  "4.21",
+  "4.22",
 ]
 
 arches:

--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: release-6.3
+        target: master # to be changed to release-6.5
       url: git@github.com:openshift-priv/cluster-logging-operator.git
       web: https://github.com/openshift/cluster-logging-operator
 distgit:

--- a/images/loki-operator.yml
+++ b/images/loki-operator.yml
@@ -4,7 +4,7 @@ content:
     path: operator
     git:
       branch:
-        target: release-6.3
+        target: main # to be changed to release-6.5
       url: git@github.com:openshift-priv/loki.git
       web: https://github.com/openshift/loki
 distgit:

--- a/images/loki.yml
+++ b/images/loki.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: upstream-v3.5.7
+        target: upstream-v3.6.5
       url: git@github.com:openshift-priv/loki.git
       web: https://github.com/openshift/loki
 distgit:

--- a/streams.yml
+++ b/streams.yml
@@ -2,11 +2,11 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.11-202601061056.ge8e5642.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:
-  image: registry.redhat.io/openshift4/ose-cli-artifacts-rhel9:v4.17
+  image: registry.redhat.io/openshift4/ose-cli-artifacts-rhel9:v4.21
 
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163


### PR DESCRIPTION
Notes:

- [x] I'm not sure if the golang-builder image I picked actually exists
  - <rayfordj> confirmed; good pullspec
- [x] Currently the `release-6.5` branches do not exist yet, but if you prefer we do not point at `main`/`master` I can also create them on Monday
  - <rayfordj> no concerns for now; switch to and build from release branch prior to release
- [x] Not sure what the `MINOR` variable in `group.yml` does, but our "target OCP version" for 6.5 is 4.21, if that's what it means. (need to update this in 6.3 as well if it should be the _target_ and not the _minimal_)
  - <rayfordj> short answer, it really doesn't matter; I used it as the min OCP for other products as a matter of convenience when I was on-boarding them -- what **_is_** important is an accurate OCP_TARGET_VERSIONS list

/cc @rayfordj @ashwindasr 