### PR TITLE
coredns hermetic 4.16

### DIFF
--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -27,6 +27,3 @@ name: openshift/ose-coredns-rhel9
 payload_name: coredns
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/coredns/pull/168

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-coredns-s5kp4)