### PR TITLE
[DRAFT] Test branch for ansible-operator (4.16)

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -1,7 +1,7 @@
 ---
 
 jira_config:
-  server: "https://issues.redhat.com"
+  server: "https://redhat.atlassian.net/"
   project: "OCPBUGS"
 
 bugzilla_config:

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -3,8 +3,9 @@ content:
     dockerfile: openshift/Dockerfile
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: release-4.16
       url: git@github.com:openshift-priv/ansible-operator-plugins.git
+      url_pull: git@github.com:mytreya-rh/ansible-operator-plugins.git
       web: https://github.com/openshift/ansible-operator-plugins
     ci_alignment:
       streams_prs:


### PR DESCRIPTION
## Summary
Ports changes from PR #9453 (openshift-4.22) to openshift-4.16:
- Update Jira server URL from `issues.redhat.com` to `redhat.atlassian.net/` (Jira Cloud migration)
- Update ansible-operator branch target to `release-4.16`
- Add `url_pull` for `mytreya-rh` fork

## Test plan
- [ ] Validate YAML with `validate-ocp-build-data`
- [ ] Verify ansible-operator image builds correctly with the new branch target

🤖 Generated with [Claude Code](https://claude.com/claude-code)