### PR TITLE
scan-sources-konflux:noop [4.19] Configure build attempts

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -50,6 +50,9 @@ konflux:
   sast:
     enabled: true
   network_mode: hermetic
+  # The number of times a build should be attempted before giving up.
+  # Each failed attempt will result in a failed record in BigQuery
+  build_attempts: 1
 
 multi_arch:
   enabled: true

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -37,3 +37,4 @@ konflux:
   vm_override:
     x86_64: linux-d160-c4xlarge/amd64
     aarch64: linux-d160-c4xlarge/arm64
+  build_attempts: 3

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -43,3 +43,5 @@ name: openshift/ose-installer-rhel9
 payload_name: installer
 owners:
 - aos-install@redhat.com
+konflux:
+  build_attempts: 3


### PR DESCRIPTION
Cherry-pick of f54d1f5deb90ab52a92842fd5253746d626e0e4c from openshift-4.22.

Configures `build_attempts` for Konflux builds:
- Default of 1 attempt in group.yml
- 3 attempts for ose-installer and ose-installer-artifacts

Made with [Cursor](https://cursor.com)