### PR TITLE
ART-14786 Enable ci golang build root images for extra version

### DIFF
--- a/images/ci-openshift-build-root-extra.rhel8.yml
+++ b/images/ci-openshift-build-root-extra.rhel8.yml
@@ -1,0 +1,58 @@
+content:
+  # set_build_variables to false, as setting git commit env vars break certain
+  # workloads. Set env vars in the Dockerfile, and use modifications if they
+  # should be variable
+  set_build_variables: false
+  source:
+    dockerfile: ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+    git:
+      branch:
+        target: openshift-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: true
+      mirror_manifest_list: true
+      upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+    modifications:
+    - action: replace
+      match: "ENV CI_RPM_SVC=base-MAJOR-MINOR-rhelX.ocp.svc"
+      replacement: "ENV CI_RPM_SVC=base-{MAJOR}-{MINOR}-rhel8.ocp.svc"
+from:
+  member: ci-openshift-golang-builder-extra.rhel8
+labels:
+  io.k8s.description: golang {GO_EXTRA} build-root image for Red Hat CI
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: ci-openshift-build-root-extra-container
+
+# Repos enabled in the builder image will be ultimately be injected as repos
+# in the builder image. This means that engineers who download the image and
+# run it connected to the VPN will be able to access the content. This is
+# desirable since it allows Dockerfile builds requiring RPMs to work as long
+# as the host is connected to the VPN.
+enabled_repos:
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-server-ose-rpms
+- rhel-8-fast-datapath-rpms
+
+name: openshift/ci-openshift-build-root-extra-rhel8
+for_payload: false
+for_release: false
+owners:
+- aos-team-art@redhat.com
+maintainer:
+  component: Release
+
+# The from: stanza is exactly what we want to use. So ignore anything in
+# the Dockerfile.
+canonical_builders_from_upstream: false
+
+scan_sources:
+  exempt_rpms:
+  - '*'
+konflux:
+  network_mode: open

--- a/images/ci-openshift-build-root-extra.rhel9.yml
+++ b/images/ci-openshift-build-root-extra.rhel9.yml
@@ -1,0 +1,60 @@
+content:
+  # set_build_variables to false, as setting git commit env vars break certain
+  # workloads. Set env vars in the Dockerfile, and use modifications if they
+  # should be variable
+  set_build_variables: false
+  source:
+    dockerfile: ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+    git:
+      branch:
+        target: openshift-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: true
+      mirror_manifest_list: true
+      upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+    modifications:
+    - action: replace
+      match: "ENV CI_RPM_SVC=base-MAJOR-MINOR-rhelX.ocp.svc"
+      replacement: "ENV CI_RPM_SVC=base-{MAJOR}-{MINOR}-rhel9.ocp.svc"
+
+from:
+  member: ci-openshift-golang-builder-extra.rhel9
+labels:
+  io.k8s.description: golang {GO_EXTRA} build-root image for Red Hat CI
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ci-openshift-build-root-extra-container
+
+# Repos enabled in the builder image will be ultimately be injected as repos
+# in the builder image. This means that engineers who download the image and
+# run it connected to the VPN will be able to access the content. This is
+# desirable since it allows Dockerfile builds requiring RPMs to work as long
+# as the host is connected to the VPN.
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-codeready-builder-rpms
+- rhel-9-server-ose-rpms
+- rhel-9-fast-datapath-rpms
+
+name: openshift/ci-openshift-build-root-extra-rhel9
+for_payload: false
+for_release: false
+owners:
+- aos-team-art@redhat.com
+maintainer:
+  component: Release
+
+# The from: stanza is exactly what we want to use. So ignore anything in
+# the Dockerfile.
+canonical_builders_from_upstream: false
+
+scan_sources:
+  exempt_rpms:
+  - '*'
+konflux:
+  network_mode: open


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ART-14786

We have GO_EXTRA defined https://github.com/openshift-eng/ocp-build-data/blob/83f056efcbcbb2f557478affc4a71446a36065b3/group.yml#L27 but we are not building ci build root images for it.

The content of the config is similar to build-root-latest images https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.19/images/ci-openshift-build-root-latest.rhel8.yml
except the `latest` -> `extra`

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED