### PR TITLE
ose-agent-installer-api-server hermetic 4.14

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -27,9 +27,31 @@ name: openshift/ose-agent-installer-api-server-rhel8
 owners:
 - ocp-agent-team@redhat.com
 konflux:
-  network_mode: open
   cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
+    lockfile:
+      modules:
+      - postgresql:16
+      rpms:
+      - binutils
+      - binutils-gold
+      - cpp
+      - elfutils-debuginfod-client
+      - gcc
+      - gcc-c++
+      - libgomp
+      - libstdc++-devel
+      - glibc
+      - glibc-headers
+      - glibc-devel
+      - kernel-headers
+      - libasan
+      - libatomic
+      - libmpc
+      - libubsan
+      - libxcrypt-devel
+      - make
+      - nmstate-devel
+      - nmstate-libs
 delivery:
   delivery_repo_names:
   - openshift4/ose-agent-installer-api-server-rhel8


### PR DESCRIPTION
follows https://github.com/openshift/assisted-service/pull/9955

[test build (needs open first)](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-agent-installer-api-server-ctcsm/)