### PR TITLE
openshift-enterprise-console-operator hermetic 4.15

### DIFF
--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -29,6 +29,3 @@ owners:
 - bpeterse@redhat.com
 - spadgett@redhat.com
 - jforrest@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/console-operator/pull/1130 and https://github.com/openshift/console-operator/pull/1116

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-openshift-enterprise-console-operator-n5qv9)