### PR TITLE
[openshift-4.16] CORENET-6055: ovn-kubernetes: Remove exemptions for now unpinned OVN rpms.

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -33,7 +33,6 @@ scan_sources:
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
   - libreswan*
-  - ovn*
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ovn-kubernetes

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -29,7 +29,6 @@ scan_sources:
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
   - libreswan
-  - ovn*
 for_payload: false
 for_release: false
 from:

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -33,7 +33,6 @@ scan_sources:
   # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
   exempt_rpms:
   - libreswan
-  - ovn*
 delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ovn-kubernetes-microshift


### PR DESCRIPTION
ovn* RPMs are no longer pinned in ovn-kubernetes images in order to facilitate timely CVE and bug fix delivery. Remove from exemptions.

4.16 ovn-k PR that removed the OVN pin: https://github.com/openshift/ovn-kubernetes/pull/2972

(cherry-pick of https://github.com/openshift-eng/ocp-build-data/pull/9419)