### PR TITLE
Enable ci-openshift-build-root-latest images

### DIFF
--- a/images/ci-openshift-build-root-latest.rhel8.yml
+++ b/images/ci-openshift-build-root-latest.rhel8.yml
@@ -1,4 +1,3 @@
-mode: disabled
 content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true

--- a/images/ci-openshift-build-root-latest.rhel9.yml
+++ b/images/ci-openshift-build-root-latest.rhel9.yml
@@ -1,4 +1,3 @@
-mode: disabled
 content:
   # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
   set_build_variables: true


### PR DESCRIPTION
Remove top-level `mode: disabled` from ci-openshift-build-root-latest rhel8 and rhel9 image configs so these images are built.

Made with [Cursor](https://cursor.com)