### PR TITLE
(4.22)[images]: convert networking-console-plugin to hermetic build

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -1,5 +1,3 @@
-cachito:
-  enabled: true
 content:
   source:
     dockerfile: Dockerfile.art
@@ -8,12 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/networking-console-plugin.git
       web: https://github.com/openshift/networking-console-plugin
-    modifications:
-    - action: replace
-      match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
-      replacement: |-
-        COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/.npmrc
     pkg_managers:
     - npm
 distgit:
@@ -41,9 +33,10 @@ payload_name: networking-console-plugin
 konflux:
   vm_override:
     aarch64: linux-d160-c4xlarge/arm64
-  cachito:
-    mode: emulation
-  network_mode: open # Bunch of yarn dependencies, not sure how to fix
+  cachi2:
+    lockfile:
+      modules:
+      - nginx:1.26
 okd:
   content:
     source:


### PR DESCRIPTION
Remove legacy cachito configuration and content modifications. Switch from network_mode open to hermetic build with cachi2 lockfile.

- Remove cachito enabled flag and dockerfile modifications
- Replace cachito emulation mode with cachi2 lockfile for nginx
- Remove network_mode open override to use default hermetic mode
- Add url_pull for fork integration

/hold for upstream PR https://github.com/openshift/networking-console-plugin/pull/357