### PR TITLE
(openshift-4.18)[config]: correct content set names for RHEL 8 repositories

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -249,10 +249,10 @@ repos:
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-baseos-rpms__8
-      aarch64: rhel-8-for-aarch64-baseos-rpms__8
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms__8
-      s390x:   rhel-8-for-s390x-baseos-rpms__8
+      default: rhel-8-for-x86_64-baseos-rpms
+      aarch64: rhel-8-for-aarch64-baseos-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms
+      s390x:   rhel-8-for-s390x-baseos-rpms
     reposync:
       enabled: false
 
@@ -291,10 +291,10 @@ repos:
       extra_options:
         excludepkgs: containernetworking-plugins
     content_set:
-      default: rhel-8-for-x86_64-appstream-rpms__8
-      aarch64: rhel-8-for-aarch64-appstream-rpms__8
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms__8
-      s390x:   rhel-8-for-s390x-appstream-rpms__8
+      default: rhel-8-for-x86_64-appstream-rpms
+      aarch64: rhel-8-for-aarch64-appstream-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms
+      s390x:   rhel-8-for-s390x-appstream-rpms
     reposync:
       enabled: false
 


### PR DESCRIPTION
## Summary
Corrected 8 invalid content set names to match authoritative repository definitions

## Changes
Fixed the following content set name issues:
- Removed `__8` suffixes from RHEL 8 repositories (baseos, appstream)
- Content sets now validate successfully against known_rpm_repositories.yml

All invalid content sets have been corrected to use standard RHEL distribution repository names that match the content of this file: https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/known_rpm_repositories.yml

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED