### PR TITLE
Add gcc-plugin-annobin to ose-network-tools lockfile and bump nginx module

### DIFF
--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -35,4 +35,6 @@ konflux:
   cachi2:
     lockfile:
       modules:
-      - nginx:1.24
+      - nginx:1.26
+      rpms:
+      - gcc-plugin-annobin


### PR DESCRIPTION
## Summary
- Add missing `gcc-plugin-annobin` to the konflux cachi2 lockfile rpms for `ose-network-tools`
- Bump nginx module from 1.24 to 1.26

## Test plan
- [ ] Verify Konflux build for ose-network-tools succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)