### PR TITLE
[DRAFT] Test branch for ansible-operator (4.19)

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -1,7 +1,6 @@
 ---
-
 jira_config:
-  server: "https://issues.redhat.com"
+  server: "https://redhat.atlassian.net/"
   project: "OCPBUGS"
 
 bugzilla_config:
@@ -23,10 +22,10 @@ kernel_bug_sweep:
   tracker_jira:
     project: KMAINT
     labels:
-    - early-kernel-track
+      - early-kernel-track
   bugzilla:
     target_releases:
-    - "{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}.0"
+      - "{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}.0"
   target_jira:
     project: OCPBUGS
     component: RHCOS

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -3,8 +3,9 @@ content:
     dockerfile: openshift/Dockerfile
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: release-4.19
       url: git@github.com:openshift-priv/ansible-operator-plugins.git
+      url_pull: git@github.com:mytreya-rh/ansible-operator-plugins.git
       # : git@github.com:lgarciaaco/ansible-operator-plugins.git
       web: https://github.com/openshift/ansible-operator-plugins
     ci_alignment:
@@ -13,18 +14,18 @@ content:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
     pkg_managers:
-    - pip
+      - pip
 cachito:
   enabled: true
   packages:
     pip:
-    - path: openshift
-      requirements_files:
-      - requirements.txt
-      requirements_build_files:
-      - requirements-build.txt
-      - requirements-build1.txt
-      - requirements-pre-build.txt
+      - path: openshift
+        requirements_files:
+          - requirements.txt
+        requirements_build_files:
+          - requirements-build.txt
+          - requirements-build1.txt
+          - requirements-pre-build.txt
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-ansible-operator-container
@@ -32,42 +33,42 @@ delivery:
   # Maps to honeybadger repo_name
   repo_name: ose-ansible-operator
   delivery_repo_names:
-  - openshift4/ose-ansible-rhel9-operator
+    - openshift4/ose-ansible-rhel9-operator
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
-- rhel-9-codeready-builder-rpms
+  - rhel-9-baseos-rpms
+  - rhel-9-appstream-rpms
+  - rhel-9-codeready-builder-rpms
 for_payload: false
 from:
   builder:
-  - stream: rhel-9-golang
+    - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 maintainer:
   component: Operator SDK
 name: openshift/ose-ansible-rhel9-operator
 owners:
-- aos-operator-sdk@redhat.com
-- jlanford@redhat.com
-- fabian@redhat.com
-- tgeer@redhat.com
-- ckyal@redhat.com
-- arsen@redhat.com
+  - aos-operator-sdk@redhat.com
+  - jlanford@redhat.com
+  - fabian@redhat.com
+  - tgeer@redhat.com
+  - ckyal@redhat.com
+  - arsen@redhat.com
 konflux:
   cachi2:
     lockfile:
       rpms:
-      - binutils
-      - binutils-gold
-      - cpp
-      - elfutils-debuginfod-client
-      - gcc
-      - glibc
-      - glibc-headers
-      - glibc-devel
-      - kernel-headers
-      - libasan
-      - libatomic
-      - libmpc
-      - libubsan
-      - libxcrypt-devel
-      - make
+        - binutils
+        - binutils-gold
+        - cpp
+        - elfutils-debuginfod-client
+        - gcc
+        - glibc
+        - glibc-headers
+        - glibc-devel
+        - kernel-headers
+        - libasan
+        - libatomic
+        - libmpc
+        - libubsan
+        - libxcrypt-devel
+        - make


### PR DESCRIPTION
## Summary
Ports changes from PR #9453 (openshift-4.22) to openshift-4.19:
- Update Jira server URL from `issues.redhat.com` to `redhat.atlassian.net/` (Jira Cloud migration)
- Fix YAML list indentation in `bug.yml`
- Update ansible-operator branch target to `release-4.19`
- Add `url_pull` for `mytreya-rh` fork
- Fix YAML list indentation in `images/openshift-enterprise-ansible-operator.yml`

## Test plan
- [ ] Validate YAML with `validate-ocp-build-data`
- [ ] Verify ansible-operator image builds correctly with the new branch target

🤖 Generated with [Claude Code](https://claude.com/claude-code)