### PR TITLE
mta-8.1: freeze_automation

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: false
+freeze_automation: true
 name: mta-8.1
 csv_namespace: mta
 product: mta


### PR DESCRIPTION
Build loop caused by RPM deps

[Slack thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1776176417299849)

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED