### PR TITLE
(5.0)[images]: convert networking-console-plugin to hermetic build

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -1,5 +1,3 @@
-cachito:
-  enabled: true
 content:
   source:
     dockerfile: Dockerfile.art
@@ -8,12 +6,6 @@ content:
         target: release-4.22
       url: git@github.com:openshift-priv/networking-console-plugin.git
       web: https://github.com/openshift/networking-console-plugin
-    modifications:
-    - action: replace
-      match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
-      replacement: |-
-        COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/.npmrc
     pkg_managers:
     - npm
     okd_alignment:
@@ -43,6 +35,7 @@ payload_name: networking-console-plugin
 konflux:
   vm_override:
     aarch64: linux-d160-c4xlarge/arm64
-  cachito:
-    mode: emulation
-  network_mode: open # Bunch of yarn dependencies, not sure how to fix
+  cachi2:
+    lockfile:
+      modules:
+      - nginx:1.24


### PR DESCRIPTION
Remove legacy cachito configuration and content modifications to enable default hermetic build mode for networking-console-plugin. This allows the image to use Konflux's hermetic build capabilities instead of requiring open network access during build time.

The manual remote sources handling in content.source.modifications is no longer needed as hermetic builds handle dependency management through cachi2.

Based on hermetic/22-networking-console-plugin but using nginx:1.24