### PR TITLE
sriov-network-* hermetic 4.13

### DIFF
--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -31,7 +31,3 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-sriov-network-config-daemon
 name_in_bundle: sriov-network-config-daemon
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false # vendor changed upstream

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -31,6 +31,3 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-sriov-network-operator-bundle
   delivery_repo_names:
   - openshift4/ose-sriov-network-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -27,7 +27,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-sriov-network-webhook
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 name_in_bundle: sriov-network-webhook


### PR DESCRIPTION
follows https://github.com/openshift/sriov-network-operator/pull/1175

[sriov-network-config-daemon test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-sriov-network-config-daemon-tz272)
[sriov-network-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-sriov-network-operator-zsqwl)
[sriov-network-webhook test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-sriov-network-webhook-qnwtx)