### PR TITLE
4.19 ose-vsphere-cloud-controller-manager hermetic

### DIFF
--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -33,7 +33,3 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
-konflux:
-  # Upstream has to fix their vendor.
-  cachi2:
-    enabled: false


### PR DESCRIPTION
follows https://github.com/openshift/cloud-provider-vsphere/pull/104

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-vsphere-cloud-controller-manager-8d6z5)