### PR TITLE
Add CRB repo to ose-frr for catatonit (openshift-4.22)

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -17,6 +17,7 @@ delivery:
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms
+- rhel-9-codeready-builder-rpms
 - rhel-9-server-ose-rpms-embargoed
 for_payload: true
 dependents:


### PR DESCRIPTION
## Summary

- Enable `rhel-9-codeready-builder-rpms` for `ose-frr` image build
- `podman-catatonit` is no longer available as a subpackage of newer podman; the standalone `catatonit` package is in the CodeReady Builder (CRB) repo
- Ref: [ART-14902](https://redhat.atlassian.net/browse/ART-14902)

## Test plan

- [ ] Verify ose-frr image builds successfully with the new repo enabled
- [ ] Confirm catatonit package resolves from CRB during build