### PR TITLE
hermetic 4.14

### DIFF
--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -27,7 +27,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-csi-driver-manila-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: csi-driver-manila

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -20,9 +20,6 @@ from:
 name: openshift/ose-hypershift-rhel8
 owners:
 - hypershift-team@redhat.com
-konflux:
-  cachi2:
-    enabled: false
 delivery:
   delivery_repo_names:
   - openshift4/ose-hypershift-rhel8

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -23,8 +23,6 @@ from:
 name: openshift/ose-ironic-machine-os-downloader-rhel9
 owners:
 - ironic-osp-owners@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-ironic-machine-os-downloader-rhel9

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -21,8 +21,6 @@ from:
 name: openshift/ose-kube-proxy
 owners:
 - aos-networking-staff@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-kube-proxy

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -31,8 +31,6 @@ name: openshift/ose-ptp-rhel9
 name_in_bundle: ptp
 owners:
 - multus-dev@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-ptp-rhel9

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -53,7 +53,6 @@ konflux:
   content:
     source:
       dockerfile: Dockerfile.rhel
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-etcd-rhel9

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -27,7 +27,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibmcloud-cluster-api-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: ibmcloud-cluster-api-controllers

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -26,6 +26,3 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/metallb-rhel9
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -33,7 +33,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-openstack-cloud-controller-manager-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: openstack-cloud-controller-manager

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -21,8 +21,6 @@ from:
 name: openshift/ovirt-csi-driver-rhel8
 owners:
 - rgolan@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ovirt-csi-driver-rhel8


### PR DESCRIPTION
* [csi-driver-manila](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-csi-driver-manila-79tjp)
* [hypershift](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-hypershift-fmpv5)
* [ironic-rhcos-downloader](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ironic-rhcos-downloader-8qx4c)
* [kube-proxy](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-kube-proxy-8vdfg)
* [linuxptp-daemon](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-linuxptp-daemon-5dqhr)
* [ose-etcd](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-etcd-6kv9x)
* [ose-ibmcloud-cluster-api-controllers](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-ibmcloud-cluster-api-controllers-n9kkr)
* [ose-metallb](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-metallb-jch9z/)
* [ose-openstack-cloud-controller-manager](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-openstack-cloud-controller-manager-ch8fs)
* [ose-ovirt-csi-driver](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-ovirt-csi-driver-kxqkx)

