### PR TITLE
[ART-14883] Migrate rhel-8 golang builder to hermetic builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -11,6 +11,7 @@ vars:
   MINOR: 22
 
 konflux:
+  network_mode: hermetic
   cachi2:
     enabled: true
 

--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -17,6 +17,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="$VERSION"
 
+USER 0
+RUN dnf module enable -y python36:3.6 perl perl-IO-Socket-SSL perl-libwww-perl
 RUN dnf update -y && \
     dnf install -y --nodocs \
         bc \

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -42,7 +42,6 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
-  network_mode: open
   content:
     source:
       modifications:

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -42,6 +42,12 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
+    lockfile:
+      modules:
+      - python36:3.6
+      - perl
+      - perl-IO-Socket-SSL
+      - perl-libwww-perl
   content:
     source:
       modifications:


### PR DESCRIPTION
## Summary

Migrates rhel-8-golang-1.25 golang builder configuration to hermetic builds by removing `network_mode: open`. This enables network isolation during the build process while maintaining cross-compilation capabilities through pre-staged artifacts.

## Changes

- Remove `network_mode: open` from openshift-golang-builder.yml (RHEL 8 variant)
- Maintain existing cachi2 artifact lockfile configuration
- Supports OpenShift versions 4.21-5.0

## Test Plan

- [ ] Verify hermetic build compliance in Konflux
- [ ] Confirm cross-compilation artifacts are accessible
- [ ] Validate build success across supported architectures

**JIRA:** [ART-14883](https://redhat.atlassian.net/browse/ART-14883)