### PR TITLE
Fix ose-insights-runtime-exporter

### DIFF
--- a/images/ose-insights-runtime-exporter.yml
+++ b/images/ose-insights-runtime-exporter.yml
@@ -20,7 +20,7 @@ delivery:
   - openshift4/insights-runtime-exporter-rhel9
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9
 for_payload: true
 payload_name: insights-runtime-exporter


### PR DESCRIPTION
Test PLR: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-21/pipelineruns/ose-4-21-ose-insights-runtime-exporter-xf2rw

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED