### PR TITLE
Add CRB repo to ose-frr (4.23)

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -16,6 +16,7 @@ delivery:
   - openshift4/frr-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
+- rhel-9-codeready-builder-rpms
 - rhel-98-appstream
 - rhel-98-baseos
 - rhel-9-baseos-rpms


### PR DESCRIPTION
## Summary
- Add `rhel-9-codeready-builder-rpms` to `enabled_repos` for ose-frr
- The standalone `catatonit` package in CRB provides a virtual `podman-catatonit`, needed after podman 5.x dropped the subpackage
- Preemptive fix — validated on 4.22 via seed-lockfile #81 (SUCCESS)

[ART-14902](https://redhat.atlassian.net/browse/ART-14902)