### PR TITLE
(4.22)[hermetic]: convert monitoring-plugin to hermetic build

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -13,12 +13,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/monitoring-plugin.git
       web: https://github.com/openshift/monitoring-plugin
-    modifications:
-    - action: replace
-      match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
-      replacement: |-
-        COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/.npmrc
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -49,7 +43,6 @@ owners:
 konflux:
   cachito:
     mode: emulation
-  network_mode: open
 okd:
   content:
     source:


### PR DESCRIPTION
## Summary
Convert monitoring-plugin to hermetic build

## Changes
Remove network_mode: open override and source modifications to enable hermetic builds for monitoring-plugin. This allows the image to use the default hermetic network mode from group.yml configuration.

## Test Results
- Jenkins: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/27723/console
- Konflux: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-monitoring-plugin-xncs6/logs?task=build-images

/hold waiting for upstream PR https://github.com/openshift/monitoring-plugin/pull/799