### PR TITLE
(4.23)[images]: enable hermetic builds for ibm-vpc-block-csi-driver

### DIFF
--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -39,8 +39,3 @@ name: openshift/ose-ibm-vpc-block-csi-driver-rhel9
 payload_name: ibm-vpc-block-csi-driver
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  # New issue, need to investigate
-  cachi2:
-    enabled: false
-  network_mode: open # copier: stat: "/go/bin/ibm-vpc-block-csi-driver": no such file or directory


### PR DESCRIPTION
## Summary
Enable hermetic builds for IBM VPC Block CSI driver

## Changes
Remove konflux network_mode override to allow IBM VPC Block CSI driver to use the default hermetic build mode from group.yml. This removes the workaround that disabled cachi2 and forced open network mode due to a previous build issue that has been resolved.

## Test
Jenkins job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/27222/
Konflux Build: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-23/pipelineruns/ose-4-23-ose-ibm-vpc-block-csi-driver-7vqfn