### PR TITLE
ART-14905: Add grub2 meta-package to lockfile rpms for ironic (4.22)

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -90,6 +90,7 @@ konflux:
       - glibc-devel
       - glibc-gconv-extra
       - glibc-headers
+      - grub2
       - grub2-common
       - grub2-efi-aa64
       - grub2-efi-x64


### PR DESCRIPTION
## Summary

The `prepare-efi.sh` script runs `dnf install -y --allowerasing grub2 dosfstools mtools glibc-gconv-extra`
in a non-final build stage. The `grub2` meta-package was missing from `konflux.cachi2.lockfile.rpms`,
causing the hermetic build to fail with `No match for argument: grub2`.

The sub-packages (`grub2-common`, `grub2-efi-x64`, `grub2-pc`, etc.) were already listed but the
meta-package itself was not.

## Changes

- Added `grub2` to `konflux.cachi2.lockfile.rpms` in `images/ironic.yml`

Generated with [Claude Code](https://claude.com/claude-code)