### PR TITLE
ose-alibaba-cloud-csi-driver hermetic 4.15

### DIFF
--- a/images/ose-alibaba-cloud-csi-driver.yml
+++ b/images/ose-alibaba-cloud-csi-driver.yml
@@ -21,7 +21,7 @@ content:
       # https://github.com/openshift/alibaba-cloud-csi-driver/blob/master/build/build-all-amd.sh#L26
       - action: replace
         match: "RUN build/build-all-amd.sh noimage"
-        replacement: "RUN git checkout -b rhaos-{MAJOR}.{MINOR}-rhel9 && build/build-all-amd.sh noimage"
+        replacement: "RUN git checkout -b rhaos-{MAJOR}.{MINOR}-rhel9 && GOPATH=/go build/build-all-amd.sh noimage"
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-alibaba-cloud-csi-driver-container
@@ -41,7 +41,3 @@ name: openshift/ose-alibaba-cloud-csi-driver-container-rhel9
 payload_name: alibaba-cloud-csi-driver
 owners:
 - aos-storage-staff@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-15/pipelineruns/ose-4-15-ose-alibaba-cloud-csi-driver-jlts2/)