### PR TITLE
hermetic 4.13

### DIFF
--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -28,9 +28,12 @@ name: openshift/ose-libvirt-machine-controllers
 owners:
 - pkrupa@redhat.com
 konflux:
-  network_mode: open
   cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
+    lockfile:
+      rpms:
+        - libvirt-devel
+      modules:
+        - virt:rhel
 delivery:
   delivery_repo_names:
   - openshift4/ose-libvirt-machine-controllers

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -24,8 +24,6 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-gcp-rhel8

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -30,6 +30,3 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-metallb-operator-bundle
   delivery_repo_names:
   - openshift4/metallb-rhel8-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows
https://github.com/openshift/cluster-api-provider-libvirt/pull/305
https://github.com/openshift/machine-api-provider-gcp/pull/142
https://github.com/openshift/metallb-operator/pull/319

[ose-libvirt-machine-controllers test build (needs an open first)](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-libvirt-machine-controllers-8prf8)
[ose-machine-api-provider-gcp test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-machine-api-provider-gcp-gstw8)
[ose-metallb-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-metallb-operator-rbbcj)
