### PR TITLE
ose-vsphere-cluster-api-controllers hermetic 4.14

### DIFF
--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -27,7 +27,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-vsphere-cluster-api-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: vsphere-cluster-api-controllers


### PR DESCRIPTION
follows https://github.com/openshift/cluster-api-provider-vsphere/pull/88

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-14/pipelineruns/ose-4-14-ose-vsphere-cluster-api-controllers-j9mz8)