### PR TITLE
(openshift-4.17)[config]: correct content set names for RHEL repositories

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -245,10 +245,10 @@ repos:
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-baseos-rpms__8
-      aarch64: rhel-8-for-aarch64-baseos-rpms__8
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms__8
-      s390x:   rhel-8-for-s390x-baseos-rpms__8
+      default: rhel-8-for-x86_64-baseos-rpms
+      aarch64: rhel-8-for-aarch64-baseos-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms
+      s390x:   rhel-8-for-s390x-baseos-rpms
     reposync:
       enabled: false
 
@@ -265,10 +265,10 @@ repos:
         localdev:
           enabled: true
     content_set:
-      default: codeready-builder-for-rhel-8-x86_64-rpms__8
-      aarch64: codeready-builder-for-rhel-8-aarch64-rpms__8
-      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms__8
-      s390x:   codeready-builder-for-rhel-8-s390x-rpms__8
+      default: codeready-builder-for-rhel-8-x86_64-rpms
+      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
+      s390x:   codeready-builder-for-rhel-8-s390x-rpms
     reposync:
       enabled: false
 
@@ -307,10 +307,10 @@ repos:
       extra_options:
         excludepkgs: containernetworking-plugins
     content_set:
-      default: rhel-8-for-x86_64-appstream-rpms__8
-      aarch64: rhel-8-for-aarch64-appstream-rpms__8
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms__8
-      s390x:   rhel-8-for-s390x-appstream-rpms__8
+      default: rhel-8-for-x86_64-appstream-rpms
+      aarch64: rhel-8-for-aarch64-appstream-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms
+      s390x:   rhel-8-for-s390x-appstream-rpms
     reposync:
       enabled: false
 
@@ -539,7 +539,7 @@ repos:
         ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.6/x86_64/rt/os/
         s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.6/x86_64/rt/os/
     content_set:
-      default: rhel-8-for-x86_64-rt-rpms__8_DOT_6
+      default: rhel-8-for-x86_64-rt-rpms
       # don't have content set for other arches since they don't exist
       optional: true
     reposync:


### PR DESCRIPTION
## Summary
Corrected 13 invalid content set names to match authoritative repository definitions

## Changes
Fixed the following content set name issues:
- Removed `__8` suffixes from RHEL 8 repositories (baseos, appstream, codeready-builder)
- Removed `__8_DOT_6` suffix from RHEL 8 RT repository
- Content sets now validate successfully against known_rpm_repositories.yml

All invalid content sets have been corrected to use standard RHEL distribution repository names that match the content of this file: https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/known_rpm_repositories.yml

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED