### PR TITLE
Fix ose-powervs-block-csi-driver-operator

### DIFF
--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -29,7 +29,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-powervs-block-csi-driver-rhel9-operator
 payload_name: powervs-block-csi-driver-operator


### PR DESCRIPTION
Test: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-21/pipelineruns/ose-4-21-ose-powervs-block-csi-driver-operator-b2v92