### PR TITLE
(4.15)[images]: enable hermetic builds for ibm-vpc-block-csi-driver

### DIFF
--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -37,7 +37,3 @@ name: openshift/ose-ibm-vpc-block-csi-driver-rhel9
 payload_name: ibm-vpc-block-csi-driver
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
## Summary
Enable hermetic builds for IBM VPC Block CSI driver

## Changes
Remove konflux network_mode override to allow IBM VPC Block CSI driver to use the default hermetic build mode from group.yml. This removes the workaround that disabled cachi2 and forced open network mode due to a previous build issue that has been resolved.

## Upstream PR
Waiting for https://github.com/openshift/ibm-vpc-block-csi-driver/pull/125

/hold