### PR TITLE
ose-cluster-baremetal-operator hermetic 4.16

### DIFF
--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -26,6 +26,3 @@ name: openshift/ose-cluster-baremetal-operator-rhel9
 payload_name: cluster-baremetal-operator
 owners:
 - kni-devel-deployment@redhat.com
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260


### PR DESCRIPTION
follows https://github.com/openshift/cluster-baremetal-operator/pull/562

[test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-cluster-baremetal-operator-jwcvj)