### PR TITLE
(4.23)[images]: convert nmstate-console-plugin to hermetic build

### DIFF
--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -1,5 +1,3 @@
-cachito:
-  enabled: true  # Cachito does not work with go 1.22 https://issues.redhat.com/browse/STONEBLD-2206, explicitly enabling for nodejs
 content:
   source:
     dockerfile: Dockerfile.art
@@ -8,12 +6,6 @@ content:
         target: release-4.22
       url: git@github.com:openshift-priv/nmstate-console-plugin.git
       web: https://github.com/openshift/nmstate-console-plugin
-    modifications:
-    - action: replace
-      match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
-      replacement: |-
-        COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/.npmrc
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -49,6 +41,7 @@ owners:
 konflux:
   vm_override:
     aarch64: linux-d160-c4xlarge/arm64
-  cachito:
-    mode: emulation
-  network_mode: open # Bunch of yarn dependencies, Jira: ART-14311
+  cachi2:
+    lockfile:
+      modules:
+      - nginx:1.24


### PR DESCRIPTION
## Summary
Convert nmstate-console-plugin to hermetic build with cachi2 lockfile

## Changes
Complete hermetic build conversion for nmstate-console-plugin:
- Remove legacy cachito configuration that was explicitly enabled due to Go 1.22 issues
- Remove content source modifications that manually handled remote sources
- Remove network_mode: open override to use default hermetic mode
- Add cachi2 lockfile configuration with nginx module for proper dependency management

This enables the image to use Konflux's hermetic build capabilities with proper dependency caching through cachi2.