### PR TITLE
ib-sriov-cni hermetic 4.16

### DIFF
--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -34,6 +34,3 @@ name: openshift/ose-sriov-infiniband-cni-rhel9
 name_in_bundle: sriov-infiniband-cni
 owners:
 - multus-dev@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/ib-sriov-cni/pull/109

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ib-sriov-cni-wnkgf)