### PR TITLE
(4.18)[images]: enable hermetic builds for ibm-vpc-block-csi-driver

### DIFF
--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -37,8 +37,3 @@ name: openshift/ose-ibm-vpc-block-csi-driver-rhel9
 payload_name: ibm-vpc-block-csi-driver
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  cachi2:
-    # Need upstream fix
-    enabled: false
-  network_mode: open


### PR DESCRIPTION
## Summary
Enable hermetic builds for IBM VPC Block CSI driver

## Changes
Remove konflux network_mode override to allow IBM VPC Block CSI driver to use the default hermetic build mode from group.yml. This removes the workaround that disabled cachi2 and forced open network mode due to a previous build issue that has been resolved.

## Upstream PR
Waiting for https://github.com/openshift/ibm-vpc-block-csi-driver/pull/122

/hold