### PR TITLE
ose-powervs-machine-controllers hermetic 4.14

### DIFF
--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -25,7 +25,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-powervs-machine-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: powervs-machine-controllers


### PR DESCRIPTION
follows https://github.com/openshift/machine-api-provider-powervs/pull/136

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-powervs-machine-controllers-45q85)