### PR TITLE
Fix warnings for external-secrets-1.1 builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -16,6 +16,7 @@ arches:
 - aarch64
 
 operator_image_ref_mode: manifest-list
+canonical_builders_from_upstream: false
 konflux:
   arches:
   - x86_64

--- a/images/external-secrets-bitwarden-sdk-server.yml
+++ b/images/external-secrets-bitwarden-sdk-server.yml
@@ -6,6 +6,7 @@ content:
   source:
     dockerfile: Containerfile.art
     git:
+      allow_unprotected_branch: true
       branch:
         target: art-build-v0.5.2
       url: git@github.com:openshift-priv/external-secrets-bitwarden-sdk-server.git

--- a/images/external-secrets-operator.yml
+++ b/images/external-secrets-operator.yml
@@ -6,6 +6,7 @@ content:
   source:
     dockerfile: Containerfile.art
     git:
+      allow_unprotected_branch: true
       branch:
         target: release-1.1
       url: git@github.com:openshift-priv/external-secrets-operator.git

--- a/images/external-secrets.yml
+++ b/images/external-secrets.yml
@@ -6,6 +6,7 @@ content:
   source:
     dockerfile: Containerfile.art
     git:
+      allow_unprotected_branch: true
       branch:
         target: release-1.1
       url: git@github.com:openshift-priv/external-secrets.git


### PR DESCRIPTION
## Summary
- Add `canonical_builders_from_upstream: false` to `group.yml` to silence the "Invalid value provided for canonical_builders_from_upstream" warning from Doozer (the field was unset, defaulting to `MissingModel` instead of a proper bool)
- Add `allow_unprotected_branch: true` to all 3 image YAMLs (`external-secrets.yml`, `external-secrets-operator.yml`, `external-secrets-bitwarden-sdk-server.yml`) since these repos won't have branch protection enabled during initial onboarding

## Test plan
- [ ] Run a layered-products Jenkins build for `external-secrets-1.1` and verify warnings are no longer emitted