### PR TITLE
logging-6.3: Downgrade Loki to 3.5.7

### DIFF
--- a/images/loki.yml
+++ b/images/loki.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: upstream-v3.6.5
+        target: upstream-v3.5.7
       url: git@github.com:openshift-priv/loki.git
       web: https://github.com/openshift/loki
 distgit:


### PR DESCRIPTION
Downgrade Loki to the previous version. A regression was identified when running it with AWS STS ([LOG-8901](https://issues.redhat.com/browse/LOG-8901)).

Reverts #9055.

/cc @rayfordj 
/label tide/merge-method-squash


