### PR TITLE
hermetic 4.12

### DIFF
--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -28,7 +28,11 @@ name: openshift/ose-prometheus-node-exporter
 owners:
 - team-monitoring@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      rpms:
+      - openshift-prometheus-promu
+      - prometheus-promu
 delivery:
   delivery_repo_names:
   - openshift4/ose-prometheus-node-exporter

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -28,7 +28,11 @@ name: openshift/ose-prometheus
 owners:
 - team-monitoring@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      rpms:
+      - prometheus-promu
+      - openshift-prometheus-promu
 delivery:
   delivery_repo_names:
   - openshift4/ose-prometheus

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -33,7 +33,11 @@ name: openshift/ose-pod
 owners:
 - aos-pod@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      rpms:
+      - glibc-static
+      - libxcrypt-static
 delivery:
   delivery_repo_names:
   - openshift4/ose-pod

--- a/images/openshift-enterprise-service-idler.yml
+++ b/images/openshift-enterprise-service-idler.yml
@@ -28,5 +28,3 @@ labels:
 name: openshift/ose-service-idler
 owners:
 - anbhat@redhat.com
-konflux:
-  network_mode: open

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -23,7 +23,10 @@ name: openshift/network-tools-rhel8
 owners:
 - aos-networking-staff@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - nginx:1.20
 delivery:
   delivery_repo_names:
   - openshift4/network-tools-rhel8

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -23,7 +23,11 @@ name: openshift/ose-prom-label-proxy
 owners:
 - team-monitoring@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      rpms:
+      - openshift-prometheus-promu
+      - prometheus-promu
 delivery:
   delivery_repo_names:
   - openshift4/ose-prom-label-proxy

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -25,7 +25,11 @@ name: openshift/ose-thanos-rhel8
 owners:
 - team-monitoring@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      rpms:
+      - openshift-prometheus-promu
+      - prometheus-promu
 delivery:
   delivery_repo_names:
   - openshift4/ose-thanos-rhel8


### PR DESCRIPTION
* [golang-github-prometheus-node_exporter](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-golang-github-prometheus-node-exporter-fc98j)
* [golang-github-prometheus-prometheus](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-golang-github-prometheus-prometheus-kz94v)
* [openshift-enterprise-pod](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-openshift-enterprise-pod-9hbvt/)
* [ose-network-tools](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-network-tools-4v4hv)
* [prom-label-proxy](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-prom-label-proxy-bwc2j)
* [thanos](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-thanos-6kvbs)

openshift-enterprise-service-idler is disabled
