### PR TITLE
ose-cluster-api hermetic 4.14

### DIFF
--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -22,7 +22,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-api-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: cluster-capi-controllers


### PR DESCRIPTION
follows https://github.com/openshift/cluster-api/pull/265

[test build](http://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-cluster-api-6n2ps/)