### PR TITLE
Remove MISMATCHED_SIBLINGS code entry from prerelease_permits

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -394,8 +394,6 @@ releases:
         # ref. https://redhat-internal.slack.com/archives/C01CQA76KMX/p1738863088399379
         - code: INCONSISTENT_RHCOS_RPMS
           component: rhcos
-        - code: MISMATCHED_SIBLINGS
-          component: '*'
         - code: FAILED_CONSISTENCY_REQUIREMENT
           component: '*'
       members:


### PR DESCRIPTION
Removed the MISMATCHED_SIBLINGS code entry from releases.yml.

The rationale for this change is that MISMATCHED_SIBLINGS is a risky permit and can result in failures/regressions in nightlies and ECs we produce down the line. 