### PR TITLE
ART-14644: Add 4.18 specific SMB operands to reflect SMB's image-references

### DIFF
--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -1,0 +1,30 @@
+content:
+  source:
+    dockerfile: Dockerfile.ocp
+    git:
+      branch:
+        target: release-4.18
+      url: git@github.com:openshift-priv/csi-livenessprobe.git
+      web: https://github.com/openshift/csi-livenessprobe
+    ci_alignment:
+      streams_prs:
+        enabled: false
+dependents:
+- ose-smb-csi-driver-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: csi-livenessprobe-4.18-container
+for_payload: false
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+labels:
+  License: ASL 2.0
+  io.k8s.description: Liveness probe for CSI drivers
+  io.k8s.display-name: Liveness probe for CSI drivers
+  io.openshift.tags: csi,storage,probe
+name: openshift/ose-csi-livenessprobe-4.18-rhel9
+name_in_bundle: csi-livenessprobe-4.18
+owners:
+- aos-storage-staff@redhat.com

--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -14,6 +14,11 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-livenessprobe-4.18-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-livenessprobe
+  delivery_repo_names:
+  - openshift4/ose-csi-livenessprobe-rhel9
 for_payload: false
 from:
   builder:

--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-livenessprobe
+  delivery_repo_name_override: true
   delivery_repo_names:
   - openshift4/ose-csi-livenessprobe-rhel9
 for_payload: false

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -18,7 +18,6 @@ dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator
 - ose-secrets-store-csi-driver-operator
-- ose-smb-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-livenessprobe-container

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-node-driver-registrar
+  delivery_repo_name_override: true
   delivery_repo_names:
   - openshift4/ose-csi-node-driver-registrar-rhel9
 for_payload: false

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -14,6 +14,11 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-node-driver-registrar-4.18-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-node-driver-registrar
+  delivery_repo_names:
+  - openshift4/ose-csi-node-driver-registrar-rhel9
 for_payload: false
 from:
   builder:

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.openshift
+    git:
+      branch:
+        target: release-4.18
+      url: git@github.com:openshift-priv/csi-node-driver-registrar.git
+      web: https://github.com/openshift/csi-node-driver-registrar
+    ci_alignment:
+      streams_prs:
+        enabled: false
+dependents:
+- ose-smb-csi-driver-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: csi-node-driver-registrar-4.18-container
+for_payload: false
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-csi-node-driver-registrar-4.18-rhel9
+name_in_bundle: csi-node-driver-registrar-4.18
+owners:
+- aos-storage-staff@redhat.com

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -18,7 +18,6 @@ dependents:
 - ose-aws-efs-csi-driver-operator
 - ose-gcp-filestore-csi-driver-operator
 - ose-secrets-store-csi-driver-operator
-- ose-smb-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-node-driver-registrar-container

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -17,6 +17,7 @@ distgit:
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-csi-external-provisioner
+  delivery_repo_name_override: true
   delivery_repo_names:
   - openshift4/ose-csi-external-provisioner-rhel9
 for_payload: false

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -3,29 +3,18 @@ content:
     dockerfile: Dockerfile.openshift.rhel7
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: release-4.18
       url: git@github.com:openshift-priv/csi-external-provisioner.git
       web: https://github.com/openshift/csi-external-provisioner
     ci_alignment:
       streams_prs:
-        commit_prefix: "UPSTREAM: <carry>: "
-        ci_build_root:
-          stream: rhel-9-golang-ci-build-root
-        auto_label:
-        - approved
-        - lgtm
+        enabled: false
 dependents:
-- ose-aws-efs-csi-driver-operator
-- ose-gcp-filestore-csi-driver-operator
+- ose-smb-csi-driver-operator
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
-  component: csi-provisioner-container
-delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-external-provisioner
-  delivery_repo_names:
-  - openshift4/ose-csi-external-provisioner-rhel9
-for_payload: true
+  component: csi-provisioner-4.18-container
+for_payload: false
 from:
   builder:
   - stream: rhel-9-golang
@@ -35,8 +24,7 @@ labels:
   io.k8s.description: External provisioner for CSI volumes
   io.k8s.display-name: External provisioner for CSI volumes
   io.openshift.tags: csi,storage,provisioner
-name: openshift/ose-csi-external-provisioner-rhel9
-payload_name: csi-external-provisioner
-name_in_bundle: csi-external-provisioner
+name: openshift/ose-csi-external-provisioner-4.18-rhel9
+name_in_bundle: csi-external-provisioner-4.18
 owners:
 - aos-storage-staff@redhat.com

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -14,6 +14,11 @@ dependents:
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-provisioner-4.18-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-csi-external-provisioner
+  delivery_repo_names:
+  - openshift4/ose-csi-external-provisioner-rhel9
 for_payload: false
 from:
   builder:


### PR DESCRIPTION
Reflects changes from https://github.com/openshift/csi-operator/pull/523
Adding just `-4.18` to `name_in_bundle` would not work because image-references of other operators are still using the names without `-4.18`