### PR TITLE
mta-hub: Add missing deps for tini stage

### DIFF
--- a/images/mta-hub.yml
+++ b/images/mta-hub.yml
@@ -58,8 +58,10 @@ konflux:
         - kernel-headers
         - libasan
         - libatomic
+        - libgomp
         - libmpc
         - libpkgconf
+        - libstdc++
         - libstdc++-devel
         - libubsan
         - libuv


### PR DESCRIPTION
Signed-off-by: Franco Bladilo <fbladilo@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED