### PR TITLE
dpu-intel-ipu-p4sdk hermetic 4.19

### DIFF
--- a/images/dpu-intel-ipu-p4sdk.yml
+++ b/images/dpu-intel-ipu-p4sdk.yml
@@ -13,8 +13,17 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+    pkg_managers:
+    - pip
 dependents:
 - dpu-operator
+cachito:
+  enabled: true
+  packages:
+    pip:
+    - path: openshift
+      requirements_files:
+      - requirements-p4.txt
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: dpu-intel-ipu-p4sdk-container
@@ -38,4 +47,26 @@ owners:
 - sdaniele@redhat.com
 - vpunj@redhat.com
 konflux:
-  network_mode: open
+  cachi2:
+    lockfile:
+      rpms:
+      - gcc-c++
+      - libstdc++-devel
+      - gcc
+      - glibc-devel
+      - binutils
+      - libxcrypt-devel
+      - pkgconf-pkg-config
+      - pkgconf
+      - cpp
+      - pkgconf-m4
+      - glibc-headers
+      - kernel-headers
+      - libmpc
+      - libasan
+      - libatomic
+      - libubsan
+      - libpkgconf
+      - binutils-gold
+      - elfutils-debuginfod-client
+      - make


### PR DESCRIPTION
follows https://github.com/openshift/dpu-operator/pull/633

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-dpu-intel-ipu-p4sdk-wp9l2/)