### PR TITLE
ART-14786 Enable golang builders for extra version

### DIFF
--- a/images/ci-openshift-golang-builder-extra.rhel8.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel8.yml
@@ -1,0 +1,59 @@
+content:
+  # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
+  set_build_variables: true
+  source:
+    dockerfile: ci_images/rhel-8/ci-openshift-golang-builder/Dockerfile
+    git:
+      branch:
+        target: openshift-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: true
+      mirror_manifest_list: true
+      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-builder-multi-openshift-{MAJOR}.{MINOR}
+from:
+  stream: rhel-8-golang-{GO_EXTRA}
+labels:
+  io.k8s.description: golang {GO_EXTRA} builder image for Red Hat CI
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: ci-openshift-golang-builder-extra-container
+  name: ci-openshift-golang-builder-extra
+
+# Repos enabled in the builder image will be ultimately be injected as repos
+# in the builder image. This means that engineers who download the image and
+# run it connected to the VPN will be able to access the content. This is
+# desirable since it allows Dockerfile builds requiring RPMs to work as long
+# as the host is connected to the VPN.
+enabled_repos:
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-server-ose-rpms
+- rhel-8-fast-datapath-rpms
+
+name: openshift/ci-openshift-golang-builder-extra-rhel8
+for_payload: false
+for_release: false
+owners:
+- aos-team-art@redhat.com
+maintainer:
+  component: Release
+
+envs:
+  # These services run on the build farms and serve RPMs to CI workloads.
+  # This environment variable is used by dnf_wrapper.sh to know which service
+  # to acquire repo information from.
+  CI_RPM_SVC: "base-{MAJOR}-{MINOR}-rhel8.ocp.svc"
+
+# The from: stanza is exactly what we want to use. So ignore anything in
+# the Dockerfile.
+canonical_builders_from_upstream: false
+
+scan_sources:
+  exempt_rpms:
+  - '*'
+konflux:
+  network_mode: open

--- a/images/ci-openshift-golang-builder-extra.rhel9.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel9.yml
@@ -1,0 +1,58 @@
+content:
+  # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
+  set_build_variables: true
+  source:
+    dockerfile: ci_images/rhel-9/ci-openshift-golang-builder/Dockerfile
+    git:
+      branch:
+        target: openshift-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: true
+      mirror_manifest_list: true
+      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-builder-multi-openshift-{MAJOR}.{MINOR}
+from:
+  stream: rhel-9-golang-{GO_EXTRA}
+labels:
+  io.k8s.description: golang {GO_EXTRA} builder image for Red Hat CI
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ci-openshift-golang-builder-extra-container
+
+# Repos enabled in the builder image will be ultimately be injected as repos
+# in the builder image. This means that engineers who download the image and
+# run it connected to the VPN will be able to access the content. This is
+# desirable since it allows Dockerfile builds requiring RPMs to work as long
+# as the host is connected to the VPN.
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms
+- rhel-9-fast-datapath-rpms
+
+name: openshift/ci-openshift-golang-builder-extra-rhel9
+for_payload: false
+for_release: false
+owners:
+- aos-team-art@redhat.com
+maintainer:
+  component: Release
+
+envs:
+  # These services run on the build farms and serve RPMs to CI workloads.
+  # This environment variable is used by dnf_wrapper.sh to know which service
+  # to acquire repo information from.
+  CI_RPM_SVC: "base-{MAJOR}-{MINOR}-rhel9.ocp.svc"
+
+# The from: stanza is exactly what we want to use. So ignore anything in
+# the Dockerfile.
+canonical_builders_from_upstream: false
+
+scan_sources:
+  exempt_rpms:
+  - '*'
+konflux:
+  network_mode: open


### PR DESCRIPTION
prerequisite for https://github.com/openshift-eng/ocp-build-data/pull/9645/changes 

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED