### PR TITLE
Add missing OADP image configs for oadp-1.6

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -59,6 +59,14 @@ public_upstreams:
   public:  "https://github.com/migtools/oadp-non-admin"
 - private: "https://github.com/openshift-priv/migtools-oadp-vm-file-restore"
   public:  "https://github.com/migtools/oadp-vm-file-restore"
+- private: "https://github.com/openshift-priv/migtools-kubevirt-datamover-controller"
+  public:  "https://github.com/migtools/kubevirt-datamover-controller"
+- private: "https://github.com/openshift-priv/migtools-kubevirt-datamover-plugin"
+  public:  "https://github.com/migtools/kubevirt-datamover-plugin"
+- private: "https://github.com/openshift-priv/migtools-filebrowser"
+  public:  "https://github.com/migtools/filebrowser"
+- private: "https://github.com/openshift-priv/migtools-oadp-vmdp"
+  public:  "https://github.com/migtools/oadp-vmdp"
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub

--- a/images/oadp-kubevirt-datamover-plugin.yml
+++ b/images/oadp-kubevirt-datamover-plugin.yml
@@ -1,0 +1,46 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: konflux.Dockerfile
+    git:
+      branch:
+        target: oadp-1.6
+      url: git@github.com:openshift-priv/migtools-kubevirt-datamover-plugin.git
+      web: https://github.com/migtools/kubevirt-datamover-plugin
+    modifications:
+      - action: replace
+        match: "dnf -y"
+        replacement: "microdnf -y"
+      - action: replace
+        match: "dnf clean all"
+        replacement: "microdnf clean all"
+distgit:
+  component: oadp-kubevirt-datamover-plugin-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+    - oadp/oadp-kubevirt-datamover-plugin-rhel9
+for_payload: false
+enabled_repos:
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: oadp/oadp-kubevirt-datamover-plugin-rhel9
+owners:
+  - oadp-maintainers@redhat.com
+dependents:
+  - oadp-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+        - tzdata
+jira:
+  project: OADP
+  component: oadp-kubevirt-datamover-plugin-container

--- a/images/oadp-kubevirt-datamover.yml
+++ b/images/oadp-kubevirt-datamover.yml
@@ -1,0 +1,39 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: konflux.Dockerfile
+    git:
+      branch:
+        target: oadp-1.6
+      url: git@github.com:openshift-priv/migtools-kubevirt-datamover-controller.git
+      web: https://github.com/migtools/kubevirt-datamover-controller
+distgit:
+  component: oadp-kubevirt-datamover-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+    - oadp/oadp-kubevirt-datamover-rhel9
+for_payload: false
+enabled_repos:
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: oadp/oadp-kubevirt-datamover-rhel9
+owners:
+  - oadp-maintainers@redhat.com
+dependents:
+  - oadp-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+        - tzdata
+jira:
+  project: OADP
+  component: oadp-kubevirt-datamover-container

--- a/images/oadp-kubevirt-velero-plugin.yml
+++ b/images/oadp-kubevirt-velero-plugin.yml
@@ -1,0 +1,46 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: konflux.Dockerfile
+    git:
+      branch:
+        target: oadp-1.6
+      url: git@github.com:openshift-priv/migtools-kubevirt-velero-plugin.git
+      web: https://github.com/migtools/kubevirt-velero-plugin
+    modifications:
+      - action: replace
+        match: "dnf -y"
+        replacement: "microdnf -y"
+      - action: replace
+        match: "dnf clean all"
+        replacement: "microdnf clean all"
+distgit:
+  component: oadp-kubevirt-velero-plugin-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+    - oadp/oadp-kubevirt-velero-plugin-rhel9
+for_payload: false
+enabled_repos:
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: oadp/oadp-kubevirt-velero-plugin-rhel9
+owners:
+  - oadp-maintainers@redhat.com
+dependents:
+  - oadp-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+        - tzdata
+jira:
+  project: OADP
+  component: oadp-kubevirt-velero-plugin-container

--- a/images/oadp-vm-file-restore.yml
+++ b/images/oadp-vm-file-restore.yml
@@ -1,0 +1,39 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: konflux.Dockerfile
+    git:
+      branch:
+        target: oadp-1.6
+      url: git@github.com:openshift-priv/migtools-oadp-vm-file-restore.git
+      web: https://github.com/migtools/oadp-vm-file-restore
+distgit:
+  component: oadp-vm-file-restore-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+    - oadp/oadp-vm-file-restore-rhel9
+for_payload: false
+enabled_repos:
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: oadp/oadp-vm-file-restore-rhel9
+owners:
+  - oadp-maintainers@redhat.com
+dependents:
+  - oadp-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+        - tzdata
+jira:
+  project: OADP
+  component: oadp-vm-file-restore-container

--- a/images/oadp-vmdp.yml
+++ b/images/oadp-vmdp.yml
@@ -1,0 +1,46 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: konflux.Dockerfile
+    git:
+      branch:
+        target: oadp-1.6
+      url: git@github.com:openshift-priv/migtools-oadp-vmdp.git
+      web: https://github.com/migtools/oadp-vmdp
+    modifications:
+      - action: replace
+        match: "dnf -y"
+        replacement: "microdnf -y"
+      - action: replace
+        match: "dnf clean all"
+        replacement: "microdnf clean all"
+distgit:
+  component: oadp-vmdp-binaries-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+    - oadp/oadp-vmdp-binaries-rhel9
+for_payload: false
+enabled_repos:
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: oadp/oadp-vmdp-binaries-rhel9
+owners:
+  - oadp-maintainers@redhat.com
+dependents:
+  - oadp-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+        - tzdata
+jira:
+  project: OADP
+  component: oadp-vmdp-binaries-container

--- a/images/oadp-vmfr-access-filebrowser.yml
+++ b/images/oadp-vmfr-access-filebrowser.yml
@@ -1,0 +1,39 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: konflux.Dockerfile
+    git:
+      branch:
+        target: oadp-1.6
+      url: git@github.com:openshift-priv/migtools-filebrowser.git
+      web: https://github.com/migtools/filebrowser
+distgit:
+  component: oadp-vmfr-access-filebrowser-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+    - oadp/oadp-vmfr-access-filebrowser-rhel9
+for_payload: false
+enabled_repos:
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: oadp/oadp-vmfr-access-filebrowser-rhel9
+owners:
+  - oadp-maintainers@redhat.com
+dependents:
+  - oadp-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+        - tzdata
+jira:
+  project: OADP
+  component: oadp-vmfr-access-filebrowser-container

--- a/images/oadp-vmfr-access-filebrowser.yml
+++ b/images/oadp-vmfr-access-filebrowser.yml
@@ -22,6 +22,7 @@ enabled_repos:
   - rhel-9-baseos-rpms
 from:
   builder:
+    - stream: rhel-9-nodejs-24
     - stream: rhel-9-golang
   member: base-rhel9
 name: oadp/oadp-vmfr-access-filebrowser-rhel9

--- a/images/oadp-vmfr-access-sshd.yml
+++ b/images/oadp-vmfr-access-sshd.yml
@@ -1,0 +1,39 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: containers/side-containers/sshd/konflux.Dockerfile
+    git:
+      branch:
+        target: oadp-1.6
+      url: git@github.com:openshift-priv/migtools-oadp-vm-file-restore.git
+      web: https://github.com/migtools/oadp-vm-file-restore
+distgit:
+  component: oadp-vmfr-access-sshd-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+    - oadp/oadp-vmfr-access-sshd-rhel9
+for_payload: false
+enabled_repos:
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: oadp/oadp-vmfr-access-sshd-rhel9
+owners:
+  - oadp-maintainers@redhat.com
+dependents:
+  - oadp-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+        - tzdata
+jira:
+  project: OADP
+  component: oadp-vmfr-access-sshd-container

--- a/images/oadp-vmfr-access.yml
+++ b/images/oadp-vmfr-access.yml
@@ -1,0 +1,46 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: containers/oadp-vmfr-access/konflux.Dockerfile
+    git:
+      branch:
+        target: oadp-1.6
+      url: git@github.com:openshift-priv/migtools-oadp-vm-file-restore.git
+      web: https://github.com/migtools/oadp-vm-file-restore
+    modifications:
+      - action: replace
+        match: "dnf install -y"
+        replacement: "microdnf install -y"
+      - action: replace
+        match: "dnf clean all"
+        replacement: "microdnf clean all"
+distgit:
+  component: oadp-vmfr-access-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+    - oadp/oadp-vmfr-access-rhel9
+for_payload: false
+enabled_repos:
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: oadp/oadp-vmfr-access-rhel9
+owners:
+  - oadp-maintainers@redhat.com
+dependents:
+  - oadp-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+        - tzdata
+jira:
+  project: OADP
+  component: oadp-vmfr-access-container

--- a/images/oadp-vmfr-access.yml
+++ b/images/oadp-vmfr-access.yml
@@ -28,8 +28,6 @@ enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms
 from:
-  builder:
-    - stream: rhel-9-golang
   member: base-rhel9
 name: oadp/oadp-vmfr-access-rhel9
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -7,6 +7,9 @@ rhel-9-golang:
     - rhel-9-golang-{GO_LATEST}
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9
 
+rhel-9-nodejs-24:
+  image: registry.redhat.io/ubi9/nodejs-24:latest
+
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
   image: registry.redhat.io/ubi9/ubi-minimal@sha256:34880b64c07f28f64d95737f82f891516de9a3b43583f39970f7bf8e4cfa48b7


### PR DESCRIPTION
## Summary
Add ocp-build-data image configurations for all OADP repos that were missing from the oadp-1.6 branch:

| Config | Source Repo | Dockerfile Path | dnf modifications |
|--------|-------------|-----------------|-------------------|
| oadp-kubevirt-velero-plugin | migtools/kubevirt-velero-plugin | `konflux.Dockerfile` | yes |
| oadp-kubevirt-datamover | migtools/kubevirt-datamover-controller | `konflux.Dockerfile` | no |
| oadp-kubevirt-datamover-plugin | migtools/kubevirt-datamover-plugin | `konflux.Dockerfile` | yes |
| oadp-vmdp | migtools/oadp-vmdp | `konflux.Dockerfile` | yes |
| oadp-vm-file-restore | migtools/oadp-vm-file-restore | `konflux.Dockerfile` | no |
| oadp-vmfr-access | migtools/oadp-vm-file-restore | `containers/oadp-vmfr-access/konflux.Dockerfile` | yes |
| oadp-vmfr-access-sshd | migtools/oadp-vm-file-restore | `containers/side-containers/sshd/konflux.Dockerfile` | no (already uses microdnf) |
| oadp-vmfr-access-filebrowser | migtools/filebrowser | `konflux.Dockerfile` | no |

Multi-image repos use different Dockerfile paths:
- `migtools/oadp-vm-file-restore` produces 3 images (vm-file-restore, vmfr-access, vmfr-access-sshd)
- `migtools/filebrowser` produces the vmfr-access-filebrowser sidecar

## Test plan
- [ ] Verify configs pass ocp-build-data validation
- [ ] Verify openshift-priv repos are created by automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)