### PR TITLE
Add llvm-filesystem to ose-network-tools

### DIFF
--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -38,3 +38,4 @@ konflux:
       - nginx:1.26
       rpms:
       - gcc-plugin-annobin
+      - llvm-filesystem


### PR DESCRIPTION
## Summary
- Add llvm-filesystem to the Konflux cachi2 RPM lockfile for ose-network-tools

## Test plan
- [ ] Verify ose-network-tools builds successfully with llvm-filesystem included

🤖 Generated with [Claude Code](https://claude.com/claude-code)