### PR TITLE
ART-14844 [openshift-5.0]: hermetic openshift-enterprise-console

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -8,21 +8,18 @@ content:
       web: https://github.com/openshift/console
     modifications:
     - action: replace
-      match: "COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR"
-      replacement: |-
-        COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
-        RUN touch $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/registry-ca.pem $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/frontend/.npmrc
+      match: "./artifacts/corepack-${COREPACK_VERSION}.tar.gz"
+      replacement: "/cachi2/output/deps/generic/corepack-v${COREPACK_VERSION}.tgz"
     - action: replace
       match: "RUN container-entrypoint ./build-frontend.sh"
-      replacement: "RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env && container-entrypoint ./build-frontend.sh"
+      replacement: |
+        WORKDIR frontend
+        RUN node .yarn/releases/yarn-4.12.0.cjs install --immutable && \
+            node .yarn/releases/yarn-4.12.0.cjs build
+    - action: command
+      command: ["sh", "-c", "echo '\nsupportedArchitectures:\n  os: [\"linux\"]\n  cpu: [\"x64\", \"arm64\", \"s390x\", \"ppc64\"]' >> frontend/.yarnrc.yml"]
     pkg_managers:
-    #- gomod Take out go.mod processing because of STONEBLD-2479 not being supported
     - yarn
-    artifacts:
-      from_urls:
-      - target: yarn-v1.22.22.tar.gz
-        url: https://ocp-artifacts.engineering.redhat.com/github/yarnpkg/yarn/releases/download/v1.22.22/yarn-v1.22.22.tar.gz
-        sha256: 88268464199d1611fcf73ce9c0a6c4d44c7d5363682720d8506f6508addf36a0
 cachito:
   enabled: true
   packages:
@@ -56,7 +53,9 @@ konflux:
     x86_64: linux-d160-m2xlarge/amd64
     aarch64: linux-d160-m2xlarge/arm64
   cachito:
-    mode: emulation
+    mode: removal
   cachi2:
-    enabled: true
-  network_mode: open
+    artifact_lockfile:
+      resources:
+      - url: https://ocp-artifacts.engineering.redhat.com/github/nodejs/corepack/releases/download/v0.34.6/corepack.tgz
+        filename: corepack-v0.34.6.tgz

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -8,12 +8,6 @@ content:
       web: https://github.com/openshift/console
     modifications:
     - action: replace
-      match: "USER 0"
-      replacement: |
-        USER 0
-        RUN echo -e '\nsupportedArchitectures:\n  os: ["linux"]\n  cpu: ["x64", "arm64", "s390x", "ppc64"]\n' >> frontend/.yarnrc.yml && \
-            cat frontend/.yarnrc.yml
-    - action: replace
       match: "./artifacts/corepack-${COREPACK_VERSION}.tar.gz"
       replacement: "/cachi2/output/deps/generic/corepack-v${COREPACK_VERSION}.tgz"
     - action: replace
@@ -22,6 +16,8 @@ content:
         WORKDIR frontend
         RUN node .yarn/releases/yarn-4.12.0.cjs install --immutable && \
             node .yarn/releases/yarn-4.12.0.cjs build
+    - action: command
+      command: ["sh", "-c", "echo '\nsupportedArchitectures:\n  os: [\"linux\"]\n  cpu: [\"x64\", \"arm64\", \"s390x\", \"ppc64\"]' >> frontend/.yarnrc.yml"]
     pkg_managers:
     - yarn
 cachito:

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -8,6 +8,12 @@ content:
       web: https://github.com/openshift/console
     modifications:
     - action: replace
+      match: "USER 0"
+      replacement: |
+        USER 0
+        RUN echo -e '\nsupportedArchitectures:\n  os: ["linux"]\n  cpu: ["x64", "arm64", "s390x", "ppc64"]\n' >> frontend/.yarnrc.yml && \
+            cat frontend/.yarnrc.yml
+    - action: replace
       match: "./artifacts/corepack-${COREPACK_VERSION}.tar.gz"
       replacement: "/cachi2/output/deps/generic/corepack-v${COREPACK_VERSION}.tgz"
     - action: replace
@@ -16,8 +22,6 @@ content:
         WORKDIR frontend
         RUN node .yarn/releases/yarn-4.12.0.cjs install --immutable && \
             node .yarn/releases/yarn-4.12.0.cjs build
-    - action: command
-      command: ["sh", "-c", "echo '\nsupportedArchitectures:\n  os: [\"linux\"]\n  cpu: [\"x64\", \"arm64\", \"s390x\", \"ppc64\"]' >> frontend/.yarnrc.yml"]
     pkg_managers:
     - yarn
 cachito:


### PR DESCRIPTION
## Summary
Modernize console build process for hermetic builds by switching from network_mode: open to hermetic builds using cachi2 dependency management and yarn 4.12.0.

## Changes
Cherry-picked hermetic conversion for openshift-enterprise-console with corepack v0.34.6 and updated build process