### PR TITLE
Add mr_approvers field for QE shipment MR approval (logging-6.5)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -33,6 +33,12 @@ arches:
 
 operator_image_ref_mode: manifest-list
 
+mr_approvers:
+  QE:
+    - asdas1
+    - rjohnson
+    - fbladilo
+
 konflux:
   arches:
   - x86_64


### PR DESCRIPTION
## Summary
- Adds `mr_approvers` field to `group.yml` for the logging-6.5 group
- Configures a QE approval group with members: asdas1, rjohnson, fbladilo
- The release-from-fbc pipeline (companion art-tools PR) reads this field and automatically sets up MR-level approval rules on shipment MRs

## Example
```yaml
mr_approvers:
  QE:
    - asdas1
    - rjohnson
    - fbladilo
```

## Test plan
- [ ] Verify with a test shipment MR that QE approval rule is created with the correct members
- Companion art-tools PR: https://github.com/openshift-eng/art-tools/pull/2691

Made with [Cursor](https://cursor.com)