### PR TITLE
Add gcc-plugin-annobin to ose-network-tools cachi2 lockfile rpms

### DIFF
--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -36,3 +36,5 @@ konflux:
     lockfile:
       modules:
       - nginx:1.26
+      rpms:
+      - gcc-plugin-annobin


### PR DESCRIPTION
## Summary
- Add missing `gcc-plugin-annobin` to the konflux cachi2 lockfile rpms for `ose-network-tools`

## Test plan
- [ ] Verify Konflux build for ose-network-tools succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)