### PR TITLE
ose-insights-runtime-extractor: Add libgomp to transient deps list

### DIFF
--- a/images/ose-insights-runtime-extractor.yml
+++ b/images/ose-insights-runtime-extractor.yml
@@ -48,6 +48,7 @@ konflux:
       - libasan
       - libatomic
       - libedit
+      - libgomp
       - libmpc
       - libpkgconf
       - libubsan


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED