### PR TITLE
Update streams.yml to change alias with {GO_EXTRA}

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -14,7 +14,8 @@ vars:
   RHCOS_EL_MAJOR: 9
   RHCOS_EL_MINOR: 2
   GO_LATEST: "1.20"
-  GO_EXTRA: "1.19"
+  GO_EXTRA: "1.21"
+  GO_PREVIOUS: "1.19"
 
 compliance:
   rpm_shim:

--- a/streams.yml
+++ b/streams.yml
@@ -65,7 +65,7 @@ rhel-9-golang:
 
 rhel-9-golang-1.21:
   aliases:
-    - rhel-9-golang-1.21
+    - rhel-9-golang-{GO_EXTRA}
   image: openshift/golang-builder:v1.21.13-202507041112.g5ebadc3.el9
   mirror: true
   transform: rhel-9/golang


### PR DESCRIPTION
Because of the problem here : https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/292/console

The error is actually a validation failure in streams.yml

  Invalid configuration in streams.yml:
  rhel-9-golang-1.21:      
    aliases:
      - rhel-9-golang-1.21 
     
  The validation code (line 519) checks:
  if alias in streams_content:
      raise ValueError(f"Alias name {alias} already exists in streams.yml")



