### PR TITLE
Temporarilly switch back to 4.21-10.1 in an attempt to unlatch

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -109,13 +109,13 @@ rhcos:
       rhel_version: 9.6
       meta_type: meta
     - name: rhel-coreos-10
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.2-node-image
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.2-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.1-node-image
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.1-node-image
       rhel_version: 10.2
       meta_type: commitmeta
     - name: rhel-coreos-10-extensions
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.2-node-image-extensions
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.2-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.1-node-image-extensions
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:4.21-10.1-node-image
       rhel_version: 10.2
       meta_type: meta
   enabled_repos:


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED