### PR TITLE
ART-14901: Add non-final stage RPM pins for ose-insights-runtime-extractor (4.21)

### DIFF
--- a/images/ose-insights-runtime-extractor.yml
+++ b/images/ose-insights-runtime-extractor.yml
@@ -36,22 +36,32 @@ konflux:
   cachi2:
     lockfile:
       rpms:
+      - acl
       - binutils
       - binutils-gold
       - cargo
       - cpp
+      - dbus
+      - dbus-broker
+      - dbus-common
       - elfutils-debuginfod-client
+      - elfutils-default-yama-scope
+      - elfutils-libs
       - gcc
       - glibc-devel
       - glibc-headers
       - kernel-headers
+      - kmod-libs
       - libasan
       - libatomic
       - libedit
+      - libgomp
       - libmpc
       - libpkgconf
+      - libseccomp
       - libubsan
       - libxcrypt-devel
+      - llvm-filesystem
       - llvm-libs
       - make
       - pkgconf
@@ -61,6 +71,9 @@ konflux:
       - rust-std-static
       - rust-toolset
       - rustfmt
+      - systemd
+      - systemd-pam
+      - systemd-rpm-macros
 okd:
   enabled_repos:
   - rhel-9-server-ose-rpms


### PR DESCRIPTION
## Summary

Backport of 7d35b7282 from openshift-4.22 — adding missing `konflux.cachi2.lockfile.rpms`
entries for non-final Dockerfile stage dependencies.

**Failing stream build:** [seed-lockfile #42](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/42/) — test succeeded, stream failed.

## Analysis

The hermetic stream build fails with:
```
nothing provides libgomp.so.1()(64bit) needed by gcc-11.5.0-5.el9_5.x86_64
nothing provides libgomp = 11.5.0-5.el9_5 needed by gcc-11.5.0-5.el9_5.x86_64
```

The `gcc` package requires `libgomp` which is not in the lockfile RPMs list. Several other
transitive dependencies are also missing (dbus, systemd, elfutils, kmod-libs, etc).

## Changes

- Added 13 missing RPMs to `konflux.cachi2.lockfile.rpms` matching 4.22 config

🤖 Generated with [Claude Code](https://claude.com/claude-code)