### PR TITLE
ART-14780 ansible-operator to cs9

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -56,5 +56,3 @@ okd:
           diff --side-by-side <(rpm -qi kernel-core | grep 'Source RPM') <(rpm -qi kernel-rt-core | grep 'Source RPM') || true; \
   enabled_repos:
   - rhel-9-nfv
-  from:
-    stream: centos_stream10

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -71,5 +71,11 @@ konflux:
       - libatomic
       - libubsan
 okd:
+  distgit:
+    branch: rhaos-5.0-rhel-9
   enabled_repos:
   - rhel-9-codeready-builder-rpms
+  from:
+    builder:
+    - stream: rhel-9-golang
+    stream: centos_stream9


### PR DESCRIPTION
Test: [openshift-enterprise-ansible-operator-container-v5.0.0-202603270935.p2.g8c00498.assembly.stream.scos10](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=openshift-enterprise-ansible-operator-container-v5.0.0-202603270935.p2.g8c00498.assembly.stream.scos10&record_id=335b2ed4-bafe-ed46-f0be-8b451da976f6&group=okd-5.0&outcome=success&type=image) has `quay.io/centos/centos:stream9` as parent