### PR TITLE
Enable ci-openshift-build-root-latest images

### DIFF
--- a/images/ci-openshift-build-root-latest.rhel8.yml
+++ b/images/ci-openshift-build-root-latest.rhel8.yml
@@ -1,4 +1,3 @@
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-build-root-latest.rhel9.yml
+++ b/images/ci-openshift-build-root-latest.rhel9.yml
@@ -1,4 +1,3 @@
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they


### PR DESCRIPTION
Remove top-level `mode: disabled` from ci-openshift-build-root-latest rhel8 and rhel9 image configs so these images are built.

Made with [Cursor](https://cursor.com)