### PR TITLE
Revert "[openshift-5.0] Remove MISMATCHED_SIBLINGS code entry from prerelease_permits"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -85,6 +85,8 @@ releases:
         # ref. https://redhat-internal.slack.com/archives/C01CQA76KMX/p1738863088399379
         - code: INCONSISTENT_RHCOS_RPMS
           component: rhcos
+        - code: MISMATCHED_SIBLINGS
+          component: '*'
         - code: FAILED_CONSISTENCY_REQUIREMENT
           component: '*'
       members:


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#9535

these images are not updated when there is a mismatchjed sibling, so the previously matched siblings would remain in the image stream. 

https://github.com/openshift-eng/art-tools/pull/1951/