### PR TITLE
hermetic 4.15

### DIFF
--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -36,10 +36,8 @@ name: openshift/ose-prometheus-alertmanager
 payload_name: prometheus-alertmanager
 owners:
 - team-monitoring@redhat.com
-konflux: 
-  network_mode: open # vendor chages to be fixed upstream
+konflux:
   cachi2:
-    enabled: false # vendor chages to be fixed upstream
     lockfile:
       rpms:
       - openshift-prometheus-promu

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -27,6 +27,3 @@ name: openshift/ose-hypershift-rhel9
 payload_name: hypershift
 owners:
 - hypershift-team@redhat.com
-konflux:
-  cachi2:
-    enabled: false

--- a/images/ibm-vpc-node-label-updater.yml
+++ b/images/ibm-vpc-node-label-updater.yml
@@ -36,7 +36,3 @@ name: openshift/ose-ibm-vpc-node-label-updater-rhel9
 payload_name: ibm-vpc-node-label-updater
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -30,5 +30,3 @@ name: openshift/ose-ironic-machine-os-downloader-rhel9
 payload_name: ironic-machine-os-downloader
 owners:
 - ironic-osp-owners@redhat.com
-konflux:
-  network_mode: open

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -30,5 +30,3 @@ name: openshift/ose-kube-proxy-rhel9
 payload_name: kube-proxy
 owners:
 - aos-networking-staff@redhat.com
-konflux:
-  network_mode: open

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -36,5 +36,3 @@ name: openshift/ose-ptp-rhel9
 name_in_bundle: ptp
 owners:
 - multus-dev@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -60,4 +60,3 @@ konflux:
   content:
     source:
       dockerfile: Dockerfile.rhel
-  network_mode: open

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -33,6 +33,3 @@ payload_name: ibmcloud-cluster-api-controllers
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -30,5 +30,3 @@ name: openshift/ovirt-csi-driver-rhel9
 payload_name: ovirt-csi-driver
 owners:
 - rgolan@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -32,5 +32,3 @@ name: openshift/ose-sdn-rhel9
 payload_name: sdn
 owners:
 - aos-networking-staff@redhat.com
-konflux:
-  network_mode: open


### PR DESCRIPTION
* [golang-github-prometheus-alertmanager](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-golang-github-prometheus-alertmanager-d7gk4) -> needs an open build 
* [hypershift](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-hypershift-zlqwp)
* [ibm-vpc-node-label-updater](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-ibm-vpc-node-label-updater-xf88k)
* [ironic-rhcos-downloader](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-ironic-rhcos-downloader-dllg5)
* [kube-proxy](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-kube-proxy-ps4pg)
* [linuxptp-daemon](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-linuxptp-daemon-csn55)
* [ose-etcd](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-ose-etcd-nl256)
* [ose-ibmcloud-cluster-api-controllers](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-ose-ibmcloud-cluster-api-controllers-nxvvj)
* [ose-ovirt-csi-driver](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-ose-ovirt-csi-driver-df284)
* [ose-sdn](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-ose-sdn-86rg5)
