### PR TITLE
openshift-5.0 [images]: convert openshift-enterprise-console to hermetic build

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -6,23 +6,9 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/console.git
       web: https://github.com/openshift/console
-    modifications:
-    - action: replace
-      match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
-      replacement: |-
-        COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/frontend/.npmrc
-    - action: replace
-      match: "RUN container-entrypoint ./build-frontend.sh"
-      replacement: "RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env && container-entrypoint ./build-frontend.sh"
+      url_pull: git@github.com:lgarciaaco/console.git
     pkg_managers:
-    #- gomod Take out go.mod processing because of STONEBLD-2479 not being supported
     - yarn
-    artifacts:
-      from_urls:
-      - target: yarn-v1.22.22.tar.gz
-        url: https://ocp-artifacts.engineering.redhat.com/github/yarnpkg/yarn/releases/download/v1.22.22/yarn-v1.22.22.tar.gz
-        sha256: 88268464199d1611fcf73ce9c0a6c4d44c7d5363682720d8506f6508addf36a0
 cachito:
   enabled: true
   packages:
@@ -55,8 +41,3 @@ konflux:
   vm_override:
     x86_64: linux-d160-m2xlarge/amd64
     aarch64: linux-d160-m2xlarge/arm64
-  cachito:
-    mode: emulation
-  cachi2:
-    enabled: true
-  network_mode: open


### PR DESCRIPTION
## Summary
convert openshift-enterprise-console to hermetic build

## Changes
Remove network_mode: open override to enable default hermetic building.
Clean up build modifications and artifacts that are no longer needed
for hermetic builds including yarn artifact downloads and container
modifications for cachito emulation mode.