### PR TITLE
ART-14564: 4.19: build dtk non-hermetically

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -44,5 +44,6 @@ payload_name: driver-toolkit
 owners:
 - edge-sro@redhat.com
 konflux:
+  network_mode: open
   vm_override:
     aarch64: linux-d160-m2xlarge/arm64


### PR DESCRIPTION
DTK started to time out systematically on IBM architectures. The suspicion is that this is caused by a bug in how rpmlockfile gets generated. While this bug is sorted, let's build non-hermetically.