### PR TITLE
ART-14896: Add perl:5.32 module for openshift-base-nodejs (4.13)

### DIFF
--- a/images/openshift-base-nodejs.yml
+++ b/images/openshift-base-nodejs.yml
@@ -41,3 +41,8 @@ labels:
 name: openshift/base-nodejs
 owners:
 - aos-team-art@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      modules:
+      - perl:5.32


### PR DESCRIPTION
## Summary

Adding `konflux.cachi2.lockfile.modules` with `perl:5.32` for `openshift-base-nodejs`.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/logs?nvr=openshift-base-nodejs-container-v4.13.0-202604120109.p2.g0fb79a4.assembly.stream.el8&record_id=edd29134-0d93-b75e-94f0-39454a6c9378

## Analysis

The `yum update -y` in the Dockerfile fails because the rolling RHEL 8 appstream repo has perl 5.32 modular packages (e.g. `perl-Digest-1.20-1.module+el8.10.0`) that require `perl(:MODULE_COMPAT_5.32.1)`. The UBI base image has perl 5.26 installed, and without the `perl:5.32` module enabled, the module-compat provider is unavailable.

This configuration is already present in openshift-4.12 (`a346b1fbb`) and openshift-4.15 (`922b6531d`) but was missing from 4.13.

## Changes

- Added `konflux.cachi2.lockfile.modules: [perl:5.32]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)