### PR TITLE
hermetic 4.13

### DIFF
--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -21,8 +21,6 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-openstack-rhel8

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -35,6 +35,3 @@ delivery:
   bundle_delivery_repo_name: openshift4/ose-ptp-operator-bundle
   delivery_repo_names:
   - openshift4/ose-ptp-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows:
https://github.com/openshift/machine-api-provider-openstack/pull/166
https://github.com/openshift/ptp-operator/pull/675 & https://github.com/openshift/ptp-operator/pull/686

[ose-machine-api-provider-openstack test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-machine-api-provider-openstack-xzlgb)
[ptp-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ptp-operator-6dmbq)