### PR TITLE
Switch to 5.0 branches

### DIFF
--- a/images/agent-installer-ui.yml
+++ b/images/agent-installer-ui.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: apps/assisted-disconnected-ui/Containerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/assisted-installer-ui.git
       web: https://github.com/openshift-assisted/assisted-installer-ui
     modifications:

--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/cluster-autoscaler/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes-autoscaler.git
       web: https://github.com/openshift/kubernetes-autoscaler
     ci_alignment:

--- a/images/aws-karpenter-provider-aws.yml
+++ b/images/aws-karpenter-provider-aws.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift/Containerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/aws-karpenter-provider-aws.git
       web: https://github.com/openshift/aws-karpenter-provider-aws
     ci_alignment:

--- a/images/aws-kms-encryption-provider.yml
+++ b/images/aws-kms-encryption-provider.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/aws-encryption-provider.git
       web: https://github.com/openshift/aws-encryption-provider
     ci_alignment:

--- a/images/azure-file-csi-driver-operator.yml
+++ b/images/azure-file-csi-driver-operator.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.azure-file
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/azure-file-csi-driver.git
       web: https://github.com/openshift/azure-file-csi-driver
     ci_alignment:

--- a/images/azure-kms-encryption-provider.yml
+++ b/images/azure-kms-encryption-provider.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/azure-kubernetes-kms.git
       web: https://github.com/openshift/azure-kubernetes-kms
     ci_alignment:

--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-baremetal.git
       web: https://github.com/openshift/cluster-api-provider-baremetal
     ci_alignment:

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/baremetal-runtimecfg.git
       web: https://github.com/openshift/baremetal-runtimecfg
     ci_alignment:

--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -6,7 +6,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-event-proxy.git
       web: https://github.com/redhat-cne/cloud-event-proxy
     ci_alignment:

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-etcd-operator.git
       web: https://github.com/openshift/cluster-etcd-operator
     ci_alignment:

--- a/images/cluster-monitoring-operator.yml
+++ b/images/cluster-monitoring-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-monitoring-operator.git
       web: https://github.com/openshift/cluster-monitoring-operator
     path: ''

--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-network-operator.git
       web: https://github.com/openshift/cluster-network-operator
     ci_alignment:

--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-nfd-operator.git
       web: https://github.com/openshift/cluster-nfd-operator
     ci_alignment:

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel9
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-node-tuning-operator.git
       web: https://github.com/openshift/cluster-node-tuning-operator
     pkg_managers:

--- a/images/cluster-policy-controller.yml
+++ b/images/cluster-policy-controller.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-policy-controller.git
       web: https://github.com/openshift/cluster-policy-controller
     ci_alignment:

--- a/images/cluster-storage-operator.yml
+++ b/images/cluster-storage-operator.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-storage-operator.git
       web: https://github.com/openshift/cluster-storage-operator
     ci_alignment:

--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-version-operator.git
       web: https://github.com/openshift/cluster-version-operator
     ci_alignment:

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-resource-override-admission-operator.git
       web: https://github.com/openshift/cluster-resource-override-admission-operator
     ci_alignment:

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-resource-override-admission.git
       web: https://github.com/openshift/cluster-resource-override-admission
     ci_alignment:

--- a/images/configmap-reload.yml
+++ b/images/configmap-reload.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/configmap-reload.git
       web: https://github.com/openshift/configmap-reload
     path: ''

--- a/images/container-networking-plugins-microshift.yml
+++ b/images/container-networking-plugins-microshift.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.microshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/containernetworking-plugins.git
       web: https://github.com/openshift/containernetworking-plugins
     ci_alignment:

--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/coredns.git
       web: https://github.com/openshift/coredns
     ci_alignment:

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-external-attacher.git
       web: https://github.com/openshift/csi-external-attacher
     ci_alignment:

--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.openstack-manila
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: images/manila-csi-plugin/Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-openstack.git
       web: https://github.com/openshift/cloud-provider-openstack
     ci_alignment:

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: images/Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-driver-nfs.git
       web: https://github.com/openshift/csi-driver-nfs
     ci_alignment:

--- a/images/csi-external-snapshot-metadata.yml
+++ b/images/csi-external-snapshot-metadata.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-external-snapshot-metadata.git
       web: https://github.com/openshift/csi-external-snapshot-metadata
     ci_alignment:

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-livenessprobe.git
       web: https://github.com/openshift/csi-livenessprobe
     ci_alignment:

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-node-driver-registrar.git
       web: https://github.com/openshift/csi-node-driver-registrar
     ci_alignment:

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-external-provisioner.git
       web: https://github.com/openshift/csi-external-provisioner
     ci_alignment:

--- a/images/dpu-cni.yml
+++ b/images/dpu-cni.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.CNI.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:

--- a/images/dpu-daemon.yml
+++ b/images/dpu-daemon.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.daemon.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:

--- a/images/dpu-intel-ipu-p4sdk.yml
+++ b/images/dpu-intel-ipu-p4sdk.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.IntelP4.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:

--- a/images/dpu-intel-ipu-vsp.yml
+++ b/images/dpu-intel-ipu-vsp.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.IntelVSP.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:

--- a/images/dpu-intel-netsec-vsp.yml
+++ b/images/dpu-intel-netsec-vsp.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.IntelNetSecVSP.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:

--- a/images/dpu-marvell-cp-agent.yml
+++ b/images/dpu-marvell-cp-agent.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.mrvlCPAgent.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:

--- a/images/dpu-marvell-vsp.yml
+++ b/images/dpu-marvell-vsp.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.mrvlVSP.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:

--- a/images/dpu-network-resources-injector.yml
+++ b/images/dpu-network-resources-injector.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.networkResourcesInjector.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:

--- a/images/dpu-operator.yml
+++ b/images/dpu-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
     ci_alignment:

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -14,7 +14,7 @@ content:
     #   replacement: "ARG RT_KERNEL_VERSION='1.2.3'"
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/driver-toolkit.git
       web: https://github.com/openshift/driver-toolkit
 distgit:

--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/egress-router-cni.git
       web: https://github.com/openshift/egress-router-cni
     ci_alignment:

--- a/images/gcp-workload-identity-federation-webhook.yml
+++ b/images/gcp-workload-identity-federation-webhook.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/gcp-workload-identity-federation-webhook.git
       web: https://github.com/openshift/gcp-workload-identity-federation-webhook
     ci_alignment:

--- a/images/golang-github-openshift-oauth-proxy.yml
+++ b/images/golang-github-openshift-oauth-proxy.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oauth-proxy.git
       web: https://github.com/openshift/oauth-proxy
     ci_alignment:

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/prometheus-alertmanager.git
       web: https://github.com/openshift/prometheus-alertmanager
     ci_alignment:

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/node_exporter.git
       web: https://github.com/openshift/node_exporter
     ci_alignment:

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/prometheus.git
       web: https://github.com/openshift/prometheus
     ci_alignment:

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.control-plane
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/hypershift.git
       web: https://github.com/openshift/hypershift
     ci_alignment:

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ib-sriov-cni.git
       web: https://github.com/openshift/ib-sriov-cni
     ci_alignment:

--- a/images/ingress-node-firewall-daemon.yml
+++ b/images/ingress-node-firewall-daemon.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.daemon.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ingress-node-firewall.git
       web: https://github.com/openshift/ingress-node-firewall
     ci_alignment:

--- a/images/ingress-node-firewall-operator.yml
+++ b/images/ingress-node-firewall-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ingress-node-firewall.git
       web: https://github.com/openshift/ingress-node-firewall
     ci_alignment:

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ironic-agent-image.git
       web: https://github.com/openshift/ironic-agent-image
     pkg_managers:

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ironic-rhcos-downloader.git
       web: https://github.com/openshift/ironic-rhcos-downloader
     ci_alignment:

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ironic-static-ip-manager.git
       web: https://github.com/openshift/ironic-static-ip-manager
 distgit:

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ironic-image.git
       web: https://github.com/openshift/ironic-image
     pkg_managers:

--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kube-compare.git
       web: https://github.com/openshift/kube-compare
     ci_alignment:

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift-hack/images/kube-proxy/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes.git
       web: https://github.com/openshift/kubernetes
     ci_alignment:

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kube-rbac-proxy.git
       web: https://github.com/openshift/kube-rbac-proxy
     ci_alignment:

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kube-state-metrics.git
       web: https://github.com/openshift/kube-state-metrics
     path: ''

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: addons/redhat/Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/linuxptp-daemon.git
       web: https://github.com/openshift/linuxptp-daemon
     ci_alignment:

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.diskmaker.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/local-storage-operator.git
       web: https://github.com/openshift/local-storage-operator
     ci_alignment:

--- a/images/local-storage-mustgather.yml
+++ b/images/local-storage-mustgather.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.mustgather
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/local-storage-operator.git
       web: https://github.com/openshift/local-storage-operator
     ci_alignment:

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/local-storage-operator.git
       web: https://github.com/openshift/local-storage-operator
     ci_alignment:

--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/operator-marketplace.git
       web: https://github.com/operator-framework/operator-marketplace
     ci_alignment:

--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -15,7 +15,7 @@ content:
       replacement: "ARG BASE_IMAGE_TAG='9.6'"
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/microshift.git
       web: https://github.com/openshift/microshift
     ci_alignment:

--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -10,7 +10,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/monitoring-plugin.git
       web: https://github.com/openshift/monitoring-plugin
     ci_alignment:

--- a/images/multus-cni-container-microshift.yml
+++ b/images/multus-cni-container-microshift.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.microshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/multus-cni.git
       web: https://github.com/openshift/multus-cni
     ci_alignment:

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/multus-cni.git
       web: https://github.com/openshift/multus-cni
     ci_alignment:

--- a/images/multus-networkpolicy.yml
+++ b/images/multus-networkpolicy.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/multus-networkpolicy.git
       web: https://github.com/openshift/multus-networkpolicy
     ci_alignment:

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/networking-console-plugin.git
       web: https://github.com/openshift/networking-console-plugin
     pkg_managers:

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/nmstate-console-plugin.git
       web: https://github.com/openshift/nmstate-console-plugin
     ci_alignment:

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/node-feature-discovery.git
       web: https://github.com/openshift/node-feature-discovery
     ci_alignment:

--- a/images/oauth-server.yml
+++ b/images/oauth-server.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oauth-server.git
       web: https://github.com/openshift/oauth-server
     pkg_managers:

--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -9,7 +9,7 @@ content:
     dockerfile: images/cli/Dockerfile.art
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oc-mirror.git
       web: https://github.com/openshift/oc-mirror
     ci_alignment:

--- a/images/okd-only-upi-installer.yml
+++ b/images/okd-only-upi-installer.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: images/installer/Dockerfile.upi.ci
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/installer.git
       web: https://github.com/openshift/installer
     ci_alignment:

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift/Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ansible-operator-plugins.git
       web: https://github.com/openshift/ansible-operator-plugins
     ci_alignment:

--- a/images/openshift-enterprise-base-rhel9-minimal.yml
+++ b/images/openshift-enterprise-base-rhel9-minimal.yml
@@ -4,7 +4,7 @@ content:
     dockerfile: Dockerfile.rhel9
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/images.git
       web: https://github.com/openshift/images
     path: base

--- a/images/openshift-enterprise-base-rhel9.yml
+++ b/images/openshift-enterprise-base-rhel9.yml
@@ -4,7 +4,7 @@ content:
     dockerfile: Dockerfile.rhel9
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/images.git
       web: https://github.com/openshift/images
     path: base

--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel8
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/builder.git
       web: https://github.com/openshift/builder
     ci_alignment:

--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/cli/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oc.git
       web: https://github.com/openshift/oc
     ci_alignment:

--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/cluster-capacity/Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-capacity.git
       web: https://github.com/openshift/cluster-capacity
     ci_alignment:

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/console-operator.git
       web: https://github.com/openshift/console-operator
     ci_alignment:

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.product
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/console.git
       web: https://github.com/openshift/console
     modifications:

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oc.git
       web: https://github.com/openshift/oc
     path: images/deployer

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/router/haproxy/Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/router.git
       web: https://github.com/openshift/router
 distgit:

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: release/helm/Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ocp-release-operator-sdk.git
       web: https://github.com/openshift/ocp-release-operator-sdk
     ci_alignment:

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift-hack/images/hyperkube/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes.git
       web: https://github.com/openshift/kubernetes
     modifications:

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/images.git
       web: https://github.com/openshift/images
     path: ipfailover/keepalived

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: Dockerfile.Rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes.git
       web: https://github.com/openshift/kubernetes
     path: build/pause

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/image-registry.git
       web: https://github.com/openshift/image-registry
     ci_alignment:

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/tests/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/origin.git
       web: https://github.com/openshift/origin
     ci_alignment:

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: build/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes-nmstate.git
       web: https://github.com/openshift/kubernetes-nmstate
     ci_alignment:

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: build/Dockerfile.operator.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes-nmstate.git
       web: https://github.com/openshift/kubernetes-nmstate
     ci_alignment:

--- a/images/openshift-state-metrics.yml
+++ b/images/openshift-state-metrics.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/openshift-state-metrics.git
       web: https://github.com/openshift/openshift-state-metrics
     path: ''

--- a/images/openstack-cluster-api-controllers.yml
+++ b/images/openstack-cluster-api-controllers.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-openstack.git
       web: https://github.com/openshift/cluster-api-provider-openstack
     ci_alignment:

--- a/images/openstack-resource-controller.yml
+++ b/images/openstack-resource-controller.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/openstack-resource-controller.git
       web: https://github.com/openshift/openstack-resource-controller
     ci_alignment:

--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: operator-lifecycle-manager.Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/operator-framework-olm.git
       web: https://github.com/openshift/operator-framework-olm
     ci_alignment:

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: operator-registry.Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/operator-framework-olm.git
       web: https://github.com/openshift/operator-framework-olm
     ci_alignment:

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: ./Dockerfile.assisted-service.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/assisted-service.git
       web: https://github.com/openshift/assisted-service
     ci_alignment:

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: ./Dockerfile.assisted-installer-controller.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/assisted-installer.git
       web: https://github.com/openshift/assisted-installer
     ci_alignment:

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: ./Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/assisted-installer-agent.git
       web: https://github.com/openshift/assisted-installer-agent
     ci_alignment:

--- a/images/ose-agent-installer-orchestrator.yml
+++ b/images/ose-agent-installer-orchestrator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: ./Dockerfile.assisted-installer.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/assisted-installer.git
       web: https://github.com/openshift/assisted-installer
     ci_alignment:

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/agent-installer-utils.git
       web: https://github.com/openshift/agent-installer-utils
     ci_alignment:

--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/apiserver-network-proxy.git
       web: https://github.com/openshift/apiserver-network-proxy
     ci_alignment:

--- a/images/ose-aws-cloud-controller-manager.yml
+++ b/images/ose-aws-cloud-controller-manager.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-aws.git
       web: https://github.com/openshift/cloud-provider-aws
     ci_alignment:

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: openshift/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-aws.git
       web: https://github.com/openshift/cluster-api-provider-aws
     ci_alignment:

--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.aws-ebs
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.openshift.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/aws-ebs-csi-driver.git
       web: https://github.com/openshift/aws-ebs-csi-driver
     ci_alignment:

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.aws-efs
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/aws-efs-csi-driver.git
       web: https://github.com/openshift/aws-efs-csi-driver
     ci_alignment:

--- a/images/ose-aws-efs-utils.yml
+++ b/images/ose-aws-efs-utils.yml
@@ -13,7 +13,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/aws-efs-utils.git
       web: https://github.com/openshift/aws-efs-utils
     ci_alignment:

--- a/images/ose-aws-pod-identity-webhook.yml
+++ b/images/ose-aws-pod-identity-webhook.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/aws-pod-identity-webhook.git
       web: https://github.com/openshift/aws-pod-identity-webhook
     ci_alignment:

--- a/images/ose-azure-cloud-controller-manager.yml
+++ b/images/ose-azure-cloud-controller-manager.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-azure.git
       web: https://github.com/openshift/cloud-provider-azure
     ci_alignment:

--- a/images/ose-azure-cloud-node-manager.yml
+++ b/images/ose-azure-cloud-node-manager.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: openshift-hack/images/cloud-node-manager-openshift.Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-azure.git
       web: https://github.com/openshift/cloud-provider-azure
     ci_alignment:

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: openshift/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-azure.git
       web: https://github.com/openshift/cluster-api-provider-azure
     ci_alignment:

--- a/images/ose-azure-disk-csi-driver-operator.yml
+++ b/images/ose-azure-disk-csi-driver-operator.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.azure-disk
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.openshift.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/azure-disk-csi-driver.git
       web: https://github.com/openshift/azure-disk-csi-driver
     ci_alignment:

--- a/images/ose-azure-service-operator.yml
+++ b/images/ose-azure-service-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift/Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/azure-service-operator.git
       web: https://github.com/openshift/azure-service-operator
     ci_alignment:

--- a/images/ose-azure-storage-azcopy-base.yml
+++ b/images/ose-azure-storage-azcopy-base.yml
@@ -9,7 +9,7 @@ content:
       web: https://github.com/openshift/azure-storage-azcopy
       url: git@github.com:openshift-priv/azure-storage-azcopy.git
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "

--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -7,7 +7,7 @@ content:
       web: https://github.com/openshift/azure-workload-identity
       url: git@github.com:openshift-priv/azure-workload-identity.git
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
     dockerfile: Dockerfile.ocp
     ci_alignment:
       streams_prs:

--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-metal3.git
       web: https://github.com/openshift/cluster-api-provider-metal3
     ci_alignment:

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/baremetal/Dockerfile.ci
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/installer.git
       web: https://github.com/openshift/installer
     ci_alignment:

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/baremetal-operator.git
       web: https://github.com/openshift/baremetal-operator
     ci_alignment:

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/cli-artifacts/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oc.git
       web: https://github.com/openshift/oc
     ci_alignment:

--- a/images/ose-cloud-credential-operator.yml
+++ b/images/ose-cloud-credential-operator.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-credential-operator.git
       web: https://github.com/openshift/cloud-credential-operator
     ci_alignment:

--- a/images/ose-cloud-network-config-controller.yml
+++ b/images/ose-cloud-network-config-controller.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-network-config-controller.git
       web: https://github.com/openshift/cloud-network-config-controller
     ci_alignment:

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api.git
       web: https://github.com/openshift/cluster-api
     ci_alignment:

--- a/images/ose-cluster-authentication-operator.yml
+++ b/images/ose-cluster-authentication-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-authentication-operator.git
       web: https://github.com/openshift/cluster-authentication-operator
     ci_alignment:

--- a/images/ose-cluster-autoscaler-operator.yml
+++ b/images/ose-cluster-autoscaler-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-autoscaler-operator.git
       web: https://github.com/openshift/cluster-autoscaler-operator
     ci_alignment:

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-baremetal-operator.git
       web: https://github.com/openshift/cluster-baremetal-operator
     ci_alignment:

--- a/images/ose-cluster-bootstrap.yml
+++ b/images/ose-cluster-bootstrap.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-bootstrap.git
       web: https://github.com/openshift/cluster-bootstrap
     ci_alignment:

--- a/images/ose-cluster-capi-operator.yml
+++ b/images/ose-cluster-capi-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-capi-operator.git
       web: https://github.com/openshift/cluster-capi-operator
     ci_alignment:

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-cloud-controller-manager-operator.git
       web: https://github.com/openshift/cluster-cloud-controller-manager-operator
     ci_alignment:

--- a/images/ose-cluster-config-api.yml
+++ b/images/ose-cluster-config-api.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/api.git
       web: https://github.com/openshift/api
     ci_alignment:

--- a/images/ose-cluster-config-operator.yml
+++ b/images/ose-cluster-config-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-config-operator.git
       web: https://github.com/openshift/cluster-config-operator
     ci_alignment:

--- a/images/ose-cluster-control-plane-machine-set-operator.yml
+++ b/images/ose-cluster-control-plane-machine-set-operator.yml
@@ -8,7 +8,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-control-plane-machine-set-operator.git
       web: https://github.com/openshift/cluster-control-plane-machine-set-operator
     ci_alignment:

--- a/images/ose-cluster-csi-snapshot-controller-operator.yml
+++ b/images/ose-cluster-csi-snapshot-controller-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-csi-snapshot-controller-operator.git
       web: https://github.com/openshift/cluster-csi-snapshot-controller-operator
     ci_alignment:

--- a/images/ose-cluster-dns-operator.yml
+++ b/images/ose-cluster-dns-operator.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-dns-operator.git
       web: https://github.com/openshift/cluster-dns-operator
     ci_alignment:

--- a/images/ose-cluster-image-registry-operator.yml
+++ b/images/ose-cluster-image-registry-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-image-registry-operator.git
       web: https://github.com/openshift/cluster-image-registry-operator
     ci_alignment:

--- a/images/ose-cluster-ingress-operator.yml
+++ b/images/ose-cluster-ingress-operator.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-ingress-operator.git
       web: https://github.com/openshift/cluster-ingress-operator
     ci_alignment:

--- a/images/ose-cluster-kube-apiserver-operator.yml
+++ b/images/ose-cluster-kube-apiserver-operator.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-kube-apiserver-operator.git
       web: https://github.com/openshift/cluster-kube-apiserver-operator
     ci_alignment:

--- a/images/ose-cluster-kube-cluster-api-operator.yml
+++ b/images/ose-cluster-kube-cluster-api-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift/Dockerfile.openshift
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: release-4.23 # TODO: change to 5.0 when the branch exists
       url: git@github.com:openshift-priv/cluster-api-operator.git
       web: https://github.com/openshift/cluster-api-operator
     ci_alignment:

--- a/images/ose-cluster-kube-cluster-api-operator.yml
+++ b/images/ose-cluster-kube-cluster-api-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-operator.git
       web: https://github.com/openshift/cluster-api-operator
     ci_alignment:

--- a/images/ose-cluster-kube-controller-manager-operator.yml
+++ b/images/ose-cluster-kube-controller-manager-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-kube-controller-manager-operator.git
       web: https://github.com/openshift/cluster-kube-controller-manager-operator
     ci_alignment:

--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-kube-scheduler-operator.git
       web: https://github.com/openshift/cluster-kube-scheduler-operator
     ci_alignment:

--- a/images/ose-cluster-kube-storage-version-migrator-operator.yml
+++ b/images/ose-cluster-kube-storage-version-migrator-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/ci/Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-kube-storage-version-migrator-operator.git
       web: https://github.com/openshift/cluster-kube-storage-version-migrator-operator
     ci_alignment:

--- a/images/ose-cluster-machine-approver.yml
+++ b/images/ose-cluster-machine-approver.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-machine-approver.git
       web: https://github.com/openshift/cluster-machine-approver
     ci_alignment:

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-olm-operator.git
       web: https://github.com/openshift/cluster-olm-operator
     ci_alignment:

--- a/images/ose-cluster-openshift-apiserver-operator.yml
+++ b/images/ose-cluster-openshift-apiserver-operator.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-openshift-apiserver-operator.git
       web: https://github.com/openshift/cluster-openshift-apiserver-operator
     ci_alignment:

--- a/images/ose-cluster-openshift-controller-manager-operator.yml
+++ b/images/ose-cluster-openshift-controller-manager-operator.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-openshift-controller-manager-operator.git
       web: https://github.com/openshift/cluster-openshift-controller-manager-operator
     ci_alignment:

--- a/images/ose-cluster-samples-operator.yml
+++ b/images/ose-cluster-samples-operator.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-samples-operator.git
       web: https://github.com/openshift/cluster-samples-operator
     ci_alignment:

--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-update-keys.git
       web: https://github.com/openshift/cluster-update-keys
     ci_alignment:

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/containernetworking-plugins.git
       web: https://github.com/openshift/containernetworking-plugins
     ci_alignment:

--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-external-resizer.git
       web: https://github.com/openshift/csi-external-resizer
     ci_alignment:

--- a/images/ose-csi-external-snapshotter.yml
+++ b/images/ose-csi-external-snapshotter.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-external-snapshotter.git
       web: https://github.com/openshift/csi-external-snapshotter
     ci_alignment:

--- a/images/ose-csi-snapshot-controller.yml
+++ b/images/ose-csi-snapshot-controller.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.snapshot-controller.openshift.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-external-snapshotter.git
       web: https://github.com/openshift/csi-external-snapshotter
     ci_alignment:

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -17,7 +17,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: openshift-4.22
+        target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/etcd.git
       web: https://github.com/openshift/etcd
     pkg_managers:

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/frr.git
       web: https://github.com/openshift/frr
 distgit:

--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -8,7 +8,7 @@ content:
       url: git@github.com:openshift-priv/cloud-provider-gcp.git
       web: https://github.com/openshift/cloud-provider-gcp
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
     dockerfile: openshift-hack/images/Dockerfile.openshift
     ci_alignment:
       streams_prs:

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: openshift/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-gcp.git
       web: https://github.com/openshift/cluster-api-provider-gcp
     ci_alignment:

--- a/images/ose-gcp-filestore-csi-driver-operator.yml
+++ b/images/ose-gcp-filestore-csi-driver-operator.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/gcp-filestore-csi-driver-operator.git
       web: https://github.com/openshift/gcp-filestore-csi-driver-operator
     ci_alignment:

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/gcp-filestore-csi-driver.git
       web: https://github.com/openshift/gcp-filestore-csi-driver
     ci_alignment:

--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/gcp-pd-csi-driver-operator.git
       web: https://github.com/openshift/gcp-pd-csi-driver-operator
     ci_alignment:

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/gcp-pd-csi-driver.git
       web: https://github.com/openshift/gcp-pd-csi-driver
     ci_alignment:

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -4,7 +4,7 @@ content:
     dockerfile: images/router/base/Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/router.git
       web: https://github.com/openshift/router
     ci_alignment:

--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: openshift-hack/images/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-ibm.git
       web: https://github.com/openshift/cloud-provider-ibm
     ci_alignment:

--- a/images/ose-ibm-vpc-block-csi-driver-operator.yml
+++ b/images/ose-ibm-vpc-block-csi-driver-operator.yml
@@ -5,7 +5,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ibm-vpc-block-csi-driver-operator.git
       web: https://github.com/openshift/ibm-vpc-block-csi-driver-operator
     ci_alignment:

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ibm-vpc-block-csi-driver.git
       web: https://github.com/openshift/ibm-vpc-block-csi-driver
     ci_alignment:

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: openshift/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-ibmcloud.git
       web: https://github.com/openshift/cluster-api-provider-ibmcloud
     ci_alignment:

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -5,7 +5,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-provider-ibmcloud.git
       web: https://github.com/openshift/machine-api-provider-ibmcloud
     ci_alignment:

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -5,7 +5,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/image-customization-controller.git
       web: https://github.com/openshift/image-customization-controller
     ci_alignment:

--- a/images/ose-insights-operator.yml
+++ b/images/ose-insights-operator.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/insights-operator.git
       web: https://github.com/openshift/insights-operator
     ci_alignment:

--- a/images/ose-insights-runtime-exporter.yml
+++ b/images/ose-insights-runtime-exporter.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: ./Containerfile-exporter
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/insights-runtime-extractor.git
       web: https://github.com/openshift/insights-runtime-extractor
     ci_alignment:

--- a/images/ose-insights-runtime-extractor.yml
+++ b/images/ose-insights-runtime-extractor.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: ./Containerfile-extractor
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/insights-runtime-extractor.git
       web: https://github.com/openshift/insights-runtime-extractor
     ci_alignment:

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/installer-artifacts/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/installer.git
       web: https://github.com/openshift/installer
     ci_alignment:

--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -18,7 +18,7 @@ content:
     dockerfile: Dockerfile.installer.art-cachi2
     git:
       branch:
-        target: openshift-4.22
+        target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/etcd.git
       web: https://github.com/openshift/etcd
     pkg_managers:

--- a/images/ose-installer-kube-apiserver-artifacts.yml
+++ b/images/ose-installer-kube-apiserver-artifacts.yml
@@ -4,7 +4,7 @@ content:
     dockerfile: openshift-hack/images/installer-kube-apiserver-artifacts/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes.git
       web: https://github.com/openshift/kubernetes
     modifications:

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/installer/Dockerfile.ci
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/installer.git
       web: https://github.com/openshift/installer
     ci_alignment:

--- a/images/ose-kube-metrics-server.yml
+++ b/images/ose-kube-metrics-server.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       web: https://github.com/openshift/kubernetes-metrics-server
       url: git@github.com:openshift-priv/kubernetes-metrics-server.git
     dockerfile: Dockerfile.ocp

--- a/images/ose-kube-storage-version-migrator.yml
+++ b/images/ose-kube-storage-version-migrator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/release/Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes-kube-storage-version-migrator.git
       web: https://github.com/openshift/kubernetes-kube-storage-version-migrator
     ci_alignment:

--- a/images/ose-kubevirt-cloud-controller-manager.yml
+++ b/images/ose-kubevirt-cloud-controller-manager.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift-hack/images/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-kubevirt.git
       web: https://github.com/openshift/cloud-provider-kubevirt
     ci_alignment:

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubevirt-csi-driver.git
       web: https://github.com/openshift/kubevirt-csi-driver
     ci_alignment:

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-libvirt.git
       web: https://github.com/openshift/cluster-api-provider-libvirt
     ci_alignment:

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-operator.git
       web: https://github.com/openshift/machine-api-operator
     ci_alignment:

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-provider-aws.git
       web: https://github.com/openshift/machine-api-provider-aws
     ci_alignment:

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-provider-azure.git
       web: https://github.com/openshift/machine-api-provider-azure
     ci_alignment:

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-provider-gcp.git
       web: https://github.com/openshift/machine-api-provider-gcp
     ci_alignment:

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-provider-openstack.git
       web: https://github.com/openshift/machine-api-provider-openstack
     ci_alignment:

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-config-operator.git
       web: https://github.com/openshift/machine-config-operator
     ci_alignment:

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-os-images.git
       web: https://github.com/openshift/machine-os-images
     okd_alignment:

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -4,7 +4,7 @@ content:
       url: git@github.com:openshift-priv/metallb-operator.git
       web: https://github.com/openshift/metallb-operator
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
     dockerfile: Dockerfile.openshift
     ci_alignment:
       streams_prs:

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/metallb.git
       web: https://github.com/openshift/metallb
     ci_alignment:

--- a/images/ose-multus-admission-controller.yml
+++ b/images/ose-multus-admission-controller.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/multus-admission-controller.git
       web: https://github.com/openshift/multus-admission-controller
     ci_alignment:

--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/route-override-cni.git
       web: https://github.com/openshift/route-override-cni
     ci_alignment:

--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/whereabouts-cni.git
       web: https://github.com/openshift/whereabouts-cni
     ci_alignment:

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/must-gather.git
       web: https://github.com/openshift/must-gather
     ci_alignment:

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/bond-cni.git
       web: https://github.com/openshift/bond-cni
     ci_alignment:

--- a/images/ose-network-metrics-daemon.yml
+++ b/images/ose-network-metrics-daemon.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/network-metrics-daemon.git
       web: https://github.com/openshift/network-metrics-daemon
     ci_alignment:

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/network-tools.git
       web: https://github.com/openshift/network-tools
     ci_alignment:

--- a/images/ose-nutanix-cloud-controller-manager.yml
+++ b/images/ose-nutanix-cloud-controller-manager.yml
@@ -7,7 +7,7 @@ content:
       url: git@github.com:openshift-priv/cloud-provider-nutanix.git
       web: https://github.com/openshift/cloud-provider-nutanix
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -4,7 +4,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-provider-nutanix.git
       web: https://github.com/openshift/machine-api-provider-nutanix
     ci_alignment:

--- a/images/ose-oauth-apiserver.yml
+++ b/images/ose-oauth-apiserver.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oauth-apiserver.git
       web: https://github.com/openshift/oauth-apiserver
     ci_alignment:

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: openshift/catalogd.Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/operator-framework-operator-controller.git
       web: https://github.com/openshift/operator-framework-operator-controller
     ci_alignment:

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: openshift/operator-controller.Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/operator-framework-operator-controller.git
       web: https://github.com/openshift/operator-framework-operator-controller
     ci_alignment:

--- a/images/ose-openshift-apiserver.yml
+++ b/images/ose-openshift-apiserver.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: images/Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/openshift-apiserver.git
       web: https://github.com/openshift/openshift-apiserver
     ci_alignment:

--- a/images/ose-openshift-controller-manager.yml
+++ b/images/ose-openshift-controller-manager.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/openshift-controller-manager.git
       web: https://github.com/openshift/openshift-controller-manager
     ci_alignment:

--- a/images/ose-openstack-cinder-csi-driver-operator.yml
+++ b/images/ose-openstack-cinder-csi-driver-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openstack-cinder
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/cinder-csi-plugin/Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-openstack.git
       web: https://github.com/openshift/cloud-provider-openstack
     ci_alignment:

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/cloud-controller-manager/Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-openstack.git
       web: https://github.com/openshift/cloud-provider-openstack
     ci_alignment:

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: operator-framework-tools.Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/operator-framework-olm.git
       web: https://github.com/openshift/operator-framework-olm
     ci_alignment:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -8,7 +8,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ovn-kubernetes.git
       web: https://github.com/openshift/ovn-kubernetes
     ci_alignment:

--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ibm-powervs-block-csi-driver-operator.git
       web: https://github.com/openshift/ibm-powervs-block-csi-driver-operator
     ci_alignment:

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ibm-powervs-block-csi-driver.git
       web: https://github.com/openshift/ibm-powervs-block-csi-driver
     ci_alignment:

--- a/images/ose-powervs-cloud-controller-manager.yml
+++ b/images/ose-powervs-cloud-controller-manager.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: openshift-hack/images/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-powervs.git
       web: https://github.com/openshift/cloud-provider-powervs
     ci_alignment:

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -6,7 +6,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-provider-powervs.git
       web: https://github.com/openshift/machine-api-provider-powervs
     ci_alignment:

--- a/images/ose-route-controller-manager.yml
+++ b/images/ose-route-controller-manager.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/route-controller-manager.git
       web: https://github.com/openshift/route-controller-manager
     ci_alignment:

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/secrets-store-csi-driver-operator.git
       web: https://github.com/openshift/secrets-store-csi-driver-operator
     ci_alignment:

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/secrets-store-csi-driver.git
       web: https://github.com/openshift/secrets-store-csi-driver
     ci_alignment:

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.mustgather
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/secrets-store-csi-driver-operator.git
       web: https://github.com/openshift/secrets-store-csi-driver-operator
     ci_alignment:

--- a/images/ose-service-ca-operator.yml
+++ b/images/ose-service-ca-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/service-ca-operator.git
       web: https://github.com/openshift/service-ca-operator
     ci_alignment:

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.samba
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-operator.git
       web: https://github.com/openshift/csi-operator
     ci_alignment:

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/csi-driver-smb.git
       web: https://github.com/openshift/csi-driver-smb
     ci_alignment:

--- a/images/ose-sriov-network-metrics-exporter.yml
+++ b/images/ose-sriov-network-metrics-exporter.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/sriov-network-metrics-exporter.git
       web: https://github.com/openshift/sriov-network-metrics-exporter
     ci_alignment:

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/rdma-cni.git
       web: https://github.com/openshift/rdma-cni
     ci_alignment:

--- a/images/ose-support-log-gather-operator.yml
+++ b/images/ose-support-log-gather-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/must-gather-operator.git
       web: https://github.com/openshift/must-gather-operator
     ci_alignment:

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oc.git
       web: https://github.com/openshift/oc
     dockerfile: images/tools/Dockerfile

--- a/images/ose-vmware-vsphere-csi-driver-operator.yml
+++ b/images/ose-vmware-vsphere-csi-driver-operator.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/vmware-vsphere-csi-driver-operator.git
       web: https://github.com/openshift/vmware-vsphere-csi-driver-operator
     ci_alignment:

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/vmware-vsphere-csi-driver.git
       web: https://github.com/openshift/vmware-vsphere-csi-driver
     ci_alignment:

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -6,7 +6,7 @@ content:
       url: git@github.com:openshift-priv/cloud-provider-vsphere.git
       web: https://github.com/openshift/cloud-provider-vsphere
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
     dockerfile: openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
     ci_alignment:
       streams_prs:

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: openshift/Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-vsphere.git
       web: https://github.com/openshift/cluster-api-provider-vsphere
     ci_alignment:

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -4,7 +4,7 @@ content:
     dockerfile: Dockerfile.base
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ovn-kubernetes.git
       web: https://github.com/openshift/ovn-kubernetes
     ci_alignment:

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.microshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ovn-kubernetes.git
       web: https://github.com/openshift/ovn-kubernetes
     ci_alignment:

--- a/images/pf-status-relay-operator.yml
+++ b/images/pf-status-relay-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/pf-status-relay-operator.git
       web: https://github.com/openshift/pf-status-relay-operator
     ci_alignment:

--- a/images/pf-status-relay.yml
+++ b/images/pf-status-relay.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/pf-status-relay.git
       web: https://github.com/openshift/pf-status-relay
     ci_alignment:

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/prom-label-proxy.git
       web: https://github.com/openshift/prom-label-proxy
     ci_alignment:

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.config-reloader.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/prometheus-operator.git
       web: https://github.com/openshift/prometheus-operator
     ci_alignment:

--- a/images/prometheus-operator-admission-webhook.yml
+++ b/images/prometheus-operator-admission-webhook.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.admission-webhook.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/prometheus-operator.git
       web: https://github.com/openshift/prometheus-operator
     ci_alignment:

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/prometheus-operator.git
       web: https://github.com/openshift/prometheus-operator
     path: ''

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ptp-operator.git
       web: https://github.com/openshift/ptp-operator
     path: must-gather

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ptp-operator.git
       web: https://github.com/openshift/ptp-operator
     ci_alignment:

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/sriov-cni.git
       web: https://github.com/openshift/sriov-cni
     ci_alignment:

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/sriov-dp-admission-controller.git
       web: https://github.com/openshift/sriov-dp-admission-controller
     ci_alignment:

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.sriov-network-config-daemon.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/sriov-network-operator.git
       web: https://github.com/openshift/sriov-network-operator
     ci_alignment:

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/sriov-network-device-plugin.git
       web: https://github.com/openshift/sriov-network-device-plugin
     ci_alignment:

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/sriov-network-operator.git
       web: https://github.com/openshift/sriov-network-operator
     ci_alignment:

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: Dockerfile.webhook.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/sriov-network-operator.git
       web: https://github.com/openshift/sriov-network-operator
     ci_alignment:

--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/telemeter.git
       web: https://github.com/openshift/telemeter
     ci_alignment:

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.ocp
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/thanos.git
       web: https://github.com/openshift/thanos
     ci_alignment:

--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/vertical-pod-autoscaler-operator.git
       web: https://github.com/openshift/vertical-pod-autoscaler-operator
     ci_alignment:

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes-autoscaler.git
       web: https://github.com/openshift/kubernetes-autoscaler
     path: vertical-pod-autoscaler

--- a/images/vmware-vsphere-syncer.yml
+++ b/images/vmware-vsphere-syncer.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: Dockerfile.syncer.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/vmware-vsphere-csi-driver.git
       web: https://github.com/openshift/vmware-vsphere-csi-driver
     ci_alignment:

--- a/images/volume-data-source-validator.yml
+++ b/images/volume-data-source-validator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.openshift
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/volume-data-source-validator.git
       web: https://github.com/openshift/volume-data-source-validator
     ci_alignment:

--- a/images/vsphere-problem-detector.yml
+++ b/images/vsphere-problem-detector.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/vsphere-problem-detector.git
       web: https://github.com/openshift/vsphere-problem-detector
     ci_alignment:

--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -8,7 +8,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/microshift.git
       web: https://github.com/openshift/microshift
     specfile: packaging/rpm/microshift.spec

--- a/rpms/openshift-ansible.yml
+++ b/rpms/openshift-ansible.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/openshift-ansible.git
       web: https://github.com/openshift/openshift-ansible
     specfile: openshift-ansible.spec

--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/oc.git
       web: https://github.com/openshift/oc
     specfile: oc.spec

--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -3,7 +3,7 @@ content:
     specfile: openshift.spec
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes.git
       web: https://github.com/openshift/kubernetes
   build:

--- a/rpms/ose-aws-ecr-image-credential-provider.yml
+++ b/rpms/ose-aws-ecr-image-credential-provider.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-aws.git
       web: https://github.com/openshift/cloud-provider-aws
     specfile: ecr-credential-provider.spec

--- a/rpms/ose-azure-acr-image-credential-provider.yml
+++ b/rpms/ose-azure-acr-image-credential-provider.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-azure.git
       web: https://github.com/openshift/cloud-provider-azure
     specfile: acr-credential-provider.spec

--- a/rpms/ose-crio-credential-provider.yml
+++ b/rpms/ose-crio-credential-provider.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: release-4.22 # change this when 5.0 branch exists
       url: git@github.com:openshift-priv/crio-credential-provider.git
       web: https://github.com/openshift/crio-credential-provider
     specfile: crio-credential-provider.spec

--- a/rpms/ose-crio-credential-provider.yml
+++ b/rpms/ose-crio-credential-provider.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/crio-credential-provider.git
       web: https://github.com/openshift/crio-credential-provider
     specfile: crio-credential-provider.spec

--- a/rpms/ose-gcp-gcr-image-credential-provider.yml
+++ b/rpms/ose-gcp-gcr-image-credential-provider.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-4.22
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-gcp.git
       web: https://github.com/openshift/cloud-provider-gcp
     specfile: gcr-credential-provider.spec


### PR DESCRIPTION
Replace hardcoded version-specific branch targets with template variables to make metadata version-agnostic:
- release-4.22 → release-{MAJOR}.{MINOR} (258 files)
- openshift-4.22 → openshift-{MAJOR}.{MINOR} (2 files)