### PR TITLE
ose-agent-installer-utils, ose-ovn-kubernetes hermetic - 4.20

### DIFF
--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -36,7 +36,6 @@ payload_name: agent-installer-utils
 owners:
 - ocp-agent-team@redhat.com
 konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo
   cachi2:
     lockfile:
       rpms:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -29,8 +29,6 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-fast-datapath-rpms
 - rhel-9-server-ose-rpms-embargoed
-konflux:
-  network_mode: open  # cannot install signed rpms from unreleased ose-rpms repo
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
[ose-agent-installer-utils hermetic build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-20/pipelineruns/ose-4-20-ose-agent-installer-utils-msqgv/)

[ose-ovn-kubernetes hermetic build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-20/pipelineruns/ose-4-20-ose-ovn-kubernetes-smppd/)