### PR TITLE
Add pin success build for ironic in releases.yml

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -404,7 +404,7 @@ releases:
             why: Pin success build for ironic
             metadata:
               is:
-                el9: ironic-container-v4.22.0-202603130056.p2.g0c07656.assembly.stream.el9
+                nvr: ironic-container-v4.22.0-202603130056.p2.g0c07656.assembly.stream.el9
           - distgit_key: '*'
             why: Exclude rpm updates that should not cause mass rebuilds
             metadata:

--- a/releases.yml
+++ b/releases.yml
@@ -400,6 +400,11 @@ releases:
           component: '*'
       members:
         images:
+          - distgit_key: ironic
+            why: Pin success build for ironic
+            metadata:
+              is:
+                el9: ironic-container-v4.22.0-202603130056.p2.g0c07656.assembly.stream.el9
           - distgit_key: '*'
             why: Exclude rpm updates that should not cause mass rebuilds
             metadata:


### PR DESCRIPTION
ironic build failed due to upstream change 