### PR TITLE
hermetic 4.13

### DIFF
--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -25,7 +25,3 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-haproxy-router
 payload_name: haproxy-router
-konflux:
-  network_mode: open # vendor changed upstream
-  cachi2:
-    enabled: false

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -25,6 +25,3 @@ labels:
 name: openshift/ose-haproxy-router-base
 owners:
 - aos-network-edge@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows:
https://github.com/openshift/router/pull/743

[openshift-enterprise-haproxy-router test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-openshift-enterprise-haproxy-router-q6bz7)
[ose-haproxy-router-base test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-13/pipelineruns/ose-4-13-ose-haproxy-router-base-7rpdw)