### PR TITLE
Add MR approvers for QE and DOCS teams

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -55,6 +55,14 @@ OCP_TARGET_VERSIONS: [
 assemblies:
   enabled: true
 
+mr_approvers:
+  QE:
+    - sshveta
+    - istein
+    - dymurray
+  DOCS:
+    - anarnold
+
 public_upstreams:
 - private: "https://github.com/openshift-priv"
   public:  "https://github.com/migtools"


### PR DESCRIPTION
- QE: sshveta, istein, dymurray
- DOCS: anarnold

This enables automated GitLab MR approval rules for shipment MRs. Related: https://github.com/openshift-eng/art-tools/pull/2691

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED