### PR TITLE
Use go1.24 for ose-powervs-block-csi-driver

### DIFF
--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -12,7 +12,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
         auto_label:
         - approved
         - lgtm
@@ -30,7 +30,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.24
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-powervs-block-csi-driver-rhel9
 payload_name: powervs-block-csi-driver


### PR DESCRIPTION
Making required changes to supress rollback of image bump in https://github.com/openshift/ibm-powervs-block-csi-driver/pull/120/changes

Image availability:
```
oc image info --filter-by-os linux/amd64 registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.19 -a pull-secret | grep GO_VERSION
               GO_VERSION=v1.24.13
```

Note: Please help to confirm if the changes are relevant 🙏 