### PR TITLE
Move 4.22 from eus/e4s 9.6 to base rhel9

### DIFF
--- a/repos/rhel-9-appstream-rpms.yml
+++ b/repos/rhel-9-appstream-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -12,9 +12,9 @@
     extra_options:
       module_hotfixes: 1
   content_set:
-    aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_6
-    default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_6
-    ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_6
-    s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
+    aarch64: rhel-9-for-aarch64-appstream-rpms
+    default: rhel-9-for-x86_64-appstream-rpms
+    ppc64le: rhel-9-for-ppc64le-appstream-rpms
+    s390x: rhel-9-for-s390x-appstream-rpms
   name: rhel-9-appstream-rpms
   type: external

--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/s390x/baseos/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -12,9 +12,9 @@
     extra_options:
       module_hotfixes: 1
   content_set:
-    aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_6
-    default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6
-    ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_6
-    s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_6
+    aarch64: rhel-9-for-aarch64-baseos-rpms
+    default: rhel-9-for-x86_64-baseos-rpms
+    ppc64le: rhel-9-for-ppc64le-baseos-rpms
+    s390x: rhel-9-for-s390x-baseos-rpms
   name: rhel-9-baseos-rpms
   type: external

--- a/repos/rhel-9-codeready-builder-rpms.yml
+++ b/repos/rhel-9-codeready-builder-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/codeready-builder/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/codeready-builder/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/codeready-builder/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/codeready-builder/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/ppc64le/codeready-builder/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/s390x/codeready-builder/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os/
     ci_alignment:
       localdev:
         enabled: true

--- a/repos/rhel-9-highavailability.yml
+++ b/repos/rhel-9-highavailability.yml
@@ -1,17 +1,15 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/highavailability/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/highavailability/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/highavailability/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/highavailability/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/aarch64/highavailability/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/ppc64le/highavailability/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/s390x/highavailability/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/highavailability/os/
     extra_options:
       gpgcheck: '1'
   content_set:
-    aarch64: rhel-9-for-aarch64-highavailability-eus-rpms__9_DOT_6
-    default: rhel-9-for-x86_64-highavailability-eus-rpms__9_DOT_6
-    ppc64le: rhel-9-for-ppc64le-highavailability-eus-rpms__9_DOT_6
-    s390x: rhel-9-for-s390x-highavailability-eus-rpms__9_DOT_6
+    aarch64: rhel-9-for-aarch64-highavailability-rpms
+    default: rhel-9-for-x86_64-highavailability-rpms
+    ppc64le: rhel-9-for-ppc64le-highavailability-rpms
+    s390x: rhel-9-for-s390x-highavailability-rpms
   name: rhel-9-highavailability
-  reposync:
-    enabled: true
   type: external

--- a/repos/rhel-9-nfv.yml
+++ b/repos/rhel-9-nfv.yml
@@ -1,13 +1,13 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/nfv/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/nfv/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/nfv/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/nfv/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/nfv/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/nfv/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/nfv/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/nfv/os/
     extra_options:
       gpgcheck: '1'
   content_set:
-    default: rhel-9-for-x86_64-nfv-e4s-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-nfv-rpms
   name: rhel-9-nfv
   reposync:
     enabled: true

--- a/repos/rhel-9-rt-rpms.yml
+++ b/repos/rhel-9-rt-rpms.yml
@@ -1,13 +1,13 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/rt/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/rt/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/rt/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/rt/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/rt/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/rt/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/rt/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/rt/os/
     extra_options:
       module_hotfixes: 1
   content_set:
-    default: rhel-9-for-x86_64-rt-e4s-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-rt-rpms
     optional: true
   name: rhel-9-rt-rpms
   type: external


### PR DESCRIPTION
We intend to pick up 9.7 content with this change and move to 9.8 content once that's ready.

/cherry-pick openshift-4.23 openshift-5.0