### PR TITLE
hermetic 4.16

### DIFF
--- a/images/openshift-enterprise-base.yml
+++ b/images/openshift-enterprise-base.yml
@@ -65,7 +65,3 @@ labels:
 name: openshift/ose-base
 owners:
 - lmeyer@redhat.com
-konflux:
-  # due to lacking logic to provide modules or having a base image that doesnt require modules
-  # https://issues.redhat.com/browse/ART-14111
-  network_mode: open

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -44,7 +44,3 @@ owners:
 - jkyros@redhat.com
 - skumari@redhat.com
 - zzlotnik@redhat.com
-konflux:
-  network_mode: open # The content of the vendor directory is not consistent with go.mod
-  cachi2:
-    enabled: false


### PR DESCRIPTION
[ose-machine-config-operator](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-machine-config-operator-c7cvn/)

openshift-enterprise-base is disabled