### PR TITLE
Replace build_step_memory with build_step_resources, add ephemeral-storage

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -18,7 +18,9 @@ konflux:
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   privileged_nested: true
   additional_secret: ove-ui-image-pull-secret
-  build_step_memory: "8Gi"
+  build_step_resources:
+    memory: "8Gi"
+    ephemeral-storage: "70Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
   - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.20.8-x86_64"


### PR DESCRIPTION
## Summary

The `build` step in the `build-images` task consumes ~60 GiB of ephemeral storage, exceeding the node eviction threshold (~45 GiB) and causing pod eviction.

Replace the single-value `build_step_memory: "8Gi"` with the new generalized `build_step_resources` dict to set both `memory` and `ephemeral-storage` on the build step.

This ensures the pod is scheduled on a node with enough storage and won't be evicted mid-build.

Depends on art-tools PR: https://github.com/openshift-eng/art-tools/pull/2632
