### PR TITLE
[release-4.17] Enable cachi2 for ose-metallb

### DIFF
--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -29,6 +29,3 @@ name: openshift/metallb-rhel9
 name_in_bundle: metallb-rhel9
 owners:
 - metallb-dev@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
[Test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/27728/)