### PR TITLE
Fix bitwarden-sdk-server branch target for ESO 1.1

### DIFF
--- a/images/external-secrets-bitwarden-sdk-server.yml
+++ b/images/external-secrets-bitwarden-sdk-server.yml
@@ -8,7 +8,7 @@ content:
     git:
       allow_unprotected_branch: true
       branch:
-        target: art-build-v0.5.2
+        target: release-0.5.2
       url: git@github.com:openshift-priv/external-secrets-bitwarden-sdk-server.git
       url_pull: https://github.com/fbladilo/external-secrets-bitwarden-sdk-server.git
       web: https://github.com/openshift/external-secrets-bitwarden-sdk-server


### PR DESCRIPTION
## Summary
- Update branch target from `art-build-v0.5.2` to `release-0.5.2` to match the actual branch name created by the dev team in `openshift/external-secrets-bitwarden-sdk-server`

## Test plan
- Re-run Jenkins `layered-products` build with `GROUP=external-secrets-1.1` after merge
- Verify bitwarden-sdk-server rebase no longer fails with `fatal: couldn't find remote ref art-build-v0.5.2`