### PR TITLE
5.0 ose-frr: add rhel-98-baseos

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -17,6 +17,7 @@ delivery:
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-98-appstream
+- rhel-98-baseos
 - rhel-9-baseos-rpms
 - rhel-9-server-ose-rpms-embargoed
 for_payload: true


### PR DESCRIPTION
cherry-pick of f3ad3b6a0e196931669154633884d0d541d9290c, https://github.com/openshift-eng/ocp-build-data/pull/9863

needs an open build first
