### PR TITLE
Enable s390x arch for sriov-network-operator for 4.22

### DIFF
--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/ose-sriov-network-metrics-exporter.yml
+++ b/images/ose-sriov-network-metrics-exporter.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.sriov-network-config-daemon.ocp

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -1,7 +1,3 @@
-arches:
-- x86_64
-- aarch64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.webhook.ocp


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

same rationale as https://github.com/openshift-eng/ocp-build-data/pull/9736/ but for 4.22 instead.