### PR TITLE
Add network_mode: open for driver-toolkit on 5.0

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -44,6 +44,7 @@ payload_name: driver-toolkit
 owners:
 - edge-sro@redhat.com
 konflux:
+  network_mode: open
   vm_override:
     aarch64: linux-d160-m2xlarge/arm64
 okd:


### PR DESCRIPTION
## Summary
- Add `network_mode: open` under `konflux:` for driver-toolkit, matching 4.19-4.22 behavior

## Context
The 5.0.0-ec.0 shipment release pipeline fails at `verify-conforma` with 755 `sbom_spdx.allowed_package_sources` violations on driver-toolkit. This is because driver-toolkit on 5.0 was missing `network_mode: open`, causing it to build hermetically. The hermetic build uses cachi2/Hermeto to prefetch RPMs from `download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.8/compose/`, which are not in the allowed package sources list.

All other versions (4.19-4.22) already have `network_mode: open` set.

Related: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/16618 (conforma exception for existing builds)