### PR TITLE
Remove pip upgrade from dpu-intel-ipu-p4sdk to fix setuptools conflict

### DIFF
--- a/images/dpu-intel-ipu-p4sdk.yml
+++ b/images/dpu-intel-ipu-p4sdk.yml
@@ -9,6 +9,10 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/dpu-operator.git
       web: https://github.com/openshift/dpu-operator
+    modifications:
+    - action: replace
+      match: "RUN chmod +x install-dpu.sh \\"
+      replacement: "RUN sed -i '/python3 -m pip install --upgrade pip/d' install-dpu.sh && chmod +x install-dpu.sh \\"
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
## Summary
- Add a Dockerfile modification to strip `python3 -m pip install --upgrade pip` from `install-dpu.sh` via `sed -i` before execution
- The rolling RHEL 9 repos now ship `python3-setuptools-53.0.0-15.el9` which lacks pip RECORD metadata, causing pip to fail with "Cannot uninstall setuptools 53.0.0" when it tries to upgrade itself and then replace setuptools
- The E4S 9.6 repos (used by 4.23) still have `-13.el9_6.1` which works, explaining why 4.23 builds succeed while 4.22 and 5.0 fail

## Test plan
- [ ] Verify Konflux build for dpu-intel-ipu-p4sdk succeeds on 4.22

🤖 Generated with [Claude Code](https://claude.com/claude-code)