### PR TITLE
Switch from ephemeral-storage to workspace PVC for ISO builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -20,7 +20,7 @@ konflux:
   additional_secret: ove-ui-image-pull-secret
   build_step_resources:
     memory: "8Gi"
-    ephemeral-storage: "250Gi"
+  workspace_storage: "100Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
   - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.21.5-x86_64"


### PR DESCRIPTION
## Summary
- Replace the 250Gi `ephemeral-storage` request under `build_step_resources` with a 100Gi `workspace_storage` PVC (`volumeClaimTemplate`)
- This avoids node-level ephemeral-storage eviction issues by using network-attached persistent storage for the large ISO build artifacts
- Requires the corresponding `art-tools` change: https://github.com/openshift-eng/art-tools/pull/2632

## Details
The `art-agent-installer-iso` build produces ~60GB ISO artifacts that previously caused repeated pod evictions due to node ephemeral-storage pressure. The new `workspace_storage` field tells the ART pipeline to dynamically create a PVC with the specified size and bind it as a `workspace` in the PipelineRun, matching the upstream OVE-UI PLR pattern.

## Test plan
- [ ] Trigger a Konflux build for `art-agent-installer-iso` and verify the PipelineRun includes a `volumeClaimTemplate` workspace with 100Gi
- [ ] Verify the build completes without ephemeral-storage eviction

Made with [Cursor](https://cursor.com)