### PR TITLE
[openshift-4.20] ose-gcp-cloud-controller-manager hermetic

### DIFF
--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -32,6 +32,3 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
-konflux:
-  cachi2:
-    enabled: false


### PR DESCRIPTION
follows https://github.com/openshift/cloud-provider-gcp/pull/97

[hermetic build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-20/pipelineruns/ose-4-20-ose-gcp-cloud-controller-manager-mnsdn/)