### PR TITLE
Enable s390x arch for sriov-network-operator

### DIFF
--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/ose-sriov-network-metrics-exporter.yml
+++ b/images/ose-sriov-network-metrics-exporter.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.sriov-network-config-daemon.ocp

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -1,8 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
-- s390x
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -2,6 +2,7 @@ arches:
 - x86_64
 - aarch64
 - ppc64le
+- s390x
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.webhook.ocp


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED