### PR TITLE
Pin local-storage-mustgather build for 4.21.7

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -94,7 +94,12 @@ releases:
             aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:308136c229368cd81838c150bbbd84e34c389a95c72b27df38bb0fef8cfb7beb
       members:
         rpms: []
-        images: []
+        images:
+          - distgit_key: local-storage-mustgather
+            why: Pin build to satisfy verify_attached_operators check for local-storage-operator bundle
+            metadata:
+              is:
+                nvr: ose-local-storage-mustgather-container-v4.21.0-202603181245.p2.gd463337.assembly.stream.el9
   4.21.6:
     assembly:
       type: standard


### PR DESCRIPTION
## Summary
- Pin `ose-local-storage-mustgather-container-v4.21.0-202603181245.p2.gd463337.assembly.stream.el9` in the 4.21.7 assembly
- Fixes `prepare-release-konflux` failure where `verify_attached_operators` check failed because the local-storage-operator bundle references ose-local-storage-mustgather as an operand but it was not in the release

## Test plan
- [ ] Re-run `prepare-release-konflux` for 4.21.7 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)