### PR TITLE
Revert "NO-JIRA: OADP-1.6: update target branches"

### DIFF
--- a/images/oadp-hypershift-velero-plugin.yml
+++ b/images/oadp-hypershift-velero-plugin.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/hypershift-oadp-plugin.git
       web: https://github.com/openshift/hypershift-oadp-plugin
     modifications:

--- a/images/oadp-mustgather.yml
+++ b/images/oadp-mustgather.yml
@@ -10,7 +10,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/oadp-must-gather.git
       web: https://github.com/openshift/oadp-must-gather
     modifications:

--- a/images/oadp-non-admin.yml
+++ b/images/oadp-non-admin.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/migtools-oadp-non-admin.git
       web: https://github.com/migtools/oadp-non-admin
 distgit:

--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/oadp-operator.git
       web: https://github.com/openshift/oadp-operator
     modifications:

--- a/images/oadp-velero-plugin-for-aws.yml
+++ b/images/oadp-velero-plugin-for-aws.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/velero-plugin-for-aws.git
       web: https://github.com/openshift/velero-plugin-for-aws
     modifications:

--- a/images/oadp-velero-plugin-for-gcp.yml
+++ b/images/oadp-velero-plugin-for-gcp.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/velero-plugin-for-gcp.git
       web: https://github.com/openshift/velero-plugin-for-gcp
     modifications:

--- a/images/oadp-velero-plugin-for-legacy-aws.yml
+++ b/images/oadp-velero-plugin-for-legacy-aws.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/velero-plugin-for-legacy-aws.git
       web: https://github.com/openshift/velero-plugin-for-legacy-aws
     modifications:

--- a/images/oadp-velero-plugin-for-microsoft-azure.yml
+++ b/images/oadp-velero-plugin-for-microsoft-azure.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/velero-plugin-for-microsoft-azure.git
       web: https://github.com/openshift/velero-plugin-for-microsoft-azure
     modifications:

--- a/images/oadp-velero-plugin.yml
+++ b/images/oadp-velero-plugin.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/openshift-velero-plugin.git
       web: https://github.com/openshift/openshift-velero-plugin
     modifications:

--- a/images/oadp-velero.yml
+++ b/images/oadp-velero.yml
@@ -8,7 +8,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: oadp-1.6
+        target: oadp-1.5
       url: git@github.com:openshift-priv/velero.git
       web: https://github.com/openshift/velero
     modifications:


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#9119

Builds fail due to missing `oadp-1.6` release branch.  The few repos I checked did not yet have the branch.   Reverting changes to continue building from previous branch.  

### OADP team should PR target branch changes when they are ready to use 1.6 release branches for builds.