### PR TITLE
Fix go aliases

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -23,8 +23,8 @@ vars:
   #               aliases:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
-  GO_LATEST: "1.25.7"
-  GO_EXTRA: "1.25.7" # ovn-kubernetes or other components require Go 1.25
+  GO_LATEST: "1.25"
+  GO_EXTRA: "1.25"
 
 compliance:
   rpm_shim:


### PR DESCRIPTION
When patch versions are included, our tooling gets confused and syncs images out to the wrong pullspecs in CI. This fixes that.