### PR TITLE
ART-14653 [openshift-4.16]: hermetic monitoring-plugin

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -1,3 +1,5 @@
+envs:
+  CYPRESS_INSTALL_BINARY: "0"
 content:
   source:
     dockerfile: Dockerfile.art
@@ -12,19 +14,10 @@ content:
           stream: rhel-9-golang-ci-build-root
     modifications:
     - action: replace
-      match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
-      replacement: |-
-        COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/.npmrc $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/.yarnrc
+      match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
+      replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     pkg_managers:
     - yarn
-    artifacts:
-      from_urls:
-      - target: yarn-v1.22.19.tar.gz
-        url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
-        sha256: 732620bac8b1690d507274f025f3c6cfdc3627a84d9642e38a07452cc00e0f2e
-        source-url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-source-v1.22.19.tar.gz
-        source-sha256: 50af0025d2ef942bf3e6cdd0587dc9c4dd8d6e6e69501b84935d09f2b2b5de8b
     okd_alignment:
       dockerfile: Dockerfile
 
@@ -50,5 +43,11 @@ owners:
 - team-observability-ui@redhat.com
 konflux:
   cachito:
-    mode: emulation
-  network_mode: open
+    mode: removal
+  cachi2:
+    lockfile:
+      modules:
+      - nginx:1.24
+    artifact_lockfile:
+      resources:
+      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz


### PR DESCRIPTION
## Summary
Convert monitoring-plugin from network_mode: open to hermetic builds using cachi2 dependency management. Removes artifacts download configuration and switches to cachi2 lockfile approach for yarn dependencies.

## Changes
Applied hermetic conversion for monitoring-plugin with nginx:1.24