### PR TITLE
oadp-1.6: enable oadp-vmfr-access-sshd

### DIFF
--- a/images/oadp-vmfr-access-sshd.yml
+++ b/images/oadp-vmfr-access-sshd.yml
@@ -1,4 +1,3 @@
-mode: disabled
 cachito:
   packages:
     gomod:


### PR DESCRIPTION
[oadp-1-6/pipelineruns/oadp-1-6-oadp-vmfr-access-sshd-z98d6](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/art-oadp-tenant/applications/oadp-1-6/pipelineruns/oadp-1-6-oadp-vmfr-access-sshd-z98d6)

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED