### PR TITLE
Remove alias for rhel-9-golang-1.22

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -44,8 +44,6 @@ rhel-9-golang:
     - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.22:
-  aliases:
-    - rhel-9-golang-1.22
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.22.12-202602241847.p2.g388ceb2.el9
 
 rhel-9-golang-1.23:


### PR DESCRIPTION
```
23:15:54  ValueError: Alias name rhel-9-golang-1.22 already exists in streams.yml
```

Removed alias for rhel-9-golang-1.22 in streams.yml.