### PR TITLE
ART-14864: scan-sources-konflux:noop dynamically link thanos binary

### DIFF
--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -6,6 +6,17 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/thanos.git
       web: https://github.com/openshift/thanos
+    modifications:
+    - action: replace
+      match: 'promu build;'
+      replacement: |
+        CGO_ENABLED=1 go build -a -tags "slicelabels" \
+            -ldflags "-X github.com/prometheus/common/version.Version=${SOURCE_GIT_TAG} \
+                      -X github.com/prometheus/common/version.Revision=${SOURCE_GIT_COMMIT} \
+                      -X github.com/prometheus/common/version.Branch=${OS_GIT_MAJOR}.${OS_GIT_MINOR} \
+                      -X github.com/prometheus/common/version.BuildUser=doozer \
+                      -X github.com/prometheus/common/version.BuildDate=$(date -u +'%Y%m%d-%H:%M:%S')" \
+            -o thanos ./cmd/thanos;
     ci_alignment:
       streams_prs:
         auto_label:


### PR DESCRIPTION
Ref [ART-14864](https://redhat.atlassian.net/browse/ART-14864)
Build: [ose-thanos-container-v4.22.0-202604071539.p2.g5d9d0f3.assembly.stream.scos9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=ose-thanos-container-v4.22.0-202604071539.p2.g5d9d0f3.assembly.stream.scos9&record_id=08d68183-97d3-3bf0-2777-40e7afb70d23&group=okd-4.22&outcome=success&type=image):
Green nightly: [4.22.0-0.okd-scos-nightly-2026-04-07-225557](https://amd64.origin.releases.ci.openshift.org/releasestream/4.22.0-0.okd-scos-nightly/release/4.22.0-0.okd-scos-nightly-2026-04-07-225557)