### PR TITLE
Enable module_hotfixes on rhel-8-appstream-rpms (4.12)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -291,6 +291,7 @@ repos:
           enabled: true
       extra_options:
         excludepkgs: containernetworking-plugins
+        module_hotfixes: 1
     content_set:
       default: rhel-8-for-x86_64-appstream-e4s-rpms__8_DOT_6
       aarch64: rhel-8-for-aarch64-appstream-e4s-rpms__8_DOT_6


### PR DESCRIPTION
## Summary

Add `module_hotfixes: 1` to `rhel-8-appstream-rpms` repo configuration for openshift-4.12.

**Failing build:** [seed-lockfile #67](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/67/) — stream build failed for `openshift-enterprise-builder`
**Stream build error log:** [art-build-history](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/logs?nvr=openshift-enterprise-builder-container-v4.12.0-202604131224.p2.ge355452.assembly.test.el8&record_id=a3d7befb-bdb2-e80b-d009-befbc07d4138&group=openshift-4.12&outcome=failure&type=image)

## Analysis

The RHEL 8.6 E4S appstream repo has modular filtering that blocks `perl-Net-SSLeay`, causing a cascading dependency failure when installing `git`:

```
perl-Net-SSLeay-1.88 is filtered out by modular filtering
nothing provides libperl.so.5.24()(64bit)
nothing provides perl(:MODULE_COMPAT_5.24.4)
```

The lockfile (test) build succeeds because `lockfile.modules` enables the perl modules during resolution. The stream build fails because modular filtering hides the correct packages.

This is consistent with `rhel-9-appstream-rpms` which already has `module_hotfixes: 1` in 4.16+, and the `rhel-8-server-ose-rpms-embargoed` / `rhel-8-server-ose-rpms` repos which already have it in 4.12.

## Changes

- Added `module_hotfixes: 1` to `rhel-8-appstream-rpms` `extra_options`

🤖 Generated with [Claude Code](https://claude.com/claude-code)