### PR TITLE
hermetic 4.16

### DIFF
--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -34,6 +34,3 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -38,6 +38,7 @@ payload_name: libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com
 konflux:
-  network_mode: open
   cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
+    lockfile:
+      rpms:
+        - libvirt-devel


### PR DESCRIPTION
follows 
https://github.com/openshift/cluster-api-provider-aws/pull/591
https://github.com/openshift/cluster-api-provider-libvirt/pull/302

[ose-aws-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-aws-cluster-api-controllers-wcjtr)
[ose-libvirt-machine-controllers test build (needs an open first)](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-libvirt-machine-controllers-9sdmz)