### PR TITLE
Add MR approvers to OADP 1.6

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -49,6 +49,13 @@ OCP_TARGET_VERSIONS: [
 assemblies:
   enabled: true
 
+mr_approvers:
+  QE:
+    - akarol
+    - prajoshi
+  DOCS:
+    - anarnold
+
 public_upstreams:
 - private: "https://github.com/openshift-priv"
   public:  "https://github.com/openshift"


### PR DESCRIPTION
Signed-off-by: Franco Bladilo <fbladilo@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED