### PR TITLE
ART-14654 [openshift-4.17]: migrate monitoring-plugin to hermetic builds

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -3,7 +3,7 @@ envs:
 cachito:
   enabled: true
   packages:
-    yarn:
+    npm:
     - path: web
     gomod:
     - path: .
@@ -19,13 +19,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
-    modifications:
-    - action: replace
-      match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
-      replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
-
     pkg_managers:
-    - yarn
+    - npm
     - gomod
     okd_alignment:
       dockerfile: Dockerfile
@@ -53,10 +48,9 @@ owners:
 konflux:
   cachito:
     mode: removal
+  vm_override:
+    aarch64: linux-d160-c4xlarge/arm64
   cachi2:
     lockfile:
       modules:
       - nginx:1.24
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz


### PR DESCRIPTION
## Summary
Migrate monitoring-plugin to npm-based hermetic builds for OpenShift 4.17.

## Problem
**Before:** monitoring-plugin uses yarn packages with external artifact dependencies and cachi2 removal mode, requiring external downloads during build.

**After:** monitoring-plugin uses npm packages with cachito emulation mode, enabling full hermetic builds with pre-staged dependencies.

## Changes
- Change cachito packages from yarn to npm
- Change pkg_managers from yarn to npm+gomod
- Remove yarn artifact modifications  
- Enable cachito emulation mode for hermetic isolation

## Upstream Prerequisites
This change is enabled by upstream monitoring-plugin PRs that migrated from yarn to npm:
- [monitoring-plugin PR #813](https://github.com/openshift/monitoring-plugin/pull/813) (release-4.16)
- [monitoring-plugin PR #812](https://github.com/openshift/monitoring-plugin/pull/812) (release-4.17)

## Build Jobs
- [Jenkins](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/31308/console)
- [Konflux](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-monitoring-plugin-t5lbl)

Related: [ART-14654](https://redhat.atlassian.net/browse/ART-14654)