### PR TITLE
MIG-1868: mtc-1.8: extend support back to OCP 4.12

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,7 +1,7 @@
 name: mtc-1.8
 csv_namespace: rhmtc
 product: rhmtc
-version: 1.8.13
+version: 1.8.14
 
 vars:
   # The go versions used by the various CI builder images.
@@ -36,6 +36,8 @@ konflux:
 
 # OCP versions to publish FBC builds to
 OCP_TARGET_VERSIONS: [
+  "4.12",
+  "4.13",
   "4.14",
   "4.15",
   "4.16",


### PR DESCRIPTION
Extend OCP_TARGET_VERSIONS for MTC 1.8 release to OCP v4.12 in light of team's decision to support that according to selection of ITN_2026_00040_3A and Slack conversation reinforcing this direction.

 - [MIG_1868](https://issues.redhat.com/browse/MIG-1868)
 - [Slack thread](https://redhat-internal.slack.com/archives/CKRUT8WQ3/p1772131210032279)