### PR TITLE
Remove rjohnson@redhat.com from OADP image owners

### DIFF
--- a/images/oadp-kubevirt-velero-plugin.yml
+++ b/images/oadp-kubevirt-velero-plugin.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-kubevirt-velero-plugin-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-mustgather.yml
+++ b/images/oadp-mustgather.yml
@@ -39,7 +39,6 @@ from:
 name: oadp/oadp-mustgather-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -36,7 +36,6 @@ from:
 name: oadp/oadp-rhel9-operator
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 update-csv:
   bundle-dir: manifests/
   manifests-dir: bundle/

--- a/images/oadp-velero-plugin-for-aws.yml
+++ b/images/oadp-velero-plugin-for-aws.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-for-aws-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero-plugin-for-gcp.yml
+++ b/images/oadp-velero-plugin-for-gcp.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-for-gcp-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero-plugin-for-legacy-aws.yml
+++ b/images/oadp-velero-plugin-for-legacy-aws.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-for-legacy-aws-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero-plugin-for-microsoft-azure.yml
+++ b/images/oadp-velero-plugin-for-microsoft-azure.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero-plugin.yml
+++ b/images/oadp-velero-plugin.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero-restic-restore-helper.yml
+++ b/images/oadp-velero-restic-restore-helper.yml
@@ -36,7 +36,6 @@ from:
 name: oadp/oadp-velero-restic-restore-helper-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero.yml
+++ b/images/oadp-velero.yml
@@ -36,7 +36,6 @@ from:
 name: oadp/oadp-velero-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:


### PR DESCRIPTION
## Summary
- Remove `rjohnson@redhat.com` from the `owners` field in all OADP image YAML files
- `oadp-maintainers@redhat.com` remains as the owner for all images

## Files changed (10)
All `images/oadp-*.yml` files on the `oadp-1.4` branch.

Made with [Cursor](https://cursor.com)