### PR TITLE
4.17: Disable multi images

### DIFF
--- a/images/ci-openshift-base.rhel9.yml
+++ b/images/ci-openshift-base.rhel9.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true

--- a/images/ci-openshift-build-root-extra.rhel9.yml
+++ b/images/ci-openshift-build-root-extra.rhel9.yml
@@ -1,6 +1,7 @@
-# -extra images only need to be enabled when we are dealing with 3 versions of golang in a release
+# -extra images only need to be enabled when we are dealing with 3 versions of golang in a release`
 # instead of the normal two.
 
+mode: disabled
 content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true

--- a/images/ci-openshift-build-root-latest.rhel8.yml
+++ b/images/ci-openshift-build-root-latest.rhel8.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true

--- a/images/ci-openshift-golang-builder-extra.rhel9.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel9.yml
@@ -1,6 +1,6 @@
 # -extra images only need to be enabled when we are dealing with 3 versions of golang in a release
 # instead of the normal two.
-
+mode: disabled
 content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true

--- a/images/ci-openshift-golang-builder-latest.rhel8.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel8.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true

--- a/images/ci-openshift-golang-builder-latest.rhel9.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel9.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          stream: rhel-9-golang-1.23
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-network-interface-bond-cni-container


### PR DESCRIPTION
This PR wants to stop building the ci-openshift* images. These push to pullspecs with `multi` in their name, which no one is using in 4.17. Also, adjust the ci_alignment of network-bond-interface to look at streams rather than members.