### PR TITLE
exclude podman OCPBUGS

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -45,6 +45,12 @@ releases:
           component: multus-cni
         - code: MISMATCHED_NETWORK_MODE
           component: multus-cni-container-microshift
+      issues:
+        exclude:
+          - id: OCPBUGS-76307
+          - id: OCPBUGS-76222
+          - id: OCPBUGS-76078
+          - id: OCPBUGS-64536
       members:
         rpms: []
         images:


### PR DESCRIPTION
```
13:51:20  ValueError: No attached builds found in errata advisories for rpm tracker bugs (bug, package): 
[('OCPBUGS-76307', 'podman'), 
('OCPBUGS-76222', 'podman'), 
('OCPBUGS-76078', 'podman'), 
('OCPBUGS-64536', 'podman')].
Either attach builds or explicitly include/exclude the bug ids in the assembly definition
```