### PR TITLE
Disable oadp-operator on oadp-1.6

### DIFF
--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -1,3 +1,5 @@
+# Disabled until go 1.25.8
+mode: disabled
 cachito:
   packages:
     gomod:


### PR DESCRIPTION
Disabled dependents (oadp-vmfr-access-sshd, oadp-vmfr-access) require
the operator to be disabled as well.

Made with [Cursor](https://cursor.com)