### PR TITLE
ART-14602: Update repos

### DIFF
--- a/repos/rhel-9-appstream-rpms.yml
+++ b/repos/rhel-9-appstream-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/appstream/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -12,9 +12,9 @@
     extra_options:
       module_hotfixes: 1
   content_set:
-    aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4
-    default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4
-    ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4
-    s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4
+    aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_6
+    ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_6
+    s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
   name: rhel-9-appstream-rpms
   type: external

--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/baseos/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -12,9 +12,9 @@
     extra_options:
       module_hotfixes: 1
   content_set:
-    aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_4
-    default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4
-    ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_4
-    s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_4
+    aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6
+    ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_6
+    s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_6
   name: rhel-9-baseos-rpms
   type: external

--- a/repos/rhel-9-codeready-builder-rpms.yml
+++ b/repos/rhel-9-codeready-builder-rpms.yml
@@ -1,18 +1,18 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/codeready-builder/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/codeready-builder/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/codeready-builder/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/codeready-builder/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/codeready-builder/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/codeready-builder/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/codeready-builder/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/codeready-builder/os/
     ci_alignment:
       localdev:
         enabled: true
       profiles:
       - el9
   content_set:
-    aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_4
-    default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_4
-    ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_4
-    s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_4
+    aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_6
+    default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_6
+    ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_6
+    s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_6
   name: rhel-9-codeready-builder-rpms
   type: external


### PR DESCRIPTION
Move appstream and baseos to e4s 9.6. codeready does not have a e4s counterpart, so use eus 9.6.

Content sets exist in the whitelisting repo: https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/known_rpm_repositories.yml