### PR TITLE
Revert "4.23 to minimal"

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -28,8 +28,8 @@ delivery:
 for_release: false
 for_payload: false
 enabled_repos:
-- rhel-9-baseos
-- rhel-9-appstream
+- rhel-96-baseos
+- rhel-96-appstream
 - rhel-9-fast-datapath-rpms
 - rhel-9-server-microshift-rpms
 name: openshift/microshift-bootc-rhel9

--- a/images/openshift-base-rhel9-minimal.yml
+++ b/images/openshift-base-rhel9-minimal.yml
@@ -1,0 +1,43 @@
+base_only: true
+content:
+  source:
+    git:
+      branch:
+        target: openshift-base-rhel9
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      # The actual image used by CI for the base image is
+      # built and pushed from ci-openshift-base.rhel9.
+      # This image is technically, the openshift-enterprise-base image
+      # but it shouldn't matter for the purposes of CI
+      # Setting upstream_image here ensures that reconciliation PRs for components referencing
+      # this image as their base image will use the image created by
+      # ci-openshift-base.rhel9 and be able to resolve RPMs.
+      mirror: false
+      upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:base-rhel9-minimal
+    okd_alignment:
+      resolve_as:
+        stream: centos_stream9
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-base-rhel9-minimal-container
+enabled_repos:
+- rhel-9-minimal-baseos-rpms
+- rhel-9-minimal-appstream-rpms
+  # sometimes we ship RHEL content ahead of RHEL (usually for RHCOS).
+  # update with that content too so we avoid out-of-date assembly issues:
+- rhel-9-server-ose-rpms-embargoed
+for_payload: false
+for_release: false
+from:
+  stream: rhel9-minimal
+name: openshift/base-rhel9-minimal
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false
+okd:
+  mode: disabled
+

--- a/images/openshift-enterprise-base-rhel9-minimal.yml
+++ b/images/openshift-enterprise-base-rhel9-minimal.yml
@@ -1,0 +1,48 @@
+base_only: true
+content:
+  source:
+    dockerfile: Dockerfile.rhel9
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/images.git
+      web: https://github.com/openshift/images
+    path: base
+    ci_alignment:
+      streams_prs:
+        # Try to have this PR merge as quickly as possible by pre-approving it.
+        auto_label:
+        - approved
+        - lgtm
+        merge_first: true
+      # The actual image used by CI for the enterprise base image is
+      # built and pushed from ci-openshift-base.rhel9. Setting upstream_image
+      # here ensures that reconciliation PRs for components referencing
+      # this image as their base image will use the image created by
+      # ci-openshift-base.rhel9 and be able to resolve RPMs.
+      mirror: false
+      upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:base-rhel9-minimal
+    okd_alignment:
+      # The tag name in the okd stream to which this image should be promoted
+      tag_name: base-stream9
+      inject_rpm_repositories:
+      - id: rhel-9-server-ose
+        baseurl: http://base-{MAJOR}-{MINOR}-rhel9.ocp.svc/rhel-9-server-ose
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-enterprise-base-rhel9-minimal-container
+enabled_repos:
+- rhel-9-minimal-baseos-rpms
+- rhel-9-minimal-appstream-rpms
+for_payload: false
+for_release: false
+from:
+  member: openshift-base-rhel9-minimal
+labels:
+  License: GPLv2+
+  io.k8s.description: This is the minimal base image from which all OpenShift Container Platform images inherit.
+  io.k8s.display-name: OpenShift Container Platform RHEL 9 Base minimal
+  io.openshift.tags: openshift,base
+name: openshift/openshift-enterprise-base-rhel9-minimal
+owners:
+- lmeyer@redhat.com

--- a/repos/rhel-9-appstream-rpms.yml
+++ b/repos/rhel-9-appstream-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -12,9 +12,9 @@
     extra_options:
       module_hotfixes: 1
   content_set:
-    aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_6
-    default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_6
-    ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_6
-    s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
+    aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4
+    default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4
+    ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4
+    s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4
   name: rhel-9-appstream-rpms
   type: external

--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -12,9 +12,9 @@
     extra_options:
       module_hotfixes: 1
   content_set:
-    aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_6
-    default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6
-    ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_6
-    s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_6
+    aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_4
+    default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4
+    ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_4
+    s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_4
   name: rhel-9-baseos-rpms
   type: external

--- a/repos/rhel-9-codeready-builder-rpms.yml
+++ b/repos/rhel-9-codeready-builder-rpms.yml
@@ -1,18 +1,18 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/codeready-builder/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/codeready-builder/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/codeready-builder/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/codeready-builder/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/codeready-builder/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/ppc64le/codeready-builder/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/s390x/codeready-builder/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/codeready-builder/os/
     ci_alignment:
       localdev:
         enabled: true
       profiles:
       - el9
   content_set:
-    aarch64: codeready-builder-for-rhel-9-aarch64-e4s-rpms__9_DOT_6
-    default: codeready-builder-for-rhel-9-x86_64-e4s-rpms__9_DOT_6
-    ppc64le: codeready-builder-for-rhel-9-ppc64le-e4s-rpms__9_DOT_6
-    s390x: codeready-builder-for-rhel-9-s390x-e4s-rpms__9_DOT_6
+    aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_4
+    default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_4
+    ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_4
+    s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_4
   name: rhel-9-codeready-builder-rpms
   type: external

--- a/repos/rhel-9-minimal-appstream-rpms.yml
+++ b/repos/rhel-9-minimal-appstream-rpms.yml
@@ -1,0 +1,20 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_6
+    s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_6
+  name: rhel-9-minimal-appstream-rpms
+  type: external

--- a/repos/rhel-9-minimal-baseos-rpms.yml
+++ b/repos/rhel-9-minimal-baseos-rpms.yml
@@ -1,0 +1,21 @@
+- conf:
+    baseurl:
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
+    ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_6
+    s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_6
+  name: rhel-9-minimal-baseos-rpms
+  type: external
+

--- a/repos/rhel-9-rt-rpms.yml
+++ b/repos/rhel-9-rt-rpms.yml
@@ -1,13 +1,13 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/rt/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/rt/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/rt/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/rt/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.4/x86_64/rt/os/
     extra_options:
       module_hotfixes: 1
   content_set:
-    default: rhel-9-for-x86_64-rt-e4s-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-rt-e4s-rpms__9_DOT_4
     optional: true
   name: rhel-9-rt-rpms
   type: external

--- a/repos/rhel-96-appstream.yml
+++ b/repos/rhel-96-appstream.yml
@@ -1,0 +1,17 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
+    ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_6
+    s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_6
+  name: rhel-96-appstream
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-96-baseos.yml
+++ b/repos/rhel-96-baseos.yml
@@ -1,0 +1,17 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
+    default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
+    ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_6
+    s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_6
+  name: rhel-96-baseos
+  reposync:
+    enabled: true
+  type: external

--- a/streams.yml
+++ b/streams.yml
@@ -60,6 +60,14 @@ rhel8:
   mirror: false
 
 rhel9:
+  # the most recent release at present. since we yum update this, it does not need to float.
+  # it is important that we not build from unreleased builds and publish them.
+  # rhel-els-container-9.4-847.1719484506
+  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:0a4a4ab60ce8abac3edab51cacdbed25cd012a3e4169895bce2d18ed74364e08
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-{MAJOR}.{MINOR}.art
+  mirror: false
+
+rhel9-minimal:
   # built on top of ubi9-minimal
   image: registry.redhat.io/ubi9/ubi-minimal@sha256:34880b64c07f28f64d95737f82f891516de9a3b43583f39970f7bf8e4cfa48b7
   upstream_image: registry.ci.openshift.org/ocp/builder:ubi9-minimal-openshift-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#9363

This broke the ocp4-konflux job for 4.23