### PR TITLE
Add build_args, fix network_mode/image_repo, use x86_64_root arch

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -8,12 +8,12 @@ vars:
 
 
 arches:
-- x86_64
+- x86_64_root
 
 
 konflux:
   arches:
-  - x86_64
+  - x86_64_root
   network_mode: open
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   additional_build_args:
@@ -21,6 +21,12 @@ konflux:
   - release-value: "quay.io/openshift-release-dev/ocp-release:4.21.0-ec.1-x86_64"
   - major-minor-version: "4.21"
   - patch-version: "0"
+  build_args:
+  - "RELEASE_FLAG=--release-image-url"
+  - "RELEASE_VALUE=$(params.release-value)"
+  - "MAJOR_MINOR_VERSION=$(params.major-minor-version)"
+  - "PATCH_VERSION=$(params.patch-version)"
+  - "ARCH=x86_64"
 
 assemblies:
   enabled: true


### PR DESCRIPTION
## Summary
- Add `konflux.build_args` for buildah `--build-arg` values passed to the Konflux PipelineRun, referencing pipeline params set via `additional_build_args`
- Switch arches from `x86_64` to `x86_64_root` for privileged/nested builds using `linux-root/amd64` Konflux platform
- Fix `image_repo` to use correct `ocp-art-tenant` namespace

## Config Changes
```yaml
arches:
- x86_64_root

konflux:
  arches:
  - x86_64_root
  network_mode: open
  image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
  build_args:
  - "RELEASE_FLAG=--release-image-url"
  - "RELEASE_VALUE=$(params.release-value)"
  - "MAJOR_MINOR_VERSION=$(params.major-minor-version)"
  - "PATCH_VERSION=$(params.patch-version)"
  - "ARCH=x86_64"
```

## Depends On
- art-tools PR: https://github.com/openshift-eng/art-tools/pull/2632