### PR TITLE
Remove rjohnson@redhat.com from OADP image owners

### DIFF
--- a/images/oadp-hypershift-velero-plugin.yml
+++ b/images/oadp-hypershift-velero-plugin.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-hypershift-velero-plugin-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-kubevirt-velero-plugin.yml
+++ b/images/oadp-kubevirt-velero-plugin.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-kubevirt-velero-plugin-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-mustgather.yml
+++ b/images/oadp-mustgather.yml
@@ -36,7 +36,6 @@ from:
 name: oadp/oadp-mustgather-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-non-admin.yml
+++ b/images/oadp-non-admin.yml
@@ -27,7 +27,6 @@ from:
 name: oadp/oadp-non-admin-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -36,7 +36,6 @@ from:
 name: oadp/oadp-rhel9-operator
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 update-csv:
   bundle-dir: manifests/
   manifests-dir: bundle/

--- a/images/oadp-velero-plugin-for-aws.yml
+++ b/images/oadp-velero-plugin-for-aws.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-for-aws-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero-plugin-for-gcp.yml
+++ b/images/oadp-velero-plugin-for-gcp.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-for-gcp-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero-plugin-for-legacy-aws.yml
+++ b/images/oadp-velero-plugin-for-legacy-aws.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-for-legacy-aws-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero-plugin-for-microsoft-azure.yml
+++ b/images/oadp-velero-plugin-for-microsoft-azure.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero-plugin.yml
+++ b/images/oadp-velero-plugin.yml
@@ -35,7 +35,6 @@ from:
 name: oadp/oadp-velero-plugin-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-velero.yml
+++ b/images/oadp-velero.yml
@@ -36,7 +36,6 @@ from:
 name: oadp/oadp-velero-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:

--- a/images/oadp-vm-file-restore.yml
+++ b/images/oadp-vm-file-restore.yml
@@ -27,7 +27,6 @@ from:
 name: oadp/oadp-vm-file-restore-rhel9
 owners:
   - oadp-maintainers@redhat.com
-  - rjohnson@redhat.com
 dependents:
   - oadp-operator
 konflux:


### PR DESCRIPTION
## Summary
- Remove `rjohnson@redhat.com` from the `owners` field in all OADP image YAML files
- `oadp-maintainers@redhat.com` remains as the owner for all images

## Files changed (12)
All `images/oadp-*.yml` files on the `oadp-1.6` branch.

Made with [Cursor](https://cursor.com)