### PR TITLE
Add python3.12-watchdog to ironic lockfile RPMs

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -144,6 +144,7 @@ konflux:
       - pkgconf-m4
       - pkgconf-pkg-config
       - python3.12-devel
+      - python3.12-watchdog
       - python3.12-wheel
       - python3.12-lark
       - python3.12-ironic-prometheus-exporter


### PR DESCRIPTION
## Summary
- Add `python3.12-watchdog` to the Konflux cachi2 lockfile RPMs for the ironic image

Made with [Cursor](https://cursor.com)