### PR TITLE
Initial setup for Logging 6.0

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -73,129 +73,129 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
     content_set:
-      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-baseos-rpms
+      aarch64: rhel-9-for-aarch64-baseos-rpms
+      ppc64le: rhel-9-for-ppc64le-baseos-rpms
+      s390x: rhel-9-for-s390x-baseos-rpms
     reposync:
       enabled: false
 
   rhel-96-baseos:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/os/
       extra_options:
         gpgcheck: "1"
     content_set:
-      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-baseos-rpms
+      aarch64: rhel-9-for-aarch64-baseos-rpms
+      ppc64le: rhel-9-for-ppc64le-baseos-rpms
+      s390x: rhel-9-for-s390x-baseos-rpms
     reposync:
       enabled: true
 
   rhel-96-baseos-source:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/source/SRPMS
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/source/SRPMS
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/baseos/source/SRPMS
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/baseos/source/SRPMS
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/source/SRPMS
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/source/SRPMS
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/source/SRPMS
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/source/SRPMS
       extra_options:
         gpgcheck: "1"
     content_set:
-      default: rhel-9-for-x86_64-baseos-source-eus-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-baseos-source-eus-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-baseos-source-eus-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-baseos-source-eus-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-baseos-source-rpms
+      aarch64: rhel-9-for-aarch64-baseos-source-rpms
+      ppc64le: rhel-9-for-ppc64le-baseos-source-rpms
+      s390x: rhel-9-for-s390x-baseos-source-rpms
     reposync:
       enabled: true
 
   rhel-9-appstream-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
     content_set:
-      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-appstream-rpms
+      aarch64: rhel-9-for-aarch64-appstream-rpms
+      ppc64le: rhel-9-for-ppc64le-appstream-rpms
+      s390x: rhel-9-for-s390x-appstream-rpms
     reposync:
       enabled: false
 
   rhel-96-appstream:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/os/
       extra_options:
         gpgcheck: "1"
     content_set:
-      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-appstream-rpms
+      aarch64: rhel-9-for-aarch64-appstream-rpms
+      ppc64le: rhel-9-for-ppc64le-appstream-rpms
+      s390x: rhel-9-for-s390x-appstream-rpms
     reposync:
       enabled: true
 
   rhel-96-appstream-source:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/source/SRPMS
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/source/SRPMS
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/source/SRPMS
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/appstream/source/SRPMS
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/source/SRPMS
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/source/SRPMS
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/source/SRPMS
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/source/SRPMS
       extra_options:
         gpgcheck: "1"
     content_set:
-      default: rhel-9-for-x86_64-appstream-source-eus-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-appstream-source-eus-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-appstream-source-eus-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-appstream-source-eus-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-appstream-source-rpms
+      aarch64: rhel-9-for-aarch64-appstream-source-rpms
+      ppc64le: rhel-9-for-ppc64le-appstream-source-rpms
+      s390x: rhel-9-for-s390x-appstream-source-rpms
     reposync:
       enabled: true
 
   rhel-96-appstream-debug:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/debug/
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/debug/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/appstream/debug/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/appstream/debug/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/debug/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/debug/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/debug/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/debug/
       extra_options:
         gpgcheck: "1"
     content_set:
-      default: rhel-9-for-x86_64-appstream-debug-eus-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-appstream-debug-eus-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-appstream-debug-eus-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-appstream-debug-eus-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-appstream-debug-rpms
+      aarch64: rhel-9-for-aarch64-appstream-debug-rpms
+      ppc64le: rhel-9-for-ppc64le-appstream-debug-rpms
+      s390x: rhel-9-for-s390x-appstream-debug-rpms
     reposync:
       enabled: true
 
   rhel-9-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/codeready-builder/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/codeready-builder/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/codeready-builder/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/codeready-builder/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/codeready-builder/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/codeready-builder/os/
     content_set:
-      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_6
-      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_6
-      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_6
-      s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_6
+      default: codeready-builder-for-rhel-9-x86_64-rpms
+      aarch64: codeready-builder-for-rhel-9-aarch64-rpms
+      ppc64le: codeready-builder-for-rhel-9-ppc64le-rpms
+      s390x: codeready-builder-for-rhel-9-s390x-rpms
     reposync:
       enabled: false

--- a/group.yml
+++ b/group.yml
@@ -17,7 +17,7 @@ vars:
   GO_LATEST: "1.25"
   GO_EXTRA: "1.25"  # There is no extra version at this time, so just duplicate latest.
   MAJOR: 4
-  MINOR: 17
+  MINOR: 16
 
 OCP_TARGET_VERSIONS: [
   "4.14",

--- a/group.yml
+++ b/group.yml
@@ -85,7 +85,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-96-baseos:
+  rhel-97-baseos:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
@@ -102,7 +102,7 @@ repos:
     reposync:
       enabled: true
 
-  rhel-96-baseos-source:
+  rhel-97-baseos-source:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/source/SRPMS
@@ -134,7 +134,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-96-appstream:
+  rhel-97-appstream:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
@@ -151,7 +151,7 @@ repos:
     reposync:
       enabled: true
 
-  rhel-96-appstream-source:
+  rhel-97-appstream-source:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/source/SRPMS
@@ -168,7 +168,7 @@ repos:
     reposync:
       enabled: true
 
-  rhel-96-appstream-debug:
+  rhel-97-appstream-debug:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/debug/

--- a/group.yml
+++ b/group.yml
@@ -85,24 +85,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-97-baseos:
-    conf:
-      baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/os/
-      extra_options:
-        gpgcheck: "1"
-    content_set:
-      default: rhel-9-for-x86_64-baseos-rpms
-      aarch64: rhel-9-for-aarch64-baseos-rpms
-      ppc64le: rhel-9-for-ppc64le-baseos-rpms
-      s390x: rhel-9-for-s390x-baseos-rpms
-    reposync:
-      enabled: true
-
-  rhel-97-baseos-source:
+  rhel-9-baseos-source:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/source/SRPMS
@@ -117,7 +100,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-baseos-source-rpms
       s390x: rhel-9-for-s390x-baseos-source-rpms
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-appstream-rpms:
     conf:
@@ -134,24 +117,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-97-appstream:
-    conf:
-      baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/os/
-      extra_options:
-        gpgcheck: "1"
-    content_set:
-      default: rhel-9-for-x86_64-appstream-rpms
-      aarch64: rhel-9-for-aarch64-appstream-rpms
-      ppc64le: rhel-9-for-ppc64le-appstream-rpms
-      s390x: rhel-9-for-s390x-appstream-rpms
-    reposync:
-      enabled: true
-
-  rhel-97-appstream-source:
+  rhel-9-appstream-source:
     conf:
       baseurl:
         x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/source/SRPMS
@@ -166,7 +132,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-appstream-source-rpms
       s390x: rhel-9-for-s390x-appstream-source-rpms
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-97-appstream-debug:
     conf:
@@ -183,7 +149,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-appstream-debug-rpms
       s390x: rhel-9-for-s390x-appstream-debug-rpms
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-codeready-builder-rpms:
     conf:

--- a/group.yml
+++ b/group.yml
@@ -2,7 +2,7 @@ freeze_automation: true
 name: logging-6.0
 csv_namespace: openshift-logging
 product: openshift-logging
-version: 6.0.16
+version: 6.0.15
 
 vars:
   # The go versions used by the various CI builder images.
@@ -14,16 +14,16 @@ vars:
   #               aliases:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
-  GO_LATEST: "1.23"
-  GO_EXTRA: "1.24=3"  # There is no extra version at this time, so just duplicate latest.
+  GO_LATEST: "1.25"
+  GO_EXTRA: "1.25"  # There is no extra version at this time, so just duplicate latest.
   MAJOR: 4
   MINOR: 17
 
 OCP_TARGET_VERSIONS: [
+  "4.14",
+  "4.15",
+  "4.16",
   "4.17",
-  "4.18",
-  "4.19",
-  "4.20",
 ]
 
 arches:

--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: release-6.3
+        target: release-6.0
       url: git@github.com:openshift-priv/cluster-logging-operator.git
       web: https://github.com/openshift/cluster-logging-operator
 distgit:

--- a/images/loki-operator.yml
+++ b/images/loki-operator.yml
@@ -4,7 +4,7 @@ content:
     path: operator
     git:
       branch:
-        target: release-6.3
+        target: release-6.0
       url: git@github.com:openshift-priv/loki.git
       web: https://github.com/openshift/loki
 distgit:

--- a/images/vector.yml
+++ b/images/vector.yml
@@ -23,8 +23,8 @@ for_payload: false
 dependents:
 - cluster-logging-operator
 enabled_repos:
-- rhel-97-appstream
-- rhel-97-baseos
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 from:
   builder:
     - member: base-rhel9

--- a/images/vector.yml
+++ b/images/vector.yml
@@ -23,8 +23,8 @@ for_payload: false
 dependents:
 - cluster-logging-operator
 enabled_repos:
-- rhel-96-appstream
-- rhel-96-baseos
+- rhel-97-appstream
+- rhel-97-baseos
 from:
   builder:
     - member: base-rhel9

--- a/images/vector.yml
+++ b/images/vector.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: v0.47.0-rh
+        target: v0.43.1-rh
       url: git@github.com:openshift-priv/vector.git
       web: https://github.com/ViaQ/vector
     pkg_managers:

--- a/images/vector.yml
+++ b/images/vector.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: v0.43.1-rh
+        target: v0.37.1-rh
       url: git@github.com:openshift-priv/vector.git
       web: https://github.com/ViaQ/vector
     pkg_managers:

--- a/images/vector.yml
+++ b/images/vector.yml
@@ -354,7 +354,7 @@ konflux:
       - rust
       - rust-std-static
       - rust-toolset
-      - rust-toolset-1.84.1
+      - rust-toolset-1.75.0
       - scl-utils
       - systemd
       - systemtap-sdt-devel

--- a/streams.yml
+++ b/streams.yml
@@ -10,4 +10,4 @@ ose-cli-artifacts:
 
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
-  image: registry.redhat.io/ubi9/ubi-minimal@sha256:34880b64c07f28f64d95737f82f891516de9a3b43583f39970f7bf8e4cfa48b7
+  image: registry.redhat.io/ubi9/ubi-minimal@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183


### PR DESCRIPTION
Upstream changes:

- [x] cluster-logging-operator (openshift/cluster-logging-operator#3250)
- [x] loki-operator (openshift/loki#497)
- [x] vector (ViaQ/vector#253)

Todo:

- [x] Update vector package list (different version than other releases)

/label tide/merge-method-squash
/hold needs upstream changes
