### PR TITLE
ART-14754: Switch to x86_64 with vm_override for installer-ove-ui-4.20

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -8,12 +8,12 @@ vars:
 
 
 arches:
-- x86_64_root
+- x86_64
 
 
 konflux:
   arches:
-  - x86_64_root
+  - x86_64
   network_mode: open
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   privileged_nested: true

--- a/images/art-agent-installer-iso.yml
+++ b/images/art-agent-installer-iso.yml
@@ -27,3 +27,5 @@ owners:
 - ocp-agent-team@redhat.com
 konflux:
   no_shell: true  # Skip .oit injected RUN commands (e.g. yum repo setup) since this image does not use RPMs
+  vm_override:
+    x86_64: "linux-d320-m8xlarge/amd64"


### PR DESCRIPTION
## Summary

Port the same changes from `installer-ove-ui-4.21` to the 4.20 branch:

- Replace `x86_64_root` with `x86_64` in `arches` and `konflux.arches` (root access no longer needed)
- Keep `ephemeral-storage` at `150Gi`
- Add `vm_override` to image config to use `linux-d320-m8xlarge/amd64` for x86_64 (larger VM to accommodate ~54GB ISO build)

### Files changed
- `group.yml` -- arch change
- `images/art-agent-installer-iso.yml` -- vm_override added