### PR TITLE
hermetic 4.17

### DIFF
--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -34,6 +34,3 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -34,6 +34,3 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -33,6 +33,3 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -40,6 +40,3 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows 
https://github.com/openshift/cluster-api-provider-aws/pull/590
https://github.com/openshift/cluster-api-provider-azure/pull/363
https://github.com/openshift/cluster-api-provider-vsphere/pull/85
https://github.com/openshift/ptp-operator/pull/671


[ose-aws-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-ose-aws-cluster-api-controllers-vdlj2)
[ose-azure-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-ose-azure-cluster-api-controllers-t6bp2)
[ose-vsphere-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-ose-vsphere-cluster-api-controllers-rm2qc)
[ptp-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-ptp-operator-lpkx6)