### PR TITLE
[DRAFT] test openshift-console for 5.0

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -1,6 +1,7 @@
 content:
   source:
     dockerfile: Dockerfile.product
+    hermetic: true
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -20,9 +21,9 @@ content:
     - yarn
     artifacts:
       from_urls:
-      - target: yarn-v1.22.22.tar.gz
-        url: https://ocp-artifacts.engineering.redhat.com/github/yarnpkg/yarn/releases/download/v1.22.22/yarn-v1.22.22.tar.gz
-        sha256: 88268464199d1611fcf73ce9c0a6c4d44c7d5363682720d8506f6508addf36a0
+      - target: corepack-0.34.6.tar.gz
+        url: https://ocp-artifacts.engineering.redhat.com/github/nodejs/corepack/releases/download/v0.34.6/corepack.tgz
+        sha256: af29678fc25ed5ae02343e9b67b214a25bacdcffae566f8cf848936beb23a7c8
 cachito:
   enabled: true
   packages:


### PR DESCRIPTION
## Summary
- Enable hermetic build for openshift-enterprise-console
- Replace yarn artifact with corepack 0.34.6

## Test plan
- [ ] Verify console image builds successfully with hermetic mode and corepack

🤖 Generated with [Claude Code](https://claude.com/claude-code)