### PR TITLE
ART-14530 Let 5.0 consume 4.23 repos

### DIFF
--- a/repos/rhel-10-server-ose-rpms-embargoed.yml
+++ b/repos/rhel-10-server-ose-rpms-embargoed.yml
@@ -33,9 +33,13 @@
     source:
       embargoed_tags:
       - rhaos-{MAJOR}.{MINOR}-rhel-10-embargoed
+      - rhaos-4.23-rhel-10-embargoed
       from_tags:
       - name: rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-10
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-10
+      - name: rhaos-4.23-rhel-10-candidate
+        product_version: OSE-4.23-RHEL-10
+        release_tag: rhaos-4.23-rhel-10
       type: brew
   type: plashet

--- a/repos/rhel-10-server-ose-rpms.yml
+++ b/repos/rhel-10-server-ose-rpms.yml
@@ -33,10 +33,14 @@
     source:
       embargoed_tags:
       - rhaos-{MAJOR}.{MINOR}-rhel-10-embargoed
+      - rhaos-4.23-rhel-10-embargoed
       from_tags:
       - name: rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-10
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-10
+      - name: rhaos-4.23-rhel-10-candidate
+        product_version: OSE-4.23-RHEL-10
+        release_tag: rhaos-4.23-rhel-10
       type: brew
   reposync:
     latest_only: false

--- a/repos/rhel-8-server-ose-rpms-embargoed.yml
+++ b/repos/rhel-8-server-ose-rpms-embargoed.yml
@@ -33,9 +33,13 @@
     source:
       embargoed_tags:
       - rhaos-{MAJOR}.{MINOR}-rhel-8-embargoed
+      - rhaos-4.23-rhel-8-embargoed
       from_tags:
       - name: rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-8
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-8
+      - name: rhaos-4.23-rhel-8-candidate
+        product_version: OSE-4.23-RHEL-8
+        release_tag: rhaos-4.23-rhel-8
       type: brew
   type: plashet

--- a/repos/rhel-8-server-ose-rpms.yml
+++ b/repos/rhel-8-server-ose-rpms.yml
@@ -33,10 +33,14 @@
     source:
       embargoed_tags:
       - rhaos-{MAJOR}.{MINOR}-rhel-8-embargoed
+      - rhaos-4.23-rhel-8-embargoed
       from_tags:
       - name: rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-8
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-8
+      - name: rhaos-4.23-rhel-8-candidate
+        product_version: OSE-4.23-RHEL-8
+        release_tag: rhaos-4.23-rhel-8
       type: brew
   reposync:
     latest_only: false

--- a/repos/rhel-9-server-ironic-rpms.yml
+++ b/repos/rhel-9-server-ironic-rpms.yml
@@ -28,6 +28,9 @@
       - name: rhaos-{MAJOR}.{MINOR}-ironic-rhel-9-candidate
         product_version: OSE-IRONIC-{MAJOR}.{MINOR}-RHEL-9
         release_tag: rhaos-{MAJOR}.{MINOR}-ironic-rhel-9
+      - name: rhaos-4.23-ironic-rhel-9-candidate
+        product_version: OSE-IRONIC-4.23-RHEL-9
+        release_tag: rhaos-4.23-ironic-rhel-9
       type: brew
   reposync:
     latest_only: false

--- a/repos/rhel-9-server-microshift-rpms.yml
+++ b/repos/rhel-9-server-microshift-rpms.yml
@@ -21,5 +21,8 @@
       - name: rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-9
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-9
+      - name: rhaos-4.23-rhel-9-candidate
+        product_version: OSE-4.23-RHEL-9
+        release_tag: rhaos-4.23-rhel-9
       type: brew
   type: plashet

--- a/repos/rhel-9-server-ose-rpms-embargoed.yml
+++ b/repos/rhel-9-server-ose-rpms-embargoed.yml
@@ -33,9 +33,13 @@
     source:
       embargoed_tags:
       - rhaos-{MAJOR}.{MINOR}-rhel-9-embargoed
+      - rhaos-4.23-rhel-9-embargoed
       from_tags:
       - name: rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-9
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-9
+      - name: rhaos-4.23-rhel-9-candidate
+        product_version: OSE-4.23-RHEL-9
+        release_tag: rhaos-4.23-rhel-9
       type: brew
   type: plashet

--- a/repos/rhel-9-server-ose-rpms.yml
+++ b/repos/rhel-9-server-ose-rpms.yml
@@ -33,10 +33,14 @@
     source:
       embargoed_tags:
       - rhaos-{MAJOR}.{MINOR}-rhel-9-embargoed
+      - rhaos-4.23-rhel-9-embargoed
       from_tags:
       - name: rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-9
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-9
+      - name: rhaos-4.23-rhel-9-candidate
+        product_version: OSE-4.23-RHEL-9
+        release_tag: rhaos-4.23-rhel-9
       type: brew
   reposync:
     latest_only: false


### PR DESCRIPTION
 ### Add 4.23 fallback tags to 5.0 plashet repos

####  Problem:
 5.0 brew tags are not set up yet, causing empty plashets and build failures.

#### Solution:
Add 4.23 brew tags as secondary sources for all plashet repos