### PR TITLE
hermetic 4.13

### DIFF
--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -20,9 +20,6 @@ from:
 name: openshift/ose-hypershift-rhel8
 owners:
 - hypershift-team@redhat.com
-konflux:
-  cachi2:
-    enabled: false
 delivery:
   delivery_repo_names:
   - openshift4/ose-hypershift-rhel8

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -22,7 +22,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-nutanix-machine-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: nutanix-machine-controllers

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -25,7 +25,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-powervs-machine-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: powervs-machine-controllers


### PR DESCRIPTION
follows 
https://github.com/openshift/hypershift/pull/7822
https://github.com/openshift/machine-api-provider-nutanix/pull/131
https://github.com/openshift/machine-api-provider-powervs/pull/137

[hypershift test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-hypershift-hgm96)
[ose-nutanix-machine-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-nutanix-machine-controllers-xrmqh)
[ose-powervs-machine-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-powervs-machine-controllers-tbcjh)