### PR TITLE
hermetic 4.16

### DIFF
--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -33,6 +33,3 @@ name: openshift/ose-csi-driver-manila-rhel9
 payload_name: csi-driver-manila
 owners:
 - shiftstack-team@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -37,9 +37,7 @@ payload_name: prometheus-alertmanager
 owners:
 - team-monitoring@redhat.com
 konflux:
-  network_mode: open  # Upstream has to fix their vendor.
   cachi2:
-    enabled: false  # Upstream has to fix their vendor.
     lockfile:
       rpms:
       - openshift-prometheus-promu

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -27,6 +27,3 @@ name: openshift/ose-hypershift-rhel9
 payload_name: hypershift
 owners:
 - hypershift-team@redhat.com
-konflux:
-  cachi2:
-    enabled: false

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -30,7 +30,3 @@ name: openshift/ose-kube-proxy-rhel9
 payload_name: kube-proxy
 owners:
 - aos-networking-staff@redhat.com
-konflux:
-  network_mode: open # The content of the vendor directory is not consistent with go.mod
-  cachi2:
-    enabled: false

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -28,5 +28,3 @@ labels:
 name: openshift/ose-egress-http-proxy-rhel9
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -33,6 +33,3 @@ payload_name: ibmcloud-cluster-api-controllers
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -39,6 +39,3 @@ owners:
 - dmoiseev@redhat.com
 - mbooth@redhat.com
 - m.andre@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -30,5 +30,3 @@ name: openshift/ovirt-csi-driver-rhel9
 payload_name: ovirt-csi-driver
 owners:
 - rgolan@redhat.com
-konflux:
-  network_mode: open


### PR DESCRIPTION
* [csi-driver-manila](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-csi-driver-manila-rxwp8/)
* [golang-github-prometheus-alertmanager](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-golang-github-prometheus-alertmanager-xz7kg) open first
* [hypershift](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-hypershift-jtp9s/)
* [kube-proxy](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-kube-proxy-v8hvb/)
* [ose-egress-http-proxy](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-egress-http-proxy-srs2w)
* [ose-ibmcloud-cluster-api-controllers](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-ibmcloud-cluster-api-controllers-krv2n/)
* [ose-openstack-cloud-controller-manager](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-openstack-cloud-controller-manager-x8ndg/)
* [ose-ovirt-csi-driver](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-ovirt-csi-driver-hlwpl/)

