### PR TITLE
Use literal values in build_args, remove unused additional_build_args

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -18,14 +18,11 @@ konflux:
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   additional_build_args:
   - privileged-nested: true
-  - release-value: "quay.io/openshift-release-dev/ocp-release:4.21.0-ec.1-x86_64"
-  - major-minor-version: "4.21"
-  - patch-version: "0"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
-  - "RELEASE_VALUE=$(params.release-value)"
-  - "MAJOR_MINOR_VERSION=$(params.major-minor-version)"
-  - "PATCH_VERSION=$(params.patch-version)"
+  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.21.0-ec.1-x86_64"
+  - "MAJOR_MINOR_VERSION=4.21"
+  - "PATCH_VERSION=0"
   - "ARCH=x86_64"
 
 assemblies:


### PR DESCRIPTION
## Summary
- Use literal values in `build_args` instead of Tekton `$(params.xxx)` references, since Tekton does not support nested parameter substitution
- Remove `release-value`, `major-minor-version`, and `patch-version` from `additional_build_args` as they are no longer needed as pipeline params

## Problem
The previous config used `$(params.release-value)` etc. inside `build_args`, expecting Tekton to resolve them from `additional_build_args`-set pipeline params. However, Tekton parameter substitution is single-pass: when `build-args` pipeline param values are expanded into the task, any `$(params.xxx)` inside those values are treated as task-level param references which don't exist.

## Fix
Replace param references with literal values in `build_args`.

## Depends On
- art-tools PR: https://github.com/openshift-eng/art-tools/pull/2632
