### PR TITLE
ose-vsphere-cloud-controller-manager hermetic 4.14

### DIFF
--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -27,7 +27,4 @@ from:
 delivery:
   delivery_repo_names:
   - openshift4/ose-vsphere-cloud-controller-manager-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: vsphere-cloud-controller-manager


### PR DESCRIPTION
follows https://github.com/openshift/cloud-provider-vsphere/pull/109

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-vsphere-cloud-controller-manager-x6mxp)