### PR TITLE
hermetic 4.12

### DIFF
--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -22,7 +22,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-azure-cluster-api-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: azure-cluster-api-controllers

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -17,7 +17,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-api-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: cluster-capi-controllers

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -23,8 +23,6 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-azure-rhel8

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -22,7 +22,4 @@ from:
 delivery:
   delivery_repo_names:
   - openshift4/ose-vsphere-cloud-controller-manager-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: vsphere-cloud-controller-manager


### PR DESCRIPTION
follows
https://github.com/openshift/cluster-api-provider-azure/pull/368
https://github.com/openshift/cluster-api/pull/267
https://github.com/openshift/machine-api-provider-azure/pull/188
https://github.com/openshift/cloud-provider-vsphere/pull/111

[ose-azure-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-azure-cluster-api-controllers-kdwgf)
[ose-cluster-api test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-cluster-api-hhh7d)
[ose-machine-api-provider-azure test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-machine-api-provider-azure-fpnkw)
[ose-vsphere-cloud-controller-manager test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-vsphere-cloud-controller-manager-88brk)
