### PR TITLE
Add repository listing to dnf_wrapper build log output

### DIFF
--- a/ci_images/dnf_wrapper.sh
+++ b/ci_images/dnf_wrapper.sh
@@ -174,6 +174,23 @@ if [[ "${SKIP_REPO_INSTALL}" == "0" ]]; then
     # Set the repo file search path for DNF
     EXTRA_DNF_ARGS="${EXTRA_DNF_ARGS} --setopt=reposdir=${DNF_OPTS_REPOSDIR}"
     echoerr "DNF will search for repo files in: ${DNF_OPTS_REPOSDIR}"
+
+    # List configured repositories so they are visible in build logs,
+    # since microdnf does not display repo names during metadata download.
+    for repodir in ${DNF_OPTS_REPOSDIR//,/ }; do
+      if [[ -d "${repodir}" ]]; then
+        for repofile in "${repodir}"/*.repo; do
+          if [[ -f "${repofile}" ]]; then
+            echoerr "Configured repositories in $(basename "${repofile}"):"
+            while IFS= read -r line; do
+              if [[ "${line}" =~ ^\[.*\]$ ]]; then
+                echoerr "  - ${line//[\[\]]/}"
+              fi
+            done < "${repofile}"
+          fi
+        done
+      fi
+    done
   fi
 
 fi


### PR DESCRIPTION
microdnf does not display repository names during metadata download, making it difficult to debug package resolution failures in CI builds. Parse .repo files in the configured reposdir and log the repository IDs before invoking the underlying package manager.