### PR TITLE
4.13: golang-github-prometheus-alertmanager hermetic

### DIFF
--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -29,8 +29,10 @@ owners:
 - team-monitoring@redhat.com
 konflux:
   cachi2:
-    enabled: false
-  network_mode: open
+    lockfile:
+      rpms:
+      - prometheus-promu
+      - openshift-prometheus-promu
 delivery:
   delivery_repo_names:
   - openshift4/ose-prometheus-alertmanager


### PR DESCRIPTION
follows https://github.com/openshift/prometheus-alertmanager/pull/122

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-golang-github-prometheus-alertmanager-dksfk/logs?task=build-images)