### PR TITLE
ART-14900: Fix pkg_manager for networking-console-plugin (4.21)

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -13,7 +13,7 @@ content:
       match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
       replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     pkg_managers:
-    - yarn
+    - npm
     okd_alignment:
       dockerfile: Dockerfile
 distgit:


### PR DESCRIPTION
## Summary

Changing `pkg_managers` from `yarn` to `npm` for networking-console-plugin on 4.21,
matching what was done in 4.22 in commit 709eee19e.

## Analysis

The upstream source repo migrated from yarn to npm in PR
[#359](https://github.com/openshift/networking-console-plugin/pull/359) (cherry-pick
of [#331](https://github.com/openshift/networking-console-plugin/pull/331),
OCPBUGS-74423), merged April 9. The Dockerfile.art now uses `npm ci && npm run build`
and has a `package-lock.json`.

The ocp-build-data config still specifies `pkg_managers: [yarn]`, causing the
hermeto/cachi2 prefetch step to fail with:
```
PackageRejected: Unable to determine the yarn version to use to process the request
Ensure that either yarnPath is defined in .yarnrc.yml or that packageManager is defined in package.json
```

This was already fixed in 4.22 (commit 709eee19e by D. Paolella).

## Changes

- Changed `pkg_managers` from `yarn` to `npm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)