### PR TITLE
hermetic 4.14

### DIFF
--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -28,9 +28,12 @@ name: openshift/ose-libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com
 konflux:
-  network_mode: open
   cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
+    lockfile:
+      rpms:
+        - libvirt-devel
+      modules:
+        - virt:rhel
 delivery:
   delivery_repo_names:
   - openshift4/ose-libvirt-machine-controllers

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -21,8 +21,6 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-openstack-rhel8

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -35,6 +35,3 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-ptp-operator-bundle
   delivery_repo_names:
   - openshift4/ose-ptp-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows:
https://github.com/openshift/cluster-api-provider-libvirt/pull/304
https://github.com/openshift/machine-api-provider-openstack/pull/165
https://github.com/openshift/ptp-operator/pull/674

[ose-libvirt-machine-controllers test build (needs open first)](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-libvirt-machine-controllers-mhcz5/)
[ose-machine-api-provider-openstack test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-machine-api-provider-openstack-684xr)
[ptp-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ptp-operator-t6zrn)