### PR TITLE
ose-metallb-operator hermetic 4.12

### DIFF
--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -30,6 +30,3 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-metallb-operator-bundle
   delivery_repo_names:
   - openshift4/metallb-rhel8-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/metallb-operator/pull/320

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-metallb-operator-6q8d8)