### PR TITLE
revert ose-metallb hermetic migration

### DIFF
--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -29,3 +29,6 @@ name: openshift/metallb-rhel9
 name_in_bundle: metallb-rhel9
 owners:
 - metallb-dev@redhat.com
+konflux:
+  cachi2:
+    enabled: false # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
failing https://redhat-internal.slack.com/archives/CB95J6R4N/p1771989263660849?thread_ts=1771989262.665249&cid=CB95J6R4N

```
Error: PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
  Please try running `go mod vendor` and committing the changes.
  Note that you may need to `git add --force` ignored files in the vendor/ dir.
```