### PR TITLE
(openshift-4.12)[config]: correct RT repository content set name for RHEL 8.6

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -273,7 +273,7 @@ repos:
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-rt-rpms__8_DOT_6
+      default: rhel-8-for-x86_64-rt-tus-rpms__8_DOT_6
       # don't have content set for other arches
       optional: true
 


### PR DESCRIPTION
## Summary
correct RT repository content set name for RHEL 8.6

## Changes
Update rhel-8-rt-rpms repository to use proper TUS content set name.
The baseurl indicates this is a Technology Update Services repository
but content_set was missing the 'tus' designation.