### PR TITLE
ART-14890 [rhel-9-golang-1.25]: migrate to hermetic builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -11,6 +11,7 @@ vars:
   MINOR: 22
 
 konflux:
+  network_mode: hermetic
   cachi2:
     enabled: true
 

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -43,7 +43,6 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
-  network_mode: open
   content:
     source:
       modifications:


### PR DESCRIPTION
## Summary

Migrates rhel-9-golang-1.25 golang builder configuration to hermetic builds by removing `network_mode: open`. This enables network isolation during the build process while maintaining cross-compilation capabilities through pre-staged artifacts.

## Changes

- Remove `network_mode: open` from openshift-golang-builder.yml
- Maintain existing cachi2 artifact lockfile configuration
- Supports OpenShift versions 4.21-5.0

## Test Plan

- [x] Verify hermetic build compliance in Konflux
- [x] Confirm cross-compilation artifacts are accessible
- [x] Validate build success across supported architectures

**JIRA:** [ART-14890](https://redhat.atlassian.net/browse/ART-14890)