### PR TITLE
ART-14904: Add glibc-gconv-extra to lockfile rpms for ose-agent-installer-utils (4.22)

### DIFF
--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -47,6 +47,7 @@ konflux:
       - gcc-c++
       - gcc-plugin-annobin
       - glibc
+      - glibc-gconv-extra
       - glibc-devel
       - glibc-headers
       - kernel-headers


### PR DESCRIPTION
## Summary

Adding `glibc-gconv-extra` to `konflux.cachi2.lockfile.rpms` for `ose-agent-installer-utils`
on openshift-4.22.

**Failing build:** [seed-lockfile #40](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%25252Fseed-lockfile/40/) (stream build failed after successful test build)

## Analysis

The hermetic stream build fails at `dnf install -y gcc nmstate-devel nmstate-libs` with:

```
package gcc-11.5.0-11.el9 from rhel-9-for-x86_64-appstream-rpms requires
libc.so.6(GLIBC_2.35)(64bit), but none of the providers can be installed
 - package glibc requires (glibc-gconv-extra if redhat-rpm-config),
   but none of the providers can be installed
```

Dependency chain: `gcc` → `glibc` (GLIBC_2.35) → `glibc-gconv-extra` (conditional on
`redhat-rpm-config` being installed in the base image). The `glibc-gconv-extra` package
must be prefetched for the hermetic build.

## Changes

- Added `glibc-gconv-extra` to `konflux.cachi2.lockfile.rpms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)