### PR TITLE
ec.3: Drop rpm and rhcos advisories

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -8,8 +8,6 @@ releases:
           x86_64: 4.22.0-0.nightly-2026-02-23-040809
       group:
         advisories:
-          rpm: 159596
-          rhcos: 159597
           microshift: 159142
         release_jira: ART-14438
         shipment:


### PR DESCRIPTION
ET is missing product versions. Those advisories are not required duing ec time.