### PR TITLE
[openshift-4.19] ose-sriov-rdma-cni hermetic

### DIFF
--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -37,7 +37,3 @@ owners:
 - apanatto@redhat.com
 - wizhao@redhat.com
 - sscheink@redhat.com
-konflux:
-  network_mode: open # vendor changed upstream
-  cachi2:
-    enabled: false


### PR DESCRIPTION
follows https://github.com/openshift/rdma-cni/pull/27

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-sriov-rdma-cni-8sbg9/)