### PR TITLE
Fix etcd dockerfile

### DIFF
--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -14,7 +14,7 @@ cachito:
     - path: tools/mod
 content:
   source:
-    dockerfile: Dockerfile.art
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: openshift-{MAJOR}.{MINOR}
@@ -58,10 +58,6 @@ owners:
 - melbeher@redhat.com
 maintainer:
   component: "Etcd"
-konflux:
-  content:
-    source:
-      dockerfile: Dockerfile.rhel
 okd:
   content:
     source:


### PR DESCRIPTION
scan-sources for 5.0 has been failing: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/42481/console

since upstream dockerfile got removed (https://github.com/openshift/etcd/pull/356)
Looking back in history https://github.com/openshift-eng/ocp-build-data/pull/8819 is the 
relevant config change for 4.23.