### PR TITLE
hermetic 4.14

### DIFF
--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -41,7 +41,10 @@ owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - python36:3.6
 delivery:
   delivery_repo_names:
   - openshift4/ose-kuryr-cni-rhel8

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -35,7 +35,10 @@ owners:
 - kuryr-team@redhat.com
 - mdulko@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - python36:3.6
 delivery:
   delivery_repo_names:
   - openshift4/ose-kuryr-controller-rhel8

--- a/images/openshift-base-nodejs.yml
+++ b/images/openshift-base-nodejs.yml
@@ -36,4 +36,7 @@ name: openshift/base-nodejs
 owners:
 - aos-team-art@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - python36:3.6

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -27,8 +27,6 @@ owners:
 - aos-operator-sdk@redhat.com
 - jlanford@redhat.com
 - fabian@redhat.com
-konflux:
-  network_mode: open
 delivery:
   delivery_repo_names:
   - openshift4/ose-ansible-operator

--- a/images/openshift-enterprise-base.yml
+++ b/images/openshift-enterprise-base.yml
@@ -57,6 +57,7 @@ name: openshift/ose-base
 owners:
 - lmeyer@redhat.com
 konflux:
-  # due to lacking logic to provide modules or having a base image that doesnt require modules
-  # https://issues.redhat.com/browse/ART-14111
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - python36:3.6

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -21,7 +21,11 @@ name: openshift/ose-egress-http-proxy
 owners:
 - aos-network-edge@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - perl
+      - squid
 delivery:
   delivery_repo_names:
   - openshift4/ose-egress-http-proxy

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -23,7 +23,10 @@ name: openshift/network-tools-rhel8
 owners:
 - aos-networking-staff@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - nginx:1.20
 delivery:
   delivery_repo_names:
   - openshift4/network-tools-rhel8

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -27,7 +27,10 @@ name: openshift/ose-sdn-rhel8
 owners:
 - aos-networking-staff@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      modules:
+      - container-tools
 delivery:
   delivery_repo_names:
   - openshift4/ose-sdn-rhel8


### PR DESCRIPTION
* [kuryr-cni](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-kuryr-cni-l8pf4/)
* [kuryr-controller](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-kuryr-controller-7bc5k/)
* [openshift-base-nodejs](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-openshift-base-nodejs-hffvb/)
* [openshift-enterprise-ansible-operator](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-openshift-enterprise-ansible-operator-ljc49)
* [openshift-enterprise-base](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-openshift-enterprise-base-st9pd/)
* [ose-egress-http-proxy](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-egress-http-proxy-w8wz7)
* [ose-network-tools](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-network-tools-jpr28/)
* [ose-sdn](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-sdn-b6ngp)
