### PR TITLE
baremetal-machine-controller hermetic 4.12

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -26,7 +26,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-baremetal-machine-controllers
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: baremetal-machine-controllers


### PR DESCRIPTION
follows https://github.com/openshift/cluster-api-provider-baremetal/pull/247

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-baremetal-machine-controller-5hwgj)