### PR TITLE
4.17.51 - prepare-release: pin components

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -13,6 +13,20 @@ releases:
         advisories:
           rpm: 163538
           rhcos: 163539
+        dependencies:
+          rpms:
+          - el9: runc-1.2.9-3.rhaos4.17.el9
+            non_gc_tag: insert tag here if needed
+            why: pin rpm
+          - el9: podman-5.2.2-12.rhaos4.17.el9
+            non_gc_tag: insert tag here if needed
+            why: pin rpm
+          - el9: skopeo-1.16.1-4.rhaos4.17.el9
+            non_gc_tag: insert tag here if needed
+            why: pin rpm
+          - el9: containernetworking-plugins-1.4.0-6.el9_4.1
+            non_gc_tag: insert tag here if needed
+            why: pin rpm                    
         release_jira: ART-0
         shipment:
           advisories:


### PR DESCRIPTION
Fix for the following issue in prepare release:
ValueError: No attached builds found in errata advisories for rpm tracker bugs (bug, package): [('OCPBUGS-76302', 'podman'), ('OCPBUGS-76206', 'skopeo'), ('OCPBUGS-76205', 'runc'), ('OCPBUGS-76204', 'podman'), ('OCPBUGS-76192', 'containernetworking-plugins'), ('OCPBUGS-76060', 'podman'), ('OCPBUGS-64553', 'skopeo'), ('OCPBUGS-64535', 'podman')]. Either attach builds or explicitly include/exclude the bug ids in the assembly definition