### PR TITLE
hermetic 4.12

### DIFF
--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -21,10 +21,6 @@ labels:
 name: openshift/ose-haproxy-router
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  network_mode: open
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 delivery:
   delivery_repo_names:
   - openshift4/ose-haproxy-router

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -25,6 +25,3 @@ labels:
 name: openshift/ose-haproxy-router-base
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -22,7 +22,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-vsphere-cluster-api-controllers-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: vsphere-cluster-api-controllers


### PR DESCRIPTION
follows:
https://github.com/openshift/router/pull/744
https://github.com/openshift/cluster-api-provider-vsphere/pull/90

[openshift-enterprise-haproxy-router test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-openshift-enterprise-haproxy-router-brjr8)
[ose-haproxy-router-base test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-haproxy-router-base-mnvrz)
[ose-vsphere-cluster-api-controllers test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-vsphere-cluster-api-controllers-xbg9g)