### PR TITLE
openshift-kubernetes-nmstate hermetic 4.13

### DIFF
--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -31,10 +31,6 @@ owners:
 - ellorent@redhat.com
 - phoracek@redhat.com
 - yboaron@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-kubernetes-nmstate-handler-rhel8

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -31,9 +31,6 @@ update-csv:
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
-konflux:
-  cachi2:
-    enabled: false
 delivery:
   bundle_delivery_repo_name: openshift4/kubernetes-nmstate-operator-bundle
   delivery_repo_names:


### PR DESCRIPTION
follows https://github.com/openshift/kubernetes-nmstate/pull/725

[openshift-kubernetes-nmstate-handler test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-openshift-kubernetes-nmstate-handler-vwrxg)
[openshift-kubernetes-nmstate-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-openshift-kubernetes-nmstate-operator-th5jh)