### PR TITLE
Revert "Update repo for rhel-9-golang-1.25"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -40,29 +40,12 @@ repos:
     conf:
       extra_options:
         module_hotfixes: 1
-        includepkgs: module-build-macros goversioninfo
+        includepkgs: module-build-macros golang* goversioninfo
       baseurl:
         aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
         ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
         s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
         x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
-    # These content sets are not used, so just putting something here
-    content_set:
-      default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
-      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
-      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
-      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
-      optional: true
-  rhel-97-golang-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1
-        includepkgs: golang*
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/os
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/os
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/os
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -16,7 +16,6 @@ content:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-golang-rpms
-- rhel-97-golang-rpms
 # for clang
 - rhel-9-appstream-rpms
 - rhel-9-codeready-builder-rpms


### PR DESCRIPTION
ref: https://redhat-internal.slack.com/archives/CB95J6R4N/p1775147838868839?thread_ts=1774974981.196549&cid=CB95J6R4N

Reverts openshift-eng/ocp-build-data#8282