### PR TITLE
ironic: restore full cachi2 lockfile RPM list

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -50,38 +50,67 @@ konflux:
     lockfile:
       cross_arch: true
       rpms:
+      - acl
+      - attr
+      - binutils
+      - binutils-gold
       - cpio
+      - cpp
+      - crypto-policies-scripts
       - cryptsetup-libs
+      - dbus
+      - dbus-broker
+      - dbus-common
+      - dbus-libs
       - device-mapper
       - device-mapper-libs
+      - dmidecode
+      - dnf
+      - dnf-plugins-core
       - dosfstools
       - dracut
       - e2fsprogs
       - e2fsprogs-libs
       - efi-filesystem
       - efivar-libs
+      - elfutils-debuginfod-client
+      - elfutils-default-yama-scope
+      - elfutils-libs
       - file
       - flashrom
       - fuse-libs
       - fwupd
       - fwupd-plugin-flashrom
+      - gcc
+      - gcc-c++
       - gdisk
       - gettext
       - gettext-libs
+      - git-core
+      - glibc-devel
       - glibc-gconv-extra
+      - glibc-headers
       - grub2-common
+      - grub2-efi-aa64
       - grub2-efi-x64
       - grub2-pc
       - grub2-pc-modules
       - grub2-tools
       - grub2-tools-minimal
+      - ima-evm-utils
       - inih
       - kbd
       - kbd-legacy
       - kbd-misc
+      - kernel-headers
+      - keyutils
       - kmod
+      - kmod-libs
       - kpartx
+      - less
+      - libasan
       - libatasmart
+      - libatomic
       - libblockdev
       - libblockdev-crypto
       - libblockdev-fs
@@ -91,18 +120,31 @@ konflux:
       - libblockdev-swap
       - libblockdev-utils
       - libbytesize
+      - libcbor
+      - libcomps
       - libedit
+      - libfido2
+      - libgomp
       - libgudev
       - libgusb
       - libjcat
       - libkcapi
       - libkcapi-hmaccalc
+      - libmpc
+      - libnsl2
+      - libpkgconf
+      - libseccomp
       - libss
+      - libstdc++-devel
+      - libubsan
       - libudisks2
       - libusbx
+      - libxcrypt-devel
       - libxmlb
+      - make
       - mdadm
       - mokutil
+      - mpdecimal
       - mtools
       - nspr
       - nss
@@ -110,49 +152,60 @@ konflux:
       - nss-softokn-freebl
       - nss-sysinit
       - nss-util
+      - openssh
+      - openssh-clients
       - os-prober
       - parted
       - pciutils-libs
       - pigz
+      - pkgconf
+      - pkgconf-m4
+      - pkgconf-pkg-config
       - polkit
       - polkit-libs
       - polkit-pkla-compat
+      - python3-dateutil
+      - python3-dbus
+      - python3-dnf
+      - python3-dnf-plugins-core
+      - python3-gpg
+      - python3-hawkey
+      - python3-libcomps
+      - python3-libdnf
+      - python3-rpm
+      - python3-six
+      - python3-systemd
+      - python3.12
+      - python3.12-devel
+      - python3.12-ironic-prometheus-exporter
+      - python3.12-lark
+      - python3.12-libs
+      - python3.12-packaging
+      - python3.12-pbr
+      - python3.12-pip
+      - python3.12-pip-wheel
+      - python3.12-setuptools
+      - python3.12-setuptools_scm
+      - python3.12-typing-extensions
+      - python3.12-watchdog
+      - python3.12-wheel
+      - rpm-build-libs
+      - rpm-plugin-systemd-inhibit
+      - rpm-sign-libs
       - shared-mime-info
+      - shim-aa64
       - shim-x64
+      - sqlite
+      - systemd
+      - systemd-pam
+      - systemd-rpm-macros
       - systemd-udev
+      - tpm2-tss
       - udisks2
       - userspace-rcu
       - volume_key-libs
       - xfsprogs
       - xz
-      - sqlite
-      - binutils
-      - binutils-gold
-      - cpp
-      - elfutils-debuginfod-client
-      - gcc
-      - gcc-c++
-      - glibc-devel
-      - glibc-headers
-      - kernel-headers
-      - libmpc
-      - libpkgconf
-      - libstdc++-devel
-      - libxcrypt-devel
-      - make
-      - pkgconf
-      - pkgconf-m4
-      - pkgconf-pkg-config
-      - python3.12-devel
-      - python3.12-watchdog
-      - python3.12-wheel
-      - python3.12-lark
-      - python3.12-ironic-prometheus-exporter
-      - grub2-efi-aa64
-      - libasan
-      - libatomic
-      - libubsan
-      - shim-aa64
 okd:
   content:
     source:


### PR DESCRIPTION
The lockfile was missing critical packages like dnf, dnf-plugins-core, and their python3 dependencies that were present in 4.22. Without these in the lockfile, the Dockerfile tries to install them at build time via microdnf, which fails due to missing RHEL entitlement certificates in the Konflux build environment.