### PR TITLE
sriov-cni hermetic 4.13

### DIFF
--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -30,6 +30,3 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/sriov-cni-rhel9
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/sriov-cni/pull/173

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-sriov-cni-4svfn)