### PR TITLE
Add dnf and dnf-plugins-core to konflux cachi2 rpms for 4.23

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -50,6 +50,8 @@ konflux:
     lockfile:
       cross_arch: true
       rpms:
+      - dnf
+      - dnf-plugins-core
       - cpio
       - cryptsetup-libs
       - device-mapper


### PR DESCRIPTION
This fixes this error:
```
+ prepare-efi.sh redhat
+ OS=redhat
+ dnf install -y dnf dnf-plugins-core

(microdnf:1646): librhsm-WARNING **: 00:26:52.683: Found 0 entitlement certificates

(microdnf:1646): librhsm-WARNING **: 00:26:52.685: Found 0 entitlement certificates
error: No package matches 'dnf'
```

Example build: https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/logs?nvr=ironic-container-v4.23.0-202603312349.p2.g437c88a.assembly.stream.el9&record_id=c9381db5-caa4-3ac5-c304-ea250cf61c80&group=openshift-4.23