### PR TITLE
openshift-kubernetes-nmstate hermetic 4.18

### DIFF
--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -38,7 +38,3 @@ owners:
 - mko@redhat.com
 - phoracek@redhat.com
 - yboaron@redhat.com
-konflux:
-  network_mode: open # vendor changed upstream
-  cachi2:
-    enabled: false

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -39,7 +39,3 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
-konflux:
-  cachi2:
-    # Upstream is fixed
-    enabled: false


### PR DESCRIPTION
follows https://github.com/openshift/kubernetes-nmstate/pull/720

[openshift-kubernetes-nmstate-operator](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-openshift-kubernetes-nmstate-operator-z246p/)
[openshift-kubernetes-nmstate-handler](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-openshift-kubernetes-nmstate-handler-6xtt5/)