### PR TITLE
Switch from dist/9.6 to e4s/9.6 and eus/9.6 where applicable

### DIFF
--- a/repos/rhel-9-appstream-rpms.yml
+++ b/repos/rhel-9-appstream-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
     ci_alignment:
       localdev:
         enabled: true

--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
     ci_alignment:
       localdev:
         enabled: true

--- a/repos/rhel-9-codeready-builder-rpms.yml
+++ b/repos/rhel-9-codeready-builder-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/codeready-builder/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/ppc64le/codeready-builder/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/s390x/codeready-builder/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/x86_64/codeready-builder/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/codeready-builder/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/codeready-builder/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/codeready-builder/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/codeready-builder/os/
     ci_alignment:
       localdev:
         enabled: true


### PR DESCRIPTION
Since 9.7 went GA dist/9.6 is no longer updated. Then all repos with e4s should use it, however codeready lacks e4s where we'll use eus instad. Using e4s ensures that we don't have to come back and move those forward when eus comes to an end in a few years.