### PR TITLE
Replace individual owners with mta-devs@redhat.com

### DIFF
--- a/images/mta-analyzer-addon.yml
+++ b/images/mta-analyzer-addon.yml
@@ -28,8 +28,7 @@ from:
   member: mta-analyzer-lsp
 name: mta/mta-analyzer-addon-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
 konflux:

--- a/images/mta-analyzer-lsp.yml
+++ b/images/mta-analyzer-lsp.yml
@@ -28,8 +28,7 @@ from:
   stream: rhel9
 name: mta/mta-analyzer-lsp-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
   - mta-analyzer-addon

--- a/images/mta-analyzer-rpc.yml
+++ b/images/mta-analyzer-rpc.yml
@@ -30,8 +30,7 @@ from:
   stream: rhel9
 name: mta/mta-analyzer-rpc-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
 konflux:

--- a/images/mta-cli.yml
+++ b/images/mta-cli.yml
@@ -32,8 +32,7 @@ from:
   member: mta-java-external-provider
 name: mta/mta-cli-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
 konflux:

--- a/images/mta-discovery-addon.yml
+++ b/images/mta-discovery-addon.yml
@@ -28,7 +28,6 @@ from:
   stream: rhel9
 name: mta/mta-discovery-addon-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator

--- a/images/mta-dotnet-external-provider.yml
+++ b/images/mta-dotnet-external-provider.yml
@@ -30,8 +30,7 @@ from:
   stream: rhel9
 name: mta/mta-dotnet-external-provider-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
 konflux:

--- a/images/mta-generic-external-provider.yml
+++ b/images/mta-generic-external-provider.yml
@@ -32,8 +32,7 @@ from:
   stream: rhel9
 name: mta/mta-generic-external-provider-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
   - mta-cli

--- a/images/mta-golang-dependency-provider.yml
+++ b/images/mta-golang-dependency-provider.yml
@@ -30,8 +30,7 @@ from:
   stream: rhel9
 name: mta/mta-golang-dependency-provider-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
   - mta-generic-external-provider

--- a/images/mta-hub.yml
+++ b/images/mta-hub.yml
@@ -31,8 +31,7 @@ from:
   stream: rhel9
 name: mta/mta-hub-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
 konflux:

--- a/images/mta-java-external-provider.yml
+++ b/images/mta-java-external-provider.yml
@@ -29,8 +29,7 @@ from:
   member: mta-jdtls-server-base
 name: mta/mta-java-external-provider-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-cli
   - mta-operator

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -24,8 +24,7 @@ from:
   stream: rhel9
 name: mta/mta-jdtls-server-base-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
   - mta-java-external-provider

--- a/images/mta-operator.yml
+++ b/images/mta-operator.yml
@@ -29,8 +29,7 @@ from:
   stream: rhel-9-ansible-operator
 name: mta/mta-rhel9-operator
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 update-csv:
   bundle-dir: manifests/
   manifests-dir: bundle/

--- a/images/mta-platform-addon.yml
+++ b/images/mta-platform-addon.yml
@@ -28,7 +28,6 @@ from:
   stream: rhel9
 name: mta/mta-platform-addon-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -25,8 +25,7 @@ from:
   stream: rhel9
 name: mta/mta-solution-server-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
 konflux:

--- a/images/mta-static-report.yml
+++ b/images/mta-static-report.yml
@@ -34,8 +34,7 @@ from:
   stream: rhel9
 name: mta/mta-static-report-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator
   - mta-cli

--- a/images/mta-ui.yml
+++ b/images/mta-ui.yml
@@ -33,7 +33,6 @@ from:
   stream: rhel-9-nodejs-20
 name: mta/mta-ui-rhel9
 owners:
-- fbladilo@redhat.com
-- rjohnson@redhat.com
+- mta-devs@redhat.com
 dependents:
   - mta-operator


### PR DESCRIPTION
## Summary
- Replace `fbladilo@redhat.com` and `rjohnson@redhat.com` with the team alias `mta-devs@redhat.com` in the `owners` field of all MTA image YAML files

## Files changed (16)
All `images/mta-*.yml` files on the `mta-8.1` branch.