### PR TITLE
Fix golang-1.24 streams using wrong upstream_image variable

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -42,7 +42,7 @@ rhel-9-golang-1.24:
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 rhel-8-golang-1.24:
   aliases:
@@ -51,7 +51,7 @@ rhel-8-golang-1.24:
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.23:
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202603131509.p2.gdc331c7.el8


### PR DESCRIPTION
The rhel-9-golang-1.24 and rhel-8-golang-1.24 streams had their upstream_image fields using {GO_LATEST} (resolving to 1.23) instead of {GO_EXTRA} (resolving to 1.24). This caused doozer reconciliation PRs to incorrectly downgrade FROM lines from golang-1.24 to golang-1.23 in upstream repos (e.g. openshift/ibm-powervs-block-csi-driver#120).