### PR TITLE
Add Konflux build_step_resources and workspace_storage for large builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -49,6 +49,10 @@ konflux:
       force: true
   sast:
     enabled: true
+  build_step_resources:
+    memory: "8Gi"
+    ephemeral-storage: "250Gi"
+  workspace_storage: "100Gi"
   network_mode: hermetic
 
 okd:


### PR DESCRIPTION
## Summary
- Add `build_step_resources` (memory: 8Gi, ephemeral-storage: 250Gi) and `workspace_storage: 100Gi` to the global Konflux config in group.yml
- This provisions a 100Gi PVC via `volumeClaimTemplate` on the PipelineRun and requests 250Gi ephemeral-storage for the build step
- Needed for large image builds like `agent-installer-iso` (~54GB) that exceed default node ephemeral storage limits

## Test plan
- [x] Verified art-tools code correctly reads and injects these values
- [ ] Trigger a Konflux build for agent-installer-iso and verify the PLR includes both the volumeClaimTemplate and ephemeral-storage requests

Made with [Cursor](https://cursor.com)