### PR TITLE
ART-14628 Revert microshift bootc to 9.6

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -9,10 +9,10 @@ content:
     modifications:
     - action: replace
       match: "ARG BASE_IMAGE_URL"
-      replacement: "ARG BASE_IMAGE_URL='registry.stage.redhat.io/rhel9/rhel-bootc'"
+      replacement: "ARG BASE_IMAGE_URL='registry.redhat.io/rhel9-eus/rhel-9.6-bootc'"
     - action: replace
       match: "ARG BASE_IMAGE_TAG"
-      replacement: "ARG BASE_IMAGE_TAG='9.8'"
+      replacement: "ARG BASE_IMAGE_TAG='9.6'"
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
revert https://github.com/openshift-eng/ocp-build-data/pull/9383
ref https://redhat-internal.slack.com/archives/CB95J6R4N/p1774862817582879?thread_ts=1773303491.865269&cid=CB95J6R4N