### PR TITLE
baremetal-machine-controller hermetic 4.13

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -26,7 +26,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-baremetal-machine-controllers
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: baremetal-machine-controllers


### PR DESCRIPTION
follows https://github.com/openshift/cluster-api-provider-baremetal/pull/246

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-baremetal-machine-controller-n6m45)