### PR TITLE
hermetic 4.16

### DIFF
--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -29,6 +29,3 @@ owners:
 - bpeterse@redhat.com
 - spadgett@redhat.com
 - jforrest@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -30,5 +30,3 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -33,6 +33,3 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows 
https://github.com/openshift/console-operator/pull/1115
https://github.com/openshift/machine-api-provider-openstack/pull/163
https://github.com/openshift/cloud-provider-vsphere/pull/107

[openshift-enterprise-console-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-openshift-enterprise-console-operator-7lpds)
[ose-machine-api-provider-openstack test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-machine-api-provider-openstack-vcn8f/)
[ose-vsphere-cloud-controller-manager test build ](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-vsphere-cloud-controller-manager-794gf)
