### PR TITLE
oadp-1.6: oadp-vmfr-access: disable ppc64le arch

### DIFF
--- a/images/oadp-vmfr-access.yml
+++ b/images/oadp-vmfr-access.yml
@@ -1,4 +1,4 @@
-mode: disabled
+#mode: disabled
 cachito:
   packages:
     gomod:
@@ -25,6 +25,10 @@ delivery:
   delivery_repo_names:
     - oadp/oadp-vmfr-access-rhel9
 for_payload: false
+arches:
+- aarch64
+- s390x
+- x86_64
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms


### PR DESCRIPTION
Per [Slack discussion](https://redhat-internal.slack.com/archives/CB95J6R4N/p1775675198234959?thread_ts=1775254906.460319&cid=CB95J6R4N)

test build: [oadp-1-6/pipelineruns/oadp-1-6-oadp-vmfr-access-xx6gn](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/art-oadp-tenant/applications/oadp-1-6/pipelineruns/oadp-1-6-oadp-vmfr-access-xx6gn)

<img width="666" height="236" alt="image" src="https://github.com/user-attachments/assets/5b0e5bfb-4090-4846-be70-78c82fb4b6f8" />



Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED