### PR TITLE
Add image_repo and additional_build_args to group.yml for installer-ove-ui

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -14,6 +14,12 @@ konflux:
   arches:
   - x86_64
   network_mode: hermetic
+  image_repo: quay.io/redhat-user-workloads/ocp-agent-based-installer-tenant/ove-ui-iso
+  additional_build_args:
+  - privileged-nested: true
+  - release-value: "quay.io/openshift-release-dev/ocp-release:4.21.0-ec.1-x86_64"
+  - major-minor-version: "4.21"
+  - patch-version: "0"
 
 assemblies:
   enabled: true


### PR DESCRIPTION
## Summary
- Add `konflux.image_repo` to specify the custom Quay repository for the OVE UI ISO builder component (`quay.io/redhat-user-workloads/ocp-agent-based-installer-tenant/ove-ui-iso`)
- Add `konflux.additional_build_args` with the required build parameters: `privileged-nested`, `release-value`, `major-minor-version`, and `patch-version`

## Test plan
- [ ] Verify with a layered-products build that the correct image repo and build args are used

## Depends on
- openshift-eng/art-tools#2632


Made with [Cursor](https://cursor.com)