### PR TITLE
ART-14911: Set explicit pkg_managers for ose-olm-catalogd (4.20)

### DIFF
--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -1,5 +1,7 @@
 content:
   source:
+    pkg_managers:
+    - gomod
     dockerfile: openshift/catalogd.Dockerfile
     git:
       branch:


### PR DESCRIPTION
## Summary

Adding explicit `pkg_managers: [gomod]` to prevent hermeto from auto-detecting and
processing a docs-only `requirements.txt` (containing `lxml`) as a pip dependency.

**Failing build:** [ART-14911](https://issues.redhat.com/browse/ART-14911)

## Analysis

The `prefetch-dependencies-oci-ta` task was re-bumped to version 0.3 on April 10
([commit 70007c7](https://github.com/openshift-priv/art-konflux-template/commit/70007c7))
in art-konflux-template. Hermeto 0.3 auto-detects package managers from repo contents and
finds a `requirements.txt` at the repo root containing `lxml` (a docs-only dependency via
mkdocs-material → pyquery → lxml). The Dockerfile is a pure Go build with no pip usage.
Hermeto crashes with `AttributeError: 'NoneType' object has no attribute '_fields'` in
`_depends_on_rust` while processing `lxml-6.0.2`.

This same prefetch task version was manually reverted 3 times before (Dec 2025, Jan 2026,
March 2026).

## Changes

- Added `pkg_managers: [gomod]` under `content.source` to explicitly declare the only
  package manager used, preventing pip auto-detection

## Related

Same issue affects 4.21, 4.22, 4.23, and 5.0. This PR tests the fix on 4.20 first.