### PR TITLE
Revert "microshift-bootc hermetic"

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -36,5 +36,10 @@ name: openshift/microshift-bootc-rhel9
 owners:
 - microshift-devel@redhat.com
 konflux:
+  network_mode: open
+  cachi2:
+    # For them, vendor modifications are necessary
+    # https://redhat-internal.slack.com/archives/C06Q309QUDV/p1745508906683839
+    enabled: false
   sast:
     enabled: true


### PR DESCRIPTION
This reverts commit 7830d1ca86d1267fd81b00a353ef01fa88a49c71.

[failing build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-microshift-bootc-mltsj/)