### PR TITLE
4.21 ose-azure-disk-csi-driver: bump golang to 1.25

### DIFF
--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -33,7 +33,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-azure-disk-csi-driver-rhel9
 payload_name: azure-disk-csi-driver


### PR DESCRIPTION
after https://github.com/openshift/azure-disk-csi-driver/pull/126

builds failing with 
`go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`