### PR TITLE
Switch from ephemeral-storage to workspace PVC for ISO builds (4.20)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -20,7 +20,7 @@ konflux:
   additional_secret: ove-ui-image-pull-secret
   build_step_resources:
     memory: "8Gi"
-    ephemeral-storage: "150Gi"
+  workspace_storage: "100Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
   - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.20.8-x86_64"


### PR DESCRIPTION
## Summary
- Replace the 150Gi `ephemeral-storage` request under `build_step_resources` with a 100Gi `workspace_storage` PVC (`volumeClaimTemplate`)
- This avoids node-level ephemeral-storage eviction issues by using network-attached persistent storage for the large ISO build artifacts
- Mirrors the same change already merged for 4.21: https://github.com/openshift-eng/ocp-build-data/pull/9521
- Requires the corresponding `art-tools` change: https://github.com/openshift-eng/art-tools/pull/2632

## Test plan
- [ ] Trigger a Konflux build for `art-agent-installer-iso` on 4.20 and verify the PipelineRun includes a `volumeClaimTemplate` workspace with 100Gi
- [ ] Verify the build completes without ephemeral-storage eviction

Made with [Cursor](https://cursor.com)