### PR TITLE
hermetic 4.14

### DIFF
--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -21,7 +21,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-network-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: cluster-network-operator

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -28,7 +28,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-aws-cluster-api-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: aws-cluster-api-controllers

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -34,7 +34,3 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-container-networking-plugins-rhel8
 payload_name: container-networking-plugins
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # vendor changed upstream


### PR DESCRIPTION
follows
https://github.com/openshift/cluster-network-operator/pull/2913
https://github.com/openshift/containernetworking-plugins/pull/225
https://github.com/openshift/cluster-api-provider-aws/pull/593

[cluster-network-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-cluster-network-operator-ckh7d/)
[ose-aws-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-aws-cluster-api-controllers-thd5x/)
[ose-containernetworking-plugins test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-containernetworking-plugins-p7h5n/)