### PR TITLE
openshift-enterprise-console-operator hermetic 4.14

### DIFF
--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -23,7 +23,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-console-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: console-operator


### PR DESCRIPTION
follows https://github.com/openshift/console-operator/pull/1131 and https://github.com/openshift/console-operator/pull/1117

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-openshift-enterprise-console-operator-cl82w)