### PR TITLE
ose-sriov-rdma-cni hermetic 4.17

### DIFF
--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -38,6 +38,3 @@ owners:
 - apanatto@redhat.com
 - wizhao@redhat.com
 - sscheink@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/rdma-cni/pull/29

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-ose-sriov-rdma-cni-dh9zj)