### PR TITLE
Add MR approvers for QE and DOCS teams

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -51,6 +51,13 @@ OCP_TARGET_VERSIONS: [
 assemblies:
   enabled: true
 
+mr_approvers:
+  QE:
+    - akarol
+    - prajoshi
+  DOCS:
+    - anarnold
+
 public_upstreams:
 - private: "https://github.com/openshift-priv"
   public:  "https://github.com/openshift"


### PR DESCRIPTION
- QE: akarol
- DOCS: prajoshi

This enables automated GitLab MR approval rules for shipment MRs. Related: https://github.com/openshift-eng/art-tools/pull/2691

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED