### PR TITLE
openshift-kubernetes-nmstate hermetic 4.16

### DIFF
--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -38,7 +38,3 @@ owners:
 - mko@redhat.com
 - phoracek@redhat.com
 - yboaron@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -40,6 +40,3 @@ delivery:
   bundle_delivery_repo_name: openshift4/kubernetes-nmstate-operator-bundle
   delivery_repo_names:
   - openshift4/kubernetes-nmstate-rhel9-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/kubernetes-nmstate/pull/722

[openshift-kubernetes-nmstate-operator](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-openshift-kubernetes-nmstate-operator-fwhrx)
[openshift-kubernetes-nmstate-handler](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-openshift-kubernetes-nmstate-handler-v864n/)

