### PR TITLE
ART-14594: OKD to centos 10

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -52,6 +52,7 @@ konflux:
   network_mode: open
 
 okd:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-10
   konflux:
     build_priority: 8
     cachi2:


### PR DESCRIPTION
This will fix the okd 5.0 nvrs by using the `scos10` suffix.