### PR TITLE
ose-vsphere-cloud-controller-manager hermetic 4.18

### DIFF
--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -33,6 +33,3 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
-konflux:
-  cachi2:
-    enabled: false # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/cloud-provider-vsphere/pull/105

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-ose-vsphere-cloud-controller-manager-tf9rf)