### PR TITLE
(4.19)[hermetic]: enable hermetic builds for node-feature-discovery

### DIFF
--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -29,8 +29,3 @@ name: openshift/ose-node-feature-discovery-rhel9
 name_in_bundle: node-feature-discovery
 owners:
 - edge-kmm@redhat.com
-konflux:
-  # New issue, need to investigate
-  cachi2:
-    enabled: false
-  network_mode: open


### PR DESCRIPTION
Remove konflux network_mode override to use default hermetic mode from group.yml. This enables hermetic builds for node-feature-discovery across all architectures.