### PR TITLE
ose-libvirt-machine-controllers hermetic 4.18

### DIFF
--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -38,6 +38,7 @@ payload_name: libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com
 konflux:
-  network_mode: open
   cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
+    lockfile:
+      rpms:
+      - libvirt-devel


### PR DESCRIPTION
follows https://github.com/openshift/cluster-api-provider-libvirt/pull/300

[test build (needs an open one first)](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-ose-libvirt-machine-controllers-rzwdt/)