### PR TITLE
Update streams.yml to remove alias

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -64,8 +64,6 @@ rhel-9-golang:
     - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.21:
-  aliases:
-    - rhel-9-golang-1.21
   image: openshift/golang-builder:v1.21.13-202507041112.g5ebadc3.el9
   mirror: true
   transform: rhel-9/golang


### PR DESCRIPTION
Update streams.yaml since The error is actually a validation failure in streams.yml.

 The validation code (line 519) checks:
  if alias in streams_content:
      raise ValueError(f"Alias name {alias} already exists in streams.yml")

  Since rhel-9-golang-1.21 exists as both a stream name AND an alias, it fails.