### PR TITLE
dpu hermetic-4.17

### DIFF
--- a/images/dpu-cni.yml
+++ b/images/dpu-cni.yml
@@ -33,6 +33,3 @@ owners:
 - bnemeth@redhat.com
 - sdaniele@redhat.com
 - vpunj@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/dpu-daemon.yml
+++ b/images/dpu-daemon.yml
@@ -33,6 +33,3 @@ owners:
 - bnemeth@redhat.com
 - sdaniele@redhat.com
 - vpunj@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/dpu-operator.yml
+++ b/images/dpu-operator.yml
@@ -34,6 +34,3 @@ update-csv:
   manifests-dir: manifests
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/dpu-operator/pull/634

[dpu-cni test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-dpu-cni-xcp8r)
[dpu-daemon test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-dpu-daemon-n96kb)
[dpu-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-dpu-operator-qsjzq/)
