### PR TITLE
ib-sriov-cni hermetic 4.14

### DIFF
--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -28,7 +28,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-sriov-infiniband-cni
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 name_in_bundle: sriov-infiniband-cni


### PR DESCRIPTION
follows https://github.com/openshift/ib-sriov-cni/pull/111

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ib-sriov-cni-rl8mt)