### PR TITLE
[openshift-4.18](hermetic): migrate monitoring-plugin

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -17,12 +17,6 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
-    modifications:
-    - action: replace
-      match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
-      replacement: |-
-        COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/web/.npmrc
     pkg_managers:
     - npm
     - gomod
@@ -49,4 +43,3 @@ owners:
 konflux:
   cachito:
     mode: emulation
-  network_mode: open


### PR DESCRIPTION
[Jenkins job](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/27893/)
[Konflux build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-monitoring-plugin-h6p4g/)

/hold for https://github.com/openshift/monitoring-plugin/pull/818