### PR TITLE
Remove rjohnson@redhat.com from MTC image owners

### DIFF
--- a/images/openshift-migration-controller.yml
+++ b/images/openshift-migration-controller.yml
@@ -30,7 +30,6 @@ from:
 name: rhmtc/openshift-migration-controller-rhel8
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 jira:
   project: MIG
   component: openshift-migration-controller-container

--- a/images/openshift-migration-hook-runner.yml
+++ b/images/openshift-migration-hook-runner.yml
@@ -23,7 +23,6 @@ from:
 name: rhmtc/openshift-migration-hook-runner-rhel8
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 jira:
   project: MIG
   component: openshift-migration-hook-runner-container

--- a/images/openshift-migration-log-reader.yml
+++ b/images/openshift-migration-log-reader.yml
@@ -26,7 +26,6 @@ from:
 name: rhmtc/openshift-migration-log-reader-rhel8
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 jira:
   project: MIG
   component: openshift-migration-log-reader-container

--- a/images/openshift-migration-must-gather.yml
+++ b/images/openshift-migration-must-gather.yml
@@ -141,7 +141,6 @@ konflux:
 name: rhmtc/openshift-migration-must-gather-rhel8
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 jira:
   project: MIG
   component: openshift-migration-must-gather-container

--- a/images/openshift-migration-openvpn.yml
+++ b/images/openshift-migration-openvpn.yml
@@ -295,7 +295,6 @@ konflux:
 name: rhmtc/openshift-migration-openvpn-rhel8
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 jira:
   project: MIG
   component: openshift-migration-openvpn-container

--- a/images/openshift-migration-operator.yml
+++ b/images/openshift-migration-operator.yml
@@ -33,7 +33,6 @@ konflux:
 name: rhmtc/openshift-migration-rhel8-operator
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 update-csv:
   bundle-dir: manifests/
   manifests-dir: deploy/olm-catalog/bundle/

--- a/images/openshift-migration-registry.yml
+++ b/images/openshift-migration-registry.yml
@@ -41,7 +41,6 @@ konflux:
 name: rhmtc/openshift-migration-registry-rhel8
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 jira:
   project: MIG
   component: openshift-migration-registry-container

--- a/images/openshift-migration-rsync-transfer.yml
+++ b/images/openshift-migration-rsync-transfer.yml
@@ -37,7 +37,6 @@ from:
 name: rhmtc/openshift-migration-rsync-transfer-rhel8
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 jira:
   project: MIG
   component: openshift-migration-rsync-transfer-container

--- a/images/openshift-migration-ui.yml
+++ b/images/openshift-migration-ui.yml
@@ -75,7 +75,6 @@ konflux:
 name: rhmtc/openshift-migration-ui-rhel8
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 jira:
   project: MIG
   component: openshift-migration-ui-container

--- a/images/openshift-migration-velero-plugin-for-mtc.yml
+++ b/images/openshift-migration-velero-plugin-for-mtc.yml
@@ -29,7 +29,6 @@ from:
 name: rhmtc/openshift-migration-velero-plugin-for-mtc-rhel8
 owners:
   - ocp-migrate-team@redhat.com
-  - rjohnson@redhat.com
 jira:
   project: MIG
   component: openshift-migration-velero-plugin-for-mtc-container


### PR DESCRIPTION
Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED