### PR TITLE
ART-14644: Bring down SMB CSI driver operator to 4.16

### DIFF
--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -7,6 +7,9 @@ content:
         target: release-4.18
       url: git@github.com:openshift-priv/csi-livenessprobe.git
       web: https://github.com/openshift/csi-livenessprobe
+    ci_alignment:
+      stream_prs:
+        enabled: false
 dependents:
 - ose-smb-csi-driver-operator
 distgit:

--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -26,7 +26,7 @@ labels:
   io.k8s.description: Liveness probe for CSI drivers
   io.k8s.display-name: Liveness probe for CSI drivers
   io.openshift.tags: csi,storage,probe
-name: openshift/ose-csi-livenessprobe-rhel9
+name: openshift/ose-csi-livenessprobe-4.18-rhel9
 name_in_bundle: csi-livenessprobe-4.18
 owners:
 - aos-storage-staff@redhat.com

--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -8,7 +8,7 @@ content:
       url: git@github.com:openshift-priv/csi-livenessprobe.git
       web: https://github.com/openshift/csi-livenessprobe
     ci_alignment:
-      stream_prs:
+      streams_prs:
         enabled: false
 dependents:
 - ose-smb-csi-driver-operator

--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -24,6 +24,6 @@ labels:
   io.k8s.display-name: Liveness probe for CSI drivers
   io.openshift.tags: csi,storage,probe
 name: openshift/ose-csi-livenessprobe-rhel9
-name_in_bundle: csi-livenessprobe
+name_in_bundle: csi-livenessprobe-4.18
 owners:
 - aos-storage-staff@redhat.com

--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -14,7 +14,7 @@ dependents:
 - ose-smb-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
-  component: csi-livenessprobe-container
+  component: csi-livenessprobe-4.18-container
 for_payload: false
 for_release: false
 from:

--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -16,7 +16,7 @@ for_payload: false
 for_release: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.22
   member: openshift-enterprise-base-rhel9
 labels:
   License: ASL 2.0

--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -1,0 +1,29 @@
+base_only: true
+content:
+  source:
+    dockerfile: Dockerfile.ocp
+    git:
+      branch:
+        target: release-4.18
+      url: git@github.com:openshift-priv/csi-livenessprobe.git
+      web: https://github.com/openshift/csi-livenessprobe
+dependents:
+- ose-smb-csi-driver-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: csi-livenessprobe-container
+for_payload: false
+for_release: false
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+labels:
+  License: ASL 2.0
+  io.k8s.description: Liveness probe for CSI drivers
+  io.k8s.display-name: Liveness probe for CSI drivers
+  io.openshift.tags: csi,storage,probe
+name: openshift/ose-csi-livenessprobe-rhel9
+name_in_bundle: csi-livenessprobe
+owners:
+- aos-storage-staff@redhat.com

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -18,7 +18,6 @@ dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator
 - ose-secrets-store-csi-driver-operator
-- ose-smb-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-livenessprobe-container

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -19,6 +19,6 @@ from:
   - stream: rhel-9-golang-1.22
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-csi-node-driver-registrar-rhel9
-name_in_bundle: csi-node-driver-registrar
+name_in_bundle: csi-node-driver-registrar-4.18
 owners:
 - aos-storage-staff@redhat.com

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -14,7 +14,7 @@ dependents:
 - ose-smb-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
-  component: csi-node-driver-registrar-container
+  component: csi-node-driver-registrar-4.18-container
 for_payload: false
 for_release: false
 from:

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -16,7 +16,7 @@ for_payload: false
 for_release: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.22
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-csi-node-driver-registrar-rhel9
 name_in_bundle: csi-node-driver-registrar

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -7,6 +7,9 @@ content:
         target: release-4.18
       url: git@github.com:openshift-priv/csi-node-driver-registrar.git
       web: https://github.com/openshift/csi-node-driver-registrar
+    ci_alignment:
+      stream_prs:
+        enabled: false
 dependents:
 - ose-smb-csi-driver-operator
 distgit:

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -21,7 +21,7 @@ from:
   builder:
   - stream: rhel-9-golang-1.22
   member: openshift-enterprise-base-rhel9
-name: openshift/ose-csi-node-driver-registrar-rhel9
+name: openshift/ose-csi-node-driver-registrar-4.18-rhel9
 name_in_bundle: csi-node-driver-registrar-4.18
 owners:
 - aos-storage-staff@redhat.com

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -8,7 +8,7 @@ content:
       url: git@github.com:openshift-priv/csi-node-driver-registrar.git
       web: https://github.com/openshift/csi-node-driver-registrar
     ci_alignment:
-      stream_prs:
+      streams_prs:
         enabled: false
 dependents:
 - ose-smb-csi-driver-operator

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -1,0 +1,24 @@
+base_only: true
+content:
+  source:
+    dockerfile: Dockerfile.openshift
+    git:
+      branch:
+        target: release-4.18
+      url: git@github.com:openshift-priv/csi-node-driver-registrar.git
+      web: https://github.com/openshift/csi-node-driver-registrar
+dependents:
+- ose-smb-csi-driver-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: csi-node-driver-registrar-container
+for_payload: false
+for_release: false
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-csi-node-driver-registrar-rhel9
+name_in_bundle: csi-node-driver-registrar
+owners:
+- aos-storage-staff@redhat.com

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -18,7 +18,6 @@ dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator
 - ose-secrets-store-csi-driver-operator
-- ose-smb-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-node-driver-registrar-container

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -8,7 +8,7 @@ content:
       url: git@github.com:openshift-priv/csi-external-provisioner.git
       web: https://github.com/openshift/csi-external-provisioner
     ci_alignment:
-      stream_prs:
+      streams_prs:
         enabled: false
 dependents:
 - ose-smb-csi-driver-operator

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -24,6 +24,6 @@ labels:
   io.k8s.display-name: External provisioner for CSI volumes
   io.openshift.tags: csi,storage,provisioner
 name: openshift/ose-csi-external-provisioner-rhel9
-name_in_bundle: csi-external-provisioner
+name_in_bundle: csi-external-provisioner-4.18
 owners:
 - aos-storage-staff@redhat.com

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -7,6 +7,9 @@ content:
         target: release-4.18
       url: git@github.com:openshift-priv/csi-external-provisioner.git
       web: https://github.com/openshift/csi-external-provisioner
+    ci_alignment:
+      stream_prs:
+        enabled: false
 dependents:
 - ose-smb-csi-driver-operator
 distgit:

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -26,7 +26,7 @@ labels:
   io.k8s.description: External provisioner for CSI volumes
   io.k8s.display-name: External provisioner for CSI volumes
   io.openshift.tags: csi,storage,provisioner
-name: openshift/ose-csi-external-provisioner-rhel9
+name: openshift/ose-csi-external-provisioner-4.18-rhel9
 name_in_bundle: csi-external-provisioner-4.18
 owners:
 - aos-storage-staff@redhat.com

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -14,7 +14,7 @@ dependents:
 - ose-smb-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
-  component: csi-provisioner-container
+  component: csi-provisioner-4.18-container
 for_payload: false
 for_release: false
 from:

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -1,31 +1,19 @@
+base_only: true
 content:
   source:
     dockerfile: Dockerfile.openshift.rhel7
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: release-4.18
       url: git@github.com:openshift-priv/csi-external-provisioner.git
       web: https://github.com/openshift/csi-external-provisioner
-    ci_alignment:
-      streams_prs:
-        commit_prefix: "UPSTREAM: <carry>: "
-        ci_build_root:
-          stream: rhel-9-golang-ci-build-root
-        auto_label:
-        - approved
-        - lgtm
 dependents:
-- ose-aws-efs-csi-driver-operator
-- ose-gcp-filestore-csi-driver-operator
+- ose-smb-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-provisioner-container
-delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-external-provisioner
-  delivery_repo_names:
-  - openshift4/ose-csi-external-provisioner-rhel9
-for_payload: true
+for_payload: false
+for_release: false
 from:
   builder:
   - stream: rhel-9-golang
@@ -36,7 +24,6 @@ labels:
   io.k8s.display-name: External provisioner for CSI volumes
   io.openshift.tags: csi,storage,provisioner
 name: openshift/ose-csi-external-provisioner-rhel9
-payload_name: csi-external-provisioner
 name_in_bundle: csi-external-provisioner
 owners:
 - aos-storage-staff@redhat.com

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -16,7 +16,7 @@ for_payload: false
 for_release: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.22
   member: openshift-enterprise-base-rhel9
 labels:
   License: ASL 2.0

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -5,7 +5,6 @@ content:
       branch:
         target: release-4.18
       url: git@github.com:openshift-priv/csi-operator.git
-      url_pull: git@github.com:adobes1/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:
       streams_prs:

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -5,6 +5,7 @@ content:
       branch:
         target: release-4.18
       url: git@github.com:openshift-priv/csi-operator.git
+      url_pull: git@github.com:adobes1/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:
       streams_prs:

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -20,14 +20,14 @@ distgit:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.22
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-smb-csi-driver-rhel9-operator
 name_in_bundle: smb-csi-driver-rhel9-operator
 owners:
 - aos-storage-staff@redhat.com
 update-csv:
-  bundle-dir: preview
+  bundle-dir: stable
   manifests-dir: config/samba/manifests/
   registry: image-registry.openshift-imageregistry.svc:5000
   valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.samba
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: release-4.18
       url: git@github.com:openshift-priv/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -6,6 +6,9 @@ content:
         target: release-4.18
       url: git@github.com:openshift-priv/csi-driver-smb.git
       web: https://github.com/openshift/csi-driver-smb
+    ci_alignment:
+      stream_prs:
+        enabled: false
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-smb-csi-driver-container

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -6,14 +6,6 @@ content:
         target: release-4.18
       url: git@github.com:openshift-priv/csi-driver-smb.git
       web: https://github.com/openshift/csi-driver-smb
-    ci_alignment:
-      streams_prs:
-        commit_prefix: "UPSTREAM: <carry>: "
-        ci_build_root:
-          stream: rhel-9-golang-ci-build-root
-        auto_label:
-        - approved
-        - lgtm
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-smb-csi-driver-container
@@ -30,7 +22,7 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.22
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-smb-csi-driver-rhel9
 name_in_bundle: smb-csi-driver-container-rhel9

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: release-4.18
       url: git@github.com:openshift-priv/csi-driver-smb.git
       web: https://github.com/openshift/csi-driver-smb
     ci_alignment:

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -7,7 +7,7 @@ content:
       url: git@github.com:openshift-priv/csi-driver-smb.git
       web: https://github.com/openshift/csi-driver-smb
     ci_alignment:
-      stream_prs:
+      streams_prs:
         enabled: false
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9

--- a/streams.yml
+++ b/streams.yml
@@ -43,6 +43,11 @@ rhel-9-golang:
   upstream_image_mirror:
     - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
 
+rhel-9-golang-1.22:
+  aliases:
+    - rhel-9-golang-1.22
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.22.12-202602241847.p2.g388ceb2.el9
+
 rhel-9-golang-1.23:
   aliases:
     - rhel-9-golang-{GO_EXTRA}


### PR DESCRIPTION
## Summary
This addresses the OLM catalog incident where OCP 4.18 operator versions were mistakenly pushed to clusters running 4.12-4.17. Per ART remediation plan, bringing down SMB CSI operator to support 4.18 content on 4.16.

### Changes Made
**Main SMB CSI components (target: release-4.18):**
- `ose-smb-csi-driver-operator.yml`
- `ose-smb-csi-driver.yml`

**Updated shared CSI components (target: release-{MAJOR}.{MINOR}):**
- `csi-livenessprobe.yml` - removed `ose-smb-csi-driver-operator` from dependents
- `csi-provisioner.yml` - removed `ose-smb-csi-driver-operator` from dependents  
- `csi-node-driver-registrar.yml` - removed `ose-smb-csi-driver-operator` from dependents

**New 4.18-specific variants (base_only, for_release: false, target: release-4.18):**
- `csi-livenessprobe-4.18.yml` - minimal, SMB CSI dependent only
- `csi-provisioner-4.18.yml` - minimal, SMB CSI dependent only
- `csi-node-driver-registrar-4.18.yml` - minimal, SMB CSI dependent only

This ensures SMB CSI gets proper 4.18 builds while maintaining clean separation from existing 4.16 components used by other operators.