### PR TITLE
hermetic 4.13

### DIFF
--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -21,7 +21,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-network-operator
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: cluster-network-operator

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -28,7 +28,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-aws-cluster-api-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: aws-cluster-api-controllers

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -22,7 +22,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-api-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: cluster-capi-controllers

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -23,7 +23,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibmcloud-machine-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: ibmcloud-machine-controllers

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -23,8 +23,6 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-azure-rhel8


### PR DESCRIPTION
follows:
https://github.com/openshift/cluster-network-operator/pull/2914
https://github.com/openshift/cluster-api-provider-aws/pull/594
https://github.com/openshift/cluster-api/pull/266
https://github.com/openshift/machine-api-provider-ibmcloud/pull/78
https://github.com/openshift/machine-api-provider-azure/pull/187

[cluster-network-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-cluster-network-operator-fdsk2)
[ose-aws-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-aws-cluster-api-controllers-6rk9t)
[ose-cluster-api test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-cluster-api-8bxdt)
[ose-ibmcloud-machine-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-ibmcloud-machine-controllers-bhzhn)
[ose-machine-api-provider-azure test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-machine-api-provider-azure-g2rjq)

