### PR TITLE
pin goimport version to v0.36.0

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -49,8 +49,7 @@ RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
     export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
-    go install golang.org/x/tools/cmd/cover@latest && \
-    go install golang.org/x/tools/cmd/goimports@latest && \
+    go install golang.org/x/tools/cmd/goimports@v0.36.0 && \
     go install github.com/tools/godep@latest && \
     go install golang.org/x/lint/golint@latest && \
     go install gotest.tools/gotestsum@latest && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -49,8 +49,7 @@ RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOSUMDB='off' && \
     export GOFLAGS='' && export GO111MODULE=on && \
     export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
-    go install golang.org/x/tools/cmd/cover@latest && \
-    go install golang.org/x/tools/cmd/goimports@latest && \
+    go install golang.org/x/tools/cmd/goimports@v0.36.0 && \
     go install github.com/tools/godep@latest && \
     go install golang.org/x/lint/golint@latest && \
     go install gotest.tools/gotestsum@latest && \


### PR DESCRIPTION
goimport v0.36.0 use go 1.23 https://cs.opensource.google/go/x/tools/+/refs/tags/v0.36.0:go.mod;l=3
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED