### PR TITLE
ose-agent-installer-api-server hermetic 4.12

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -26,11 +26,17 @@ maintainer:
 name: openshift/ose-agent-installer-api-server-rhel8
 owners:
 - ocp-agent-team@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # vendor changed upstream - https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-agent-installer-api-server-rhel8
+konflux:
+  cachi2:
+    lockfile:
+      modules:
+      - postgresql:10
+      - virt:rhel
+      rpms:
+      - libvirt-libs
+      - nmstate
+      - postgresql-server
 payload_name: agent-installer-api-server


### PR DESCRIPTION
follows https://github.com/openshift/assisted-service/pull/9956

[test build (needs open first)](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-agent-installer-api-server-8224g)