### PR TITLE
ose-frr: add rhel-98-baseos

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -17,6 +17,7 @@ delivery:
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-98-appstream
+- rhel-98-baseos
 - rhel-9-baseos-rpms
 - rhel-9-server-ose-rpms-embargoed
 for_payload: true


### PR DESCRIPTION
[test build (after an open build)](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-23/pipelineruns/ose-4-23-ose-frr-hkvtz/)