### PR TITLE
sriov-network-* hermetic 4.12

### DIFF
--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -25,10 +25,6 @@ from:
 name: openshift/ose-sriov-network-config-daemon
 owners:
 - multus-dev@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-sriov-network-config-daemon

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -29,6 +29,3 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-sriov-network-operator-bundle
   delivery_repo_names:
   - openshift4/ose-sriov-network-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -25,7 +25,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-sriov-network-webhook
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 name_in_bundle: sriov-network-webhook


### PR DESCRIPTION
follows https://github.com/openshift/sriov-network-operator/pull/1176

[sriov-network-config-daemon test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-sriov-network-config-daemon-wbnv9)
[sriov-network-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-sriov-network-operator-kg52v)
[sriov-network-webhook test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-sriov-network-webhook-2wdhk)