### PR TITLE
ose-vsphere-cluster-api-controllers hermetic 4.18

### DIFF
--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -33,6 +33,3 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
-konflux:
-  cachi2:
-    enabled: false # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/cluster-api-provider-vsphere/pull/84

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-ose-vsphere-cluster-api-controllers-mxhpr/)