### PR TITLE
ART-14716: Bump nodejs to 18

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -91,7 +91,7 @@ rhel9:
   mirror: true
 
 nodejs:
-  image: ubi8/nodejs-16:1-82.1675799501
+  image: registry.access.redhat.com/ubi8/nodejs-18:1-86
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
[Test build](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=&group=&assembly=test&outcome=success&outcome=failure&engine=konflux&dateRange=2026-03-17+to+2026-03-18&nvr=&record_id=&image_sha_tag=&source_repo=&commitish=&art-job-url=https%3A%2F%2Fart-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com%2Fjob%2Faos-cd-builds%2Fjob%2Fbuild%25252Focp4-konflux%2F28670%2F) makes me think all builds would succeed, even though Jenkins was restarted and not all components were built.