### PR TITLE
Network mode open monitoring plugin 4.18

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -43,3 +43,4 @@ owners:
 konflux:
   cachito:
     mode: emulation
+  network_mode: open


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

monitoring-plugin on 4.18 only works with network_mode: open