### PR TITLE
repos/rhel-98: Switch to updates repo now that it's available

### DIFF
--- a/repos/rhel-98-appstream.yml
+++ b/repos/rhel-98-appstream.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/AppStream/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/AppStream/aarch64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/AppStream/ppc64le/os/
-      s390x: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/AppStream/s390x/os/
+      x86_64: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/AppStream/x86_64/os/
+      aarch64: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/AppStream/aarch64/os/
+      ppc64le: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/AppStream/ppc64le/os/
+      s390x: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/AppStream/s390x/os/
     extra_options:
       gpgcheck: '1'
   content_set:

--- a/repos/rhel-98-baseos.yml
+++ b/repos/rhel-98-baseos.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/BaseOS/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/BaseOS/aarch64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/BaseOS/ppc64le/os/
-      s390x: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/BaseOS/s390x/os/
+      x86_64: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/BaseOS/x86_64/os/
+      aarch64: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/BaseOS/aarch64/os/
+      ppc64le: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/BaseOS/ppc64le/os/
+      s390x: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/BaseOS/s390x/os/
     extra_options:
       excludepkgs: toolbox*
       gpgcheck: '1'

--- a/repos/rhel-98-highavailability.yml
+++ b/repos/rhel-98-highavailability.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/HighAvailability/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/HighAvailability/aarch64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/HighAvailability/ppc64le/os/
-      s390x: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/HighAvailability/s390x/os/
+      x86_64: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/HighAvailability/x86_64/os/
+      aarch64: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/HighAvailability/aarch64/os/
+      ppc64le: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/HighAvailability/ppc64le/os/
+      s390x: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/HighAvailability/s390x/os/
     extra_options:
       gpgcheck: '1'
   content_set:

--- a/repos/rhel-98-nfv.yml
+++ b/repos/rhel-98-nfv.yml
@@ -1,10 +1,10 @@
 - conf:
     baseurl:
       # We only have x86_64 repo for nfv
-      x86_64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/NFV/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/NFV/x86_64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/NFV/x86_64/os/
-      s390x: https://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/NFV/x86_64/os/
+      x86_64: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/NFV/x86_64/os/
+      aarch64: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/NFV/x86_64/os/
+      ppc64le: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/NFV/x86_64/os/
+      s390x: https://download.devel.redhat.com/rhel-9/nightly/updates/RHEL-9/latest-RHEL-9.8/compose/NFV/x86_64/os/
     extra_options:
       gpgcheck: '1'
   content_set:


### PR DESCRIPTION
0-day errata will start feeding into these repos and we'd like to pull those in as they become available.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED