### PR TITLE
fix microshift-bootc image tag

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -9,7 +9,7 @@ content:
     modifications:
     - action: replace
       match: "ARG BASE_IMAGE_URL"
-      replacement: "ARG BASE_IMAGE_URL='registry.stage.redhat.io/rhel9/rhel-bootc:9.8'"
+      replacement: "ARG BASE_IMAGE_URL='registry.stage.redhat.io/rhel9/rhel-bootc'"
     - action: replace
       match: "ARG BASE_IMAGE_TAG"
       replacement: "ARG BASE_IMAGE_TAG='9.8'"


### PR DESCRIPTION
[failing build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-microshift-bootc-8pp98)

`Error: parsing reference "registry.stage.redhat.io/rhel9/rhel-bootc:9.8:9.8": invalid reference format`