### PR TITLE
ART-14604: Move ironic to -minimal

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -36,8 +36,8 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - member: openshift-enterprise-base-rhel9
-  member: openshift-enterprise-base-rhel9
+  - member: openshift-enterprise-base-rhel9-minimal
+  member: openshift-enterprise-base-rhel9-minimal
 name: openshift/ose-ironic-rhel9
 payload_name: ironic
 owners:


### PR DESCRIPTION
https://github.com/openshift/ironic-image/pull/809 should allow building ironic on ubi9-minimal

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED