### PR TITLE
Update ose-powervs-block-csi-driver-operator.yml

### DIFF
--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -12,7 +12,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-golang-builder-extra.rhel9
         auto_label:
         - approved
         - lgtm


### PR DESCRIPTION
Pick rhel-9-golang-1.25  for ART consistency.