### PR TITLE
baremetal-machine-controller hermetic 4.16

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -32,6 +32,3 @@ owners:
 - rbryant@redhat.com
 - dhellman@redhat.com
 - mhrivnak@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/cluster-api-provider-baremetal/pull/243

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-baremetal-machine-controller-2jg7q)