### PR TITLE
Update repository names

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -90,7 +90,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-96-baseos:
+  rhel-97-baseos:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
@@ -107,7 +107,7 @@ repos:
     reposync:
       enabled: true
 
-  rhel-96-baseos-source:
+  rhel-97-baseos-source:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/source/SRPMS
@@ -139,7 +139,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-96-appstream:
+  rhel-97-appstream:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
@@ -156,7 +156,7 @@ repos:
     reposync:
       enabled: true
 
-  rhel-96-appstream-source:
+  rhel-97-appstream-source:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/source/SRPMS
@@ -173,7 +173,7 @@ repos:
     reposync:
       enabled: true
 
-  rhel-96-appstream-debug:
+  rhel-97-appstream-debug:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/debug/

--- a/images/vector.yml
+++ b/images/vector.yml
@@ -23,8 +23,8 @@ for_payload: false
 dependents:
 - cluster-logging-operator
 enabled_repos:
-- rhel-96-appstream
-- rhel-96-baseos
+- rhel-97-appstream
+- rhel-97-baseos
 from:
   builder:
     - member: base-rhel9


### PR DESCRIPTION
We updated Logging 6.5 to UBI9.7 recently. I missed that there are version numbers in the repository names. This PR changes those names.

Follow-up of #9572 

/label tide/merge-method-squash
