### PR TITLE
ose-cluster-baremetal-operator hermetic 4.12

### DIFF
--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -22,7 +22,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/ose-cluster-baremetal-operator-rhel8
-konflux:
-  cachi2:
-    enabled: false  # https://issues.redhat.com/browse/ART-13260
 payload_name: cluster-baremetal-operator


### PR DESCRIPTION
follows:

https://github.com/openshift/cluster-baremetal-operator/pull/566

[ose-cluster-baremetal-operator test build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-ose-cluster-baremetal-operator-b5q7c)
