### PR TITLE
Modify golang package inclusion and remove unused config

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -39,30 +39,12 @@ repos:
     conf:
       extra_options:
         module_hotfixes: 1
-        includepkgs: module-build-macros delve goversioninfo
+        includepkgs: module-build-macros delve golang* go-toolset* goversioninfo
       baseurl:
         aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
         ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/
         s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/s390x/
         x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/x86_64/
-    # These content sets are not used, so just putting something here
-    content_set:
-      default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms
-      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-8-aarch64-rpms
-      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
-      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
-      optional: true
-
-  rhel-810-golang-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1
-        includepkgs: golang* go-toolset*
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/appstream/os
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/appstream/os
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/appstream/os
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -15,7 +15,6 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-810-golang-rpms
 - rhel-8-baseos-rpms
 # for clang
 - rhel-8-appstream-rpms


### PR DESCRIPTION
slack ref: https://redhat-internal.slack.com/archives/CB95J6R4N/p1775147838868839?thread_ts=1774974981.196549&cid=CB95J6R4N

Updated the includepkgs line to include golang* and go-toolset* for rhel-8-golang-rpms. Removed rhel-810-golang-rpms configuration as it is not used.

for ref see: https://github.com/openshift-eng/ocp-build-data/blob/rhel-8-golang-1.24/group.yml
similar to https://github.com/openshift-eng/ocp-build-data/pull/9794