### PR TITLE
Disable oadp-velero-restic-restore-helper on oadp-1.4

### DIFF
--- a/images/oadp-velero-restic-restore-helper.yml
+++ b/images/oadp-velero-restic-restore-helper.yml
@@ -1,3 +1,4 @@
+mode: disabled
 cachito:
   packages:
     gomod:


### PR DESCRIPTION
## Summary
- Disable `oadp-velero-restic-restore-helper` image on the `oadp-1.4` branch by adding `mode: disabled`


Made with [Cursor](https://cursor.com)