### PR TITLE
[openshift-4.21](hermetic): migrate monitoring-plugin

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -13,12 +13,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/monitoring-plugin.git
       web: https://github.com/openshift/monitoring-plugin
-    modifications:
-    - action: replace
-      match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
-      replacement: |-
-        COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/.npmrc
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -47,7 +41,6 @@ owners:
 konflux:
   cachito:
     mode: emulation
-  network_mode: open
   vm_override:
     aarch64: linux-d160-m2xlarge/arm64
 okd:


### PR DESCRIPTION
[Jenkins job](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/27801/)
[Konflux build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-21/pipelineruns/ose-4-21-monitoring-plugin-brt85)

/approve
/hold for [upstream PR](https://github.com/openshift/monitoring-plugin/pull/808)