### PR TITLE
Add allow_mismatched_siblings for CSI 4.18 variants and SMB operator

### DIFF
--- a/images/csi-livenessprobe-4.18.yml
+++ b/images/csi-livenessprobe-4.18.yml
@@ -1,5 +1,6 @@
 content:
   source:
+    allow_mismatched_siblings: true  # 4.18 variant intentionally tracks a different branch than its sibling
     dockerfile: Dockerfile.ocp
     git:
       branch:

--- a/images/csi-node-driver-registrar-4.18.yml
+++ b/images/csi-node-driver-registrar-4.18.yml
@@ -1,5 +1,6 @@
 content:
   source:
+    allow_mismatched_siblings: true  # 4.18 variant intentionally tracks a different branch than its sibling
     dockerfile: Dockerfile.openshift
     git:
       branch:

--- a/images/csi-provisioner-4.18.yml
+++ b/images/csi-provisioner-4.18.yml
@@ -1,5 +1,6 @@
 content:
   source:
+    allow_mismatched_siblings: true  # 4.18 variant intentionally tracks a different branch than its sibling
     dockerfile: Dockerfile.openshift.rhel7
     git:
       branch:

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -1,5 +1,6 @@
 content:
   source:
+    allow_mismatched_siblings: true  # SMB operator tracks release-4.18 while its sibling aws-efs tracks release-{MAJOR}.{MINOR}
     dockerfile: Dockerfile.samba
     git:
       branch:


### PR DESCRIPTION
## Summary
- Adds `allow_mismatched_siblings: true` to 4 image configs that intentionally track different branches than their siblings:
  - `csi-livenessprobe-4.18` (tracks `release-4.18`, sibling tracks `release-{MAJOR}.{MINOR}`)
  - `csi-node-driver-registrar-4.18` (tracks `release-4.18`, sibling tracks `release-{MAJOR}.{MINOR}`)
  - `csi-provisioner-4.18` (tracks `release-4.18`, sibling tracks `release-{MAJOR}.{MINOR}`)
  - `ose-smb-csi-driver-operator` (tracks `release-4.18`, sibling `ose-aws-efs-csi-driver-operator` tracks `release-{MAJOR}.{MINOR}`)
- This suppresses false positive `MISMATCHED_SIBLINGS` assembly issues during build-sync
- Same change as https://github.com/openshift-eng/ocp-build-data/pull/9415 (openshift-4.16)

## Dependencies
- Requires art-tools PR: https://github.com/openshift-eng/art-tools/pull/2604


Made with [Cursor](https://cursor.com)