### PR TITLE
ART-14628 update microshift bootc to rhel 9.8

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -9,10 +9,10 @@ content:
     modifications:
     - action: replace
       match: "ARG BASE_IMAGE_URL"
-      replacement: "ARG BASE_IMAGE_URL='registry.redhat.io/rhel9-eus/rhel-9.6-bootc'"
+      replacement: "ARG BASE_IMAGE_URL='registry.stage.redhat.io/rhel9/rhel-bootc'"
     - action: replace
       match: "ARG BASE_IMAGE_TAG"
-      replacement: "ARG BASE_IMAGE_TAG='9.6'"
+      replacement: "ARG BASE_IMAGE_TAG='9.8'"
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED