### PR TITLE
multus-cni hermetic 4.17

### DIFF
--- a/images/multus-cni-container-microshift.yml
+++ b/images/multus-cni-container-microshift.yml
@@ -41,7 +41,3 @@ owners:
 - tohayash@redhat.com
 - dosmith@redhat.com
 - microshift-devel@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -38,7 +38,3 @@ name: openshift/ose-multus-cni-rhel9
 payload_name: multus-cni
 owners:
 - multus-dev@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false


### PR DESCRIPTION
follows https://github.com/openshift/multus-cni/pull/277

[multus-cni test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-multus-cni-vtkcp)
[multus-cni-container-microshift test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-multus-cni-container-microshift-x6r2p)