### PR TITLE
add rhel-9-codeready-builder-rpms

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -347,6 +347,26 @@ repos:
     reposync:
       enabled: false
 
+  rhel-9-codeready-builder-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/ppc64le/codeready-builder/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/s390x/codeready-builder/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.2/x86_64/codeready-builder/os/
+      ci_alignment:
+        profiles:
+        - el9
+        localdev:
+          enabled: true
+    content_set:
+      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_2
+      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_2
+      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_2
+      s390x:   codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_2
+    reposync:
+      enabled: false
+
   rhel-9-appstream-rpms:
     conf:
       extra_options:


### PR DESCRIPTION
following the merge of https://github.com/openshift-eng/ocp-build-data/pull/7904

we see failures like

```
ERROR Failed to rebase openshift-base-rhel9: rhel-9-codeready-builder-rpms is not a valid repo name!
```