### PR TITLE
NO-JIRA: bump oadp's golang-builder to 1.25.8

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -5,7 +5,7 @@ ose-cli:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081723.p2.gf28329a.el9
 
 rhel-9-nodejs-24:
   image: registry.redhat.io/ubi9/nodejs-24:latest


### PR DESCRIPTION
Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED