### PR TITLE
ART-14913: Set explicit pkg_managers for ose-olm-catalogd (4.21)

### DIFF
--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -1,5 +1,7 @@
 content:
   source:
+    pkg_managers:
+    - gomod
     dockerfile: openshift/catalogd.Dockerfile
     git:
       branch:


### PR DESCRIPTION
## Summary

Setting explicit `pkg_managers: [gomod]` for ose-olm-catalogd to prevent hermeto from
auto-detecting and processing pip dependencies.

**Error type:** Prefetch error — hermeto auto-detects `pip` from the source repo and
crashes trying to process it.

## Changes

- Added `content.source.pkg_managers: [gomod]` to exclude pip from prefetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)