### PR TITLE
(4.22)[images]: add VM override for networking-console-plugin aarch64 builds

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -39,6 +39,8 @@ owners:
 - mschatzm@redhat.com
 payload_name: networking-console-plugin
 konflux:
+  vm_override:
+    aarch64: linux-d160-c4xlarge/arm64
   cachito:
     mode: emulation
   network_mode: open # Bunch of yarn dependencies, not sure how to fix


### PR DESCRIPTION
## Summary
Add VM override for networking-console-plugin aarch64 builds

## Changes
Resolves consistent build failures due to yarn version detection errors and OOM 
issues. The larger VM (linux-d160-c4xlarge/arm64) provides sufficient resources 
for the build process to complete successfully on aarch64 architecture.