### PR TITLE
ART-14902: Add rhel-98-baseos to enabled_repos for ose-frr (4.22)

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -17,6 +17,7 @@ delivery:
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-98-appstream
+- rhel-98-baseos
 - rhel-9-baseos-rpms
 - rhel-9-server-ose-rpms-embargoed
 for_payload: true


### PR DESCRIPTION
## Summary

Adding `rhel-98-baseos` to `enabled_repos` for ose-frr on openshift-4.22.

**Failing build:** [seed-lockfile #49](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%25252Fseed-lockfile/49/)

## Analysis

The open-network test build fails during `dnf -y update` with:

```
nothing provides python3 = 3.9.25-6.el9_8 needed by
python-unversioned-command-3.9.25-6.el9_8.noarch from rhel-98-appstream-x86_64
```

The `rhel-98-appstream` repo is enabled and offers `python-unversioned-command-3.9.25-6.el9_8`,
which requires `python3 = 3.9.25-6.el9_8`. That `python3` version lives in `rhel-98-baseos`,
which is **not** enabled for 4.22 but **is** enabled for 4.23 and 5.0.

This affects all architectures (x86_64, aarch64, s390x, ppc64le).

## Changes

- Added `rhel-98-baseos` to `enabled_repos`, matching openshift-4.23 and openshift-5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)