### PR TITLE
ART-14896: Add perl:5.32 module for openshift-base-nodejs (4.14)

### DIFF
--- a/images/openshift-base-nodejs.yml
+++ b/images/openshift-base-nodejs.yml
@@ -39,4 +39,5 @@ konflux:
   cachi2:
     lockfile:
       modules:
+      - perl:5.32
       - python36:3.6


### PR DESCRIPTION
## Summary

Adding `perl:5.32` to `konflux.cachi2.lockfile.modules` for `openshift-base-nodejs`.

## Analysis

Same issue as 4.13: the rolling RHEL 8 appstream repo has perl 5.32 modular packages requiring `perl(:MODULE_COMPAT_5.32.1)`. The `python36:3.6` module was configured but `perl:5.32` was missing. This matches the configuration in openshift-4.12 and openshift-4.15.

## Changes

- Added `perl:5.32` to the existing `konflux.cachi2.lockfile.modules` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)