### PR TITLE
openshift-kubernetes-nmstate + golang-github-promotheus hermetic 4.17

### DIFF
--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -44,9 +44,7 @@ payload_name: prometheus-alertmanager
 owners:
 - team-monitoring@redhat.com
 konflux:
-  network_mode: open # vendor changed upstream
   cachi2:
-    enabled: false # vendor changed upstream
     lockfile:
       rpms:
       - openshift-prometheus-promu

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -38,7 +38,3 @@ owners:
 - mko@redhat.com
 - phoracek@redhat.com
 - yboaron@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -39,6 +39,3 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/kubernetes-nmstate/pull/721

[openshift-kubernetes-nmstate-operator](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-openshift-kubernetes-nmstate-operator-rq45d)
[openshift-kubernetes-nmstate-handler](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-openshift-kubernetes-nmstate-handler-pwh26)

[golang-github-promotheus-alertmanager](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-golang-github-prometheus-alertmanager-g5d7k) -> needs an open build first