### PR TITLE
Fix console-operator Dockerfile path to Dockerfile.ocp

### DIFF
--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -1,6 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile.ocp
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
The upstream repository changed the Dockerfile location from Dockerfile.rhel7 to Dockerfile.ocp. This was causing build failures when trying to determine the upstream RHEL version for canonical_builders_from_upstream.

Error: Could not determine upstream RHEL version. Cannot apply alternative_upstream config.

Upstream Dockerfile: https://github.com/openshift/console-operator/blob/release-4.23/Dockerfile.ocp

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED