### PR TITLE
Revert "Add pin success build for ironic in releases.yml"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -400,11 +400,6 @@ releases:
           component: '*'
       members:
         images:
-          - distgit_key: ironic
-            why: Pin success build for ironic
-            metadata:
-              is:
-                nvr: ironic-container-v4.22.0-202603130056.p2.g0c07656.assembly.stream.el9
           - distgit_key: '*'
             why: Exclude rpm updates that should not cause mass rebuilds
             metadata:


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#9438