### PR TITLE
hermetic 4.13

### DIFF
--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -28,7 +28,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-azure-cluster-api-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: azure-cluster-api-controllers

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -20,8 +20,6 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-operator

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -27,7 +27,4 @@ from:
 delivery:
   delivery_repo_names:
   - openshift4/ose-vsphere-cloud-controller-manager-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: vsphere-cloud-controller-manager


### PR DESCRIPTION
follows
https://github.com/openshift/cluster-api-provider-azure/pull/367
https://github.com/openshift/machine-api-operator/pull/1469
https://github.com/openshift/cloud-provider-vsphere/pull/110

[ose-azure-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-azure-cluster-api-controllers-h8hx5)
[ose-machine-api-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-machine-api-operator-qcr7s)
[ose-vsphere-cloud-controller-manager test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-vsphere-cloud-controller-manager-fpz4f)