### PR TITLE
Enable oadp-vmfr-access-filebrowser build with npm cachito use vmfr proper arches

### DIFF
--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -1,5 +1,3 @@
-# Disabled until go 1.25.8
-mode: disabled
 cachito:
   packages:
     gomod:

--- a/images/oadp-vm-file-restore.yml
+++ b/images/oadp-vm-file-restore.yml
@@ -17,6 +17,10 @@ delivery:
   delivery_repo_names:
     - oadp/oadp-vm-file-restore-rhel9
 for_payload: false
+arches:
+- aarch64
+- s390x
+- x86_64
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/oadp-vm-file-restore.yml
+++ b/images/oadp-vm-file-restore.yml
@@ -19,7 +19,6 @@ delivery:
 for_payload: false
 arches:
 - aarch64
-- s390x
 - x86_64
 enabled_repos:
   - rhel-9-appstream-rpms

--- a/images/oadp-vmfr-access-filebrowser.yml
+++ b/images/oadp-vmfr-access-filebrowser.yml
@@ -24,7 +24,6 @@ delivery:
 for_payload: false
 arches:
 - aarch64
-- s390x
 - x86_64
 enabled_repos:
   - rhel-9-appstream-rpms

--- a/images/oadp-vmfr-access-filebrowser.yml
+++ b/images/oadp-vmfr-access-filebrowser.yml
@@ -1,11 +1,14 @@
-# disable until fixed, npm
-mode: disabled
 cachito:
   packages:
     gomod:
       - path: .
+    npm:
+      - path: frontend
 content:
   source:
+    pkg_managers:
+      - gomod
+      - npm
     dockerfile: konflux.Dockerfile
     git:
       branch:
@@ -19,6 +22,10 @@ delivery:
   delivery_repo_names:
     - oadp/oadp-vmfr-access-filebrowser-rhel9
 for_payload: false
+arches:
+- aarch64
+- s390x
+- x86_64
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/oadp-vmfr-access-sshd.yml
+++ b/images/oadp-vmfr-access-sshd.yml
@@ -17,6 +17,10 @@ delivery:
   delivery_repo_names:
     - oadp/oadp-vmfr-access-sshd-rhel9
 for_payload: false
+arches:
+- aarch64
+- s390x
+- x86_64
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/oadp-vmfr-access-sshd.yml
+++ b/images/oadp-vmfr-access-sshd.yml
@@ -19,7 +19,6 @@ delivery:
 for_payload: false
 arches:
 - aarch64
-- s390x
 - x86_64
 enabled_repos:
   - rhel-9-appstream-rpms

--- a/images/oadp-vmfr-access.yml
+++ b/images/oadp-vmfr-access.yml
@@ -1,4 +1,3 @@
-#mode: disabled
 cachito:
   packages:
     gomod:


### PR DESCRIPTION
## Summary
- Remove `mode: disabled` from oadp-vmfr-access-filebrowser image config
- Add `npm` cachito package entry for `frontend/` directory to enable pnpm dependency pre-fetching via Cachi2
- Build was previously disabled due to npm dependencies requiring internet access during hermetic Konflux builds
- Builds on arches: [aarch64, x86_64]

## Changes
- `cachito.packages.npm` added with `path: frontend` (contains `pnpm-lock.yaml`)
- `gomod` cachito retained for Go backend
- add builds on arches: [aarch64, x86_64]

## Reference
- Follows the same pattern as [mta-ui.yml](https://github.com/openshift-eng/ocp-build-data/blob/mta-8.1/images/mta-ui.yml) which uses npm cachito for frontend dependencies

Signed-off-by: Michal Pryc <mpryc@redhat.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>