### PR TITLE
ose-machine-config-operator hermetic 4.17

### DIFF
--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -44,7 +44,3 @@ owners:
 - jkyros@redhat.com
 - skumari@redhat.com
 - zzlotnik@redhat.com
-konflux:
-  network_mode: open # The content of the vendor directory is not consistent with go.mod
-  cachi2:
-    enabled: false


### PR DESCRIPTION
follows https://github.com/openshift/machine-config-operator/pull/5733

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-ose-machine-config-operator-m9mjr/)