### PR TITLE
ose-machine-api-provider-gcp hermetic 4.12

### DIFF
--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -22,8 +22,6 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-gcp-rhel8


### PR DESCRIPTION
follows https://github.com/openshift/machine-api-provider-gcp/pull/143

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-machine-api-provider-gcp-jnndg)