### PR TITLE
hook-runner needs access to podman

### DIFF
--- a/images/openshift-migration-hook-runner.yml
+++ b/images/openshift-migration-hook-runner.yml
@@ -27,3 +27,8 @@ owners:
 jira:
   project: MIG
   component: openshift-migration-hook-runner-container
+konflux:
+  cachi2:
+    lockfile:
+      modules:
+      - container-tools:rhel8


### PR DESCRIPTION
Signed-off-by: Franco Bladilo <fbladilo@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED