### PR TITLE
scan-sources-konflux:noop update build roots

### DIFF
--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -13,7 +13,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
         auto_label:
         - approved
         - lgtm

--- a/images/ose-insights-runtime-exporter.yml
+++ b/images/ose-insights-runtime-exporter.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-insights-runtime-exporter-container


### PR DESCRIPTION
azure-disk-csi-driver and ose-insights-runtime-exporter are using  golang-1.25, updating their buildroots accordingly

Same as https://github.com/openshift-eng/ocp-build-data/pull/9698