### PR TITLE
hermetic 4.18

### DIFF
--- a/images/multus-cni-container-microshift.yml
+++ b/images/multus-cni-container-microshift.yml
@@ -41,7 +41,3 @@ owners:
 - tohayash@redhat.com
 - dosmith@redhat.com
 - microshift-devel@redhat.com
-konflux:
-  network_mode: open # vendor changed upstream
-  cachi2:
-    enabled: false

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -38,7 +38,3 @@ name: openshift/ose-multus-cni-rhel9
 payload_name: multus-cni
 owners:
 - multus-dev@redhat.com
-konflux:
-  network_mode: open # vendor changed upstream
-  cachi2:
-    enabled: false

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -34,6 +34,3 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -35,6 +35,3 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-kube-storage-version-migrator.yml
+++ b/images/ose-kube-storage-version-migrator.yml
@@ -27,6 +27,3 @@ name: openshift/ose-kube-storage-version-migrator-rhel9
 payload_name: kube-storage-version-migrator
 owners:
 - aos-master@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -41,6 +41,3 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
-konflux:
-  cachi2:
-    enabled: false


### PR DESCRIPTION
follows
https://github.com/openshift/ptp-operator/pull/670
https://github.com/openshift/cluster-api-provider-gcp/pull/265
https://github.com/openshift/cluster-api-provider-aws/pull/589
https://github.com/openshift/multus-cni/pull/276
https://github.com/openshift/kubernetes-kube-storage-version-migrator/pull/239

[multus-cni-container-microshift test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-multus-cni-container-microshift-mphdv)
[multus-cni test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-multus-cni-vhslh)
[ose-aws-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-ose-aws-cluster-api-controllers-rzsbk)
[ose-gcp-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-ose-gcp-cluster-api-controllers-cj5hp)
[ptp-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-ptp-operator-88blb)
[ose-kube-storage-version-migrator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-ose-kube-storage-version-migrator-6gp9x)