### PR TITLE
Fix microdnf skip_if_unavailable warning in ci-openshift-base-rhel9

### DIFF
--- a/ci_images/install_dnf_wrapper.sh
+++ b/ci_images/install_dnf_wrapper.sh
@@ -31,14 +31,15 @@ wrap_command() {
 # Allow repos to be skipped if they are not responsive. Reasons:
 # 1. A single misconfigured repo in the CI mirroring service should not break all CI.
 # 2. If a user it not connected to the VPN, the internal repos will not be accessible, but should not break all yum operations.
-yum config-manager --setopt=skip_if_unavailable=True --save
-
-# SSL certificates for ocp-artifacts will not be trusted by default
-# CAs, so ignore ssl requirements. http is used by the in-cluster
-# build farms.
-yum config-manager --setopt=skip_if_unavailable=True --save
+# Note: microdnf doesn't support config-manager, so write directly to config file
+if which microdnf &>/dev/null; then
+  echo "skip_if_unavailable=True" >> /etc/dnf/dnf.conf
+else
+  yum config-manager --setopt=skip_if_unavailable=True --save
+fi
 
 wrap_command yum
 wrap_command dnf
+wrap_command microdnf
 
 


### PR DESCRIPTION
## Summary
- Backport of 3b96064d7 from 4.22 to fix `yum config-manager` warnings when `microdnf` is the package manager
- Detects microdnf and writes `skip_if_unavailable=True` directly to `/etc/dnf/dnf.conf` instead of calling `yum config-manager` (which microdnf doesn't support)
- Adds `microdnf` to the list of wrapped commands

## Test plan
- [ ] Verify ci-openshift-base-rhel9 builds without `librhsm-WARNING` messages about entitlement certificates
- [ ] Verify `skip_if_unavailable=True` is correctly set in `/etc/dnf/dnf.conf` when microdnf is present
- [ ] Verify `yum config-manager` path still works for images without microdnf

🤖 Generated with [Claude Code](https://claude.com/claude-code)