### PR TITLE
Use release-6.5 branch for Loki Operator

### DIFF
--- a/images/loki-operator.yml
+++ b/images/loki-operator.yml
@@ -4,7 +4,7 @@ content:
     path: operator
     git:
       branch:
-        target: main # to be changed to release-6.5
+        target: release-6.5
       url: git@github.com:openshift-priv/loki.git
       web: https://github.com/openshift/loki
 distgit:


### PR DESCRIPTION
Just changes the branch name. Both point to the same commit right now.

/cc @rayfordj @ashwindasr 
/label tide/merge-method-squash
