### PR TITLE
ART-14811: OKD 5.0: build haproxy-router on cs9

### DIFF
--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -31,5 +31,7 @@ payload_name: haproxy-router
 owners:
 - aos-network-edge@redhat.com
 okd:
+  distgit:
+    branch: rhaos-5.0-rhel-9
   enabled_repos:
   - rhel-9-server-ose-rpms

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -28,3 +28,10 @@ labels:
 name: openshift/ose-haproxy-router-base
 owners:
 - aos-network-edge@redhat.com
+okd:
+  distgit:
+    branch: rhaos-5.0-rhel-9
+  from:
+    builder:
+    - stream: rhel-9-golang
+    stream: centos_stream9


### PR DESCRIPTION
Test: [openshift-enterprise-haproxy-router-container-v5.0.0-202604021010.p2.g8963907.assembly.stream.scos9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=openshift-enterprise-haproxy-router-container-v5.0.0-202604021010.p2.g8963907.assembly.stream.scos9&record_id=28948645-3d46-4c0b-01ef-e69d6d1acbbf&group=okd-5.0&outcome=success&type=image)