### PR TITLE
(4.22)[images]: add VM override for nmstate-console-plugin aarch64 builds

### DIFF
--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -47,6 +47,8 @@ owners:
 - phoracek@redhat.com
 - fge@redhat.com
 konflux:
+  vm_override:
+    aarch64: linux-d160-c4xlarge/arm64
   cachito:
     mode: emulation
   network_mode: open # https://issues.redhat.com/browse/ART-14311


### PR DESCRIPTION
## Summary
Add VM override for nmstate-console-plugin aarch64 builds

## Changes
Resolves consistent build failures due to yarn version detection errors and OOM 
issues. The larger VM (linux-d160-c4xlarge/arm64) provides sufficient resources 
for the build process to complete successfully on aarch64 architecture.