### PR TITLE
Add libgomp to agent-installer cachi2 lockfile rpms

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -54,6 +54,7 @@ konflux:
       - kernel-headers
       - libasan
       - libatomic
+      - libgomp
       - libmpc
       - libubsan
       - libxcrypt-devel

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -52,6 +52,7 @@ konflux:
       - kernel-headers
       - libasan
       - libatomic
+      - libgomp
       - libmpc
       - libubsan
       - libxcrypt-devel


### PR DESCRIPTION
## Summary
- Add missing `libgomp` package to the konflux cachi2 lockfile rpms for `ose-agent-installer-api-server` and `ose-agent-installer-utils`
- Other gcc sub-packages (`libasan`, `libatomic`, `libubsan`) were already listed but `libgomp` was missing, causing build failures

## Test plan
- [ ] Verify Konflux builds for both images succeed with libgomp available

🤖 Generated with [Claude Code](https://claude.com/claude-code)