### PR TITLE
hermetic 4.12

### DIFF
--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -20,9 +20,6 @@ from:
 name: openshift/ose-ibmcloud-machine-controllers-rhel8
 owners:
 - aos-cloud@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-ibmcloud-machine-controllers-rhel8

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -23,8 +23,6 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-aws-rhel8


### PR DESCRIPTION
follows
https://github.com/openshift/machine-api-provider-ibmcloud/pull/79
https://github.com/openshift/machine-api-provider-aws/pull/176

[ose-ibmcloud-machine-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-ibmcloud-machine-controllers-xpcdq)
[ose-machine-api-provider-aws test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-machine-api-provider-aws-7kpt6)