### PR TITLE
(4.23)[hermetic]: enable hermetic builds for node-feature-discovery

### DIFF
--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -29,8 +29,3 @@ name: openshift/ose-node-feature-discovery-rhel9
 name_in_bundle: node-feature-discovery
 owners:
 - edge-kmm@redhat.com
-konflux:
-  # New issue, need to investigate
-  cachi2:
-    enabled: false
-  network_mode: open


### PR DESCRIPTION
## Summary
Enable hermetic builds for node-feature-discovery by removing network_mode override

## Problem  
**Before:** node-feature-discovery uses network_mode: open, preventing hermetic builds
**After:** Uses default hermetic mode from group.yml for improved build security

/hold waiting on upstream pr https://github.com/openshift/node-feature-discovery/pull/163