### PR TITLE
hermetic 4.12

### DIFF
--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -20,9 +20,6 @@ from:
 name: openshift/ose-hypershift-rhel8
 owners:
 - hypershift-team@redhat.com
-konflux:
-  cachi2:
-    enabled: false
 delivery:
   delivery_repo_names:
   - openshift4/ose-hypershift-rhel8

--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -25,7 +25,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-multus-route-override-cni-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: multus-route-override-cni

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -22,7 +22,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-nutanix-machine-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: nutanix-machine-controllers

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -24,7 +24,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-powervs-machine-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: powervs-machine-controllers

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -25,7 +25,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-sriov-cni
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 name_in_bundle: sriov-cni


### PR DESCRIPTION
follows 
https://github.com/openshift/hypershift/pull/7823
https://github.com/openshift/route-override-cni/pull/64
https://github.com/openshift/machine-api-provider-nutanix/pull/132
https://github.com/openshift/machine-api-provider-powervs/pull/138
https://github.com/openshift/sriov-cni/pull/174

[hypershift test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-hypershift-tzms6)
[ose-multus-route-override-cni test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-multus-route-override-cni-f7htv)
[ose-nutanix-machine-controllers test build ](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-nutanix-machine-controllers-wt2zt)
[ose-powervs-machine-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-powervs-machine-controllers-7knjj)
[sriov-cni test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-sriov-cni-2m4pw)