### PR TITLE
Disable oadp-operator on oadp-1.5

### DIFF
--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -1,3 +1,5 @@
+# Disabled until go 1.25.8
+mode: disabled
 cachito:
   packages:
     gomod:


### PR DESCRIPTION
The velero image is disabled until go 1.25.8, so its dependent
oadp-operator must also be disabled.

Made with [Cursor](https://cursor.com)