### PR TITLE
hermetic 4.13

### DIFF
--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -27,7 +27,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-csi-driver-manila-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: csi-driver-manila

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -23,8 +23,6 @@ from:
 name: openshift/ose-ironic-machine-os-downloader-rhel9
 owners:
 - ironic-osp-owners@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-ironic-machine-os-downloader-rhel9

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -21,8 +21,6 @@ from:
 name: openshift/ose-kube-proxy
 owners:
 - aos-networking-staff@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-kube-proxy

--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -41,7 +41,10 @@ owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - python36:3.6
 delivery:
   delivery_repo_names:
   - openshift4/ose-kuryr-cni-rhel8

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -35,7 +35,10 @@ owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - python36:3.6
 delivery:
   delivery_repo_names:
   - openshift4/ose-kuryr-controller-rhel8

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -29,8 +29,6 @@ from:
 name: openshift/ose-ptp
 owners:
 - multus-dev@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-ptp

--- a/images/openshift-base-nodejs.yml
+++ b/images/openshift-base-nodejs.yml
@@ -41,5 +41,3 @@ labels:
 name: openshift/base-nodejs
 owners:
 - aos-team-art@redhat.com
-konflux:
-  network_mode: open

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -27,8 +27,6 @@ owners:
 - aos-operator-sdk@redhat.com
 - jlanford@redhat.com
 - fabian@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-ansible-operator

--- a/images/openshift-enterprise-base.yml
+++ b/images/openshift-enterprise-base.yml
@@ -57,6 +57,7 @@ name: openshift/ose-base
 owners:
 - lmeyer@redhat.com
 konflux:
-  # due to lacking logic to provide modules or having a base image that doesnt require modules
-  # https://issues.redhat.com/browse/ART-14111
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - python36:3.6

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -21,7 +21,11 @@ name: openshift/ose-egress-http-proxy
 owners:
 - aos-network-edge@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - perl
+      - squid
 delivery:
   delivery_repo_names:
   - openshift4/ose-egress-http-proxy

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -53,7 +53,6 @@ konflux:
   content:
     source:
       dockerfile: Dockerfile.rhel
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-etcd-rhel9

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -27,7 +27,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibmcloud-cluster-api-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: ibmcloud-cluster-api-controllers

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -33,7 +33,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-openstack-cloud-controller-manager-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: openstack-cloud-controller-manager

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -21,8 +21,6 @@ from:
 name: openshift/ovirt-csi-driver-rhel8
 owners:
 - rgolan@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ovirt-csi-driver-rhel8

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -43,10 +43,6 @@ labels:
 name: openshift/ose-ovn-kubernetes-rhel9
 owners:
 - aos-networking-staff@redhat.com
-konflux:
-  cachi2:
-    enabled: false
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-ovn-kubernetes

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -27,7 +27,10 @@ name: openshift/ose-sdn-rhel8
 owners:
 - aos-networking-staff@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - container-tools
 delivery:
   delivery_repo_names:
   - openshift4/ose-sdn-rhel8


### PR DESCRIPTION
  - [csi-driver-manila](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-csi-driver-manila-44z8x)
  - [ironic-rhcos-downloader](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ironic-rhcos-downloader-q6xj9)
  - [kube-proxy](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-kube-proxy-tdncr)
  - [kuryr-cni](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-kuryr-cni-jp8z7)
  - [kuryr-controller](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-kuryr-controller-sz82q)
  - [linuxptp-daemon](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-linuxptp-daemon-t2bfd)
  - [openshift-base-nodejs](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-openshift-base-nodejs-sjtpz/)
  - [openshift-enterprise-ansible-operator](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-openshift-enterprise-ansible-operator-vffs6)
  - [openshift-enterprise-base](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-openshift-enterprise-base-hrbhx)
  - [ose-egress-http-proxy](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-egress-http-proxy-tlgz4)
  - [ose-etcd](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-etcd-k4928)
  - [ose-ibmcloud-cluster-api-controllers](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-ibmcloud-cluster-api-controllers-sd8kv)
  - [ose-openstack-cloud-controller-manager](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-openstack-cloud-controller-manager-stq5s)
  - [ose-ovirt-csi-driver](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-ovirt-csi-driver-vvtqk)
  - [ose-ovn-kubernetes](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-ovn-kubernetes-5j4hg)
  - [ose-sdn](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-sdn-87nmv)
