### PR TITLE
ART-14903: Add glibc-gconv-extra to lockfile rpms for ose-agent-installer-api-server (4.22)

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -52,6 +52,7 @@ konflux:
       - git-core
       - git-core-doc
       - glibc
+      - glibc-gconv-extra
       - glibc-devel
       - glibc-headers
       - kernel-headers


### PR DESCRIPTION
## Summary

Adding `glibc-gconv-extra` to `konflux.cachi2.lockfile.rpms` for `ose-agent-installer-api-server`
on openshift-4.22.

**Failing build:** [seed-lockfile #50](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%25252Fseed-lockfile/50/) (stream build failed after successful test build)

## Analysis

The hermetic stream build fails at `dnf install -y gcc nmstate-devel nmstate-libs git` with:

```
package gcc-11.5.0-11.el9 from rhel-9-for-x86_64-appstream-rpms requires
libc.so.6(GLIBC_2.35)(64bit), but none of the providers can be installed
 - package glibc requires (glibc-gconv-extra if redhat-rpm-config),
   but none of the providers can be installed
```

Dependency chain: `gcc` → `glibc` (GLIBC_2.35) → `glibc-gconv-extra` (conditional on
`redhat-rpm-config` being installed in the base image). The `glibc-gconv-extra` package
must be prefetched for the hermetic build.

## Changes

- Added `glibc-gconv-extra` to `konflux.cachi2.lockfile.rpms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)