### PR TITLE
Add python3.12-watchdog to ironic lockfile RPMs

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -180,6 +180,7 @@ konflux:
       - python3.12-setuptools
       - python3.12-setuptools_scm
       - python3.12-typing-extensions
+      - python3.12-watchdog
       - python3.12-wheel
       - rpm-build-libs
       - rpm-plugin-systemd-inhibit


### PR DESCRIPTION
## Summary
- Add `python3.12-watchdog` to the Konflux cachi2 lockfile RPMs for the ironic image

Made with [Cursor](https://cursor.com)