### PR TITLE
oadp-1.6: disable oadp-vmfr-access-filebrowser

### DIFF
--- a/images/oadp-vmfr-access-filebrowser.yml
+++ b/images/oadp-vmfr-access-filebrowser.yml
@@ -1,3 +1,5 @@
+# disable until fixed, npm
+mode: disabled
 cachito:
   packages:
     gomod:


### PR DESCRIPTION
Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED