### PR TITLE
ose-machine-api-provider-openstack hermetic 4.17

### DIFF
--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -30,5 +30,3 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/machine-api-provider-openstack/pull/162

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-ose-machine-api-provider-openstack-r75qt)