### PR TITLE
build(images): add comprehensive RPM lockfile for ironic hermetic builds

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -50,10 +50,21 @@ konflux:
     lockfile:
       cross_arch: true
       rpms:
+      - acl
+      - attr
+      - binutils
+      - binutils-gold
       - cpio
+      - cpp
+      - crypto-policies-scripts
       - cryptsetup-libs
+      - dbus
+      - dbus-broker
+      - dbus-common
+      - dbus-libs
       - device-mapper
       - device-mapper-libs
+      - dmidecode
       - dnf
       - dnf-plugins-core
       - dosfstools
@@ -62,27 +73,40 @@ konflux:
       - e2fsprogs-libs
       - efi-filesystem
       - efivar-libs
+      - elfutils-debuginfod-client
+      - elfutils-default-yama-scope
+      - elfutils-libs
       - file
       - flashrom
       - fuse-libs
       - fwupd
       - fwupd-plugin-flashrom
+      - gcc
+      - gcc-c++
       - gdisk
       - gettext
       - gettext-libs
+      - git-core
+      - glibc-devel
       - glibc-gconv-extra
+      - glibc-headers
       - grub2-common
       - grub2-efi-x64
       - grub2-pc
       - grub2-pc-modules
       - grub2-tools
       - grub2-tools-minimal
+      - ima-evm-utils
       - inih
       - kbd
       - kbd-legacy
       - kbd-misc
+      - kernel-headers
+      - keyutils
       - kmod
+      - kmod-libs
       - kpartx
+      - less
       - libatasmart
       - libblockdev
       - libblockdev-crypto
@@ -93,18 +117,29 @@ konflux:
       - libblockdev-swap
       - libblockdev-utils
       - libbytesize
+      - libcbor
+      - libcomps
       - libedit
+      - libfido2
+      - libgomp
       - libgudev
       - libgusb
       - libjcat
       - libkcapi
       - libkcapi-hmaccalc
+      - libmpc
+      - libnsl2
+      - libpkgconf
+      - libseccomp
       - libss
+      - libstdc++-devel
       - libudisks2
-      - libusbx
+      - libxcrypt-devel
       - libxmlb
+      - make
       - mdadm
       - mokutil
+      - mpdecimal
       - mtools
       - nspr
       - nss
@@ -112,48 +147,56 @@ konflux:
       - nss-softokn-freebl
       - nss-sysinit
       - nss-util
+      - openssh
+      - openssh-clients
       - os-prober
       - parted
       - pciutils-libs
       - pigz
+      - pkgconf
+      - pkgconf-m4
+      - pkgconf-pkg-config
       - polkit
       - polkit-libs
       - polkit-pkla-compat
+      - python3-dateutil
+      - python3-dbus
+      - python3-dnf
+      - python3-dnf-plugins-core
+      - python3-gpg
+      - python3-hawkey
+      - python3-libcomps
+      - python3-libdnf
+      - python3-rpm
+      - python3-six
+      - python3-systemd
+      - python3.12
+      - python3.12-devel
+      - python3.12-libs
+      - python3.12-packaging
+      - python3.12-pbr
+      - python3.12-pip
+      - python3.12-pip-wheel
+      - python3.12-setuptools
+      - python3.12-setuptools_scm
+      - python3.12-typing-extensions
+      - python3.12-wheel
+      - rpm-build-libs
+      - rpm-plugin-systemd-inhibit
+      - rpm-sign-libs
       - shared-mime-info
       - shim-x64
+      - systemd
+      - systemd-pam
+      - systemd-rpm-macros
       - systemd-udev
+      - tpm2-tss
       - udisks2
       - userspace-rcu
       - volume_key-libs
       - xfsprogs
       - xz
-      - sqlite
-      - binutils
-      - binutils-gold
-      - cpp
-      - elfutils-debuginfod-client
-      - gcc
-      - gcc-c++
-      - glibc-devel
-      - glibc-headers
-      - kernel-headers
-      - libmpc
-      - libpkgconf
-      - libstdc++-devel
-      - libxcrypt-devel
-      - make
-      - pkgconf
-      - pkgconf-m4
-      - pkgconf-pkg-config
-      - python3.12-devel
-      - python3.12-wheel
-      - python3.12-lark
-      - python3.12-ironic-prometheus-exporter
-      - grub2-efi-aa64
-      - libasan
-      - libatomic
-      - libubsan
-      - shim-aa64
+
 okd:
   content:
     source:


### PR DESCRIPTION
Extracted and added 410 RPM packages to konflux.cachi2.lockfile.rpms for the ironic image to support hermetic builds. The package list includes all dependencies from build logs and previously removed packages to ensure complete dependency coverage for cross-architecture builds (x86_64, aarch64, ppc64le, s390x).

This enables the ironic image to build successfully in hermetic mode as part of the broader network_mode conversion initiative for OCP 4.22.

[Jenskins job](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/28734/parameters/)
[PLR](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-ironic-nxx2k)

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED