### PR TITLE
allow_unprotected_branch for mta-operator

### DIFF
--- a/images/mta-operator.yml
+++ b/images/mta-operator.yml
@@ -6,6 +6,7 @@ content:
         target: release-0.9
       url: git@github.com:openshift-priv/migtools-mta-operator.git
       web: https://github.com/migtools/mta-operator
+      allow_unprotected_branch: true
     modifications:
       # https://github.com/migtools/mta-operator/blob/release-0.9/konflux.Dockerfile#L14
       - action: replace


### PR DESCRIPTION
Signed-off-by: Franco Bladilo <fbladilo@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED