### PR TITLE
Fix image source path for art-agent-installer-iso

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -18,11 +18,12 @@ konflux:
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   additional_build_args:
   - privileged-nested: true
+  - ADDITIONAL_SECRET: ove-ui-image-pull-secret
   build_args:
   - "RELEASE_FLAG=--release-image-url"
-  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.21.0-ec.1-x86_64"
-  - "MAJOR_MINOR_VERSION=4.21"
-  - "PATCH_VERSION=0"
+  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.20.8-x86_64"
+  - "MAJOR_MINOR_VERSION=4.20"
+  - "PATCH_VERSION=8"
   - "ARCH=x86_64"
 
 assemblies:

--- a/group.yml
+++ b/group.yml
@@ -18,7 +18,7 @@ konflux:
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   additional_build_args:
   - privileged-nested: true
-  - ADDITIONAL_SECRET: ove-ui-image-pull-secret
+  additional_secret: ove-ui-image-pull-secret
   build_args:
   - "RELEASE_FLAG=--release-image-url"
   - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.20.8-x86_64"

--- a/group.yml
+++ b/group.yml
@@ -16,8 +16,7 @@ konflux:
   - x86_64_root
   network_mode: open
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
-  additional_build_args:
-  - privileged-nested: true
+  privileged_nested: true
   additional_secret: ove-ui-image-pull-secret
   build_args:
   - "RELEASE_FLAG=--release-image-url"

--- a/group.yml
+++ b/group.yml
@@ -18,6 +18,7 @@ konflux:
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   privileged_nested: true
   additional_secret: ove-ui-image-pull-secret
+  build_step_memory: "8Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
   - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.20.8-x86_64"

--- a/images/art-agent-installer-iso.yml
+++ b/images/art-agent-installer-iso.yml
@@ -26,4 +26,4 @@ name: ocp-art-tenant/art-agent-installer-iso
 owners:
 - ocp-agent-team@redhat.com
 konflux:
-  no_shell: true
+  no_shell: true  # Skip .oit injected RUN commands (e.g. yum repo setup) since this image does not use RPMs


### PR DESCRIPTION
## Summary
- Remove `content.source.path` so the entire repo root is used as the build context instead of just `tools/iso_builder`
- The Dockerfile path is now specified as the full relative path `tools/iso_builder/Dockerfile`
- This gives the build access to directories outside `tools/iso_builder` such as `config/4.20`
- Add inline comment explaining `no_shell: true`
