### PR TITLE
ART-14939: Add git-lfs to lockfile rpms for openshift-enterprise-builder (4.22)

### DIFF
--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -36,3 +36,8 @@ name: openshift/ose-docker-builder-rhel9
 payload_name: docker-builder
 owners:
 - openshift-build-api@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - git-lfs


### PR DESCRIPTION
## Summary

Add `git-lfs` to `konflux.cachi2.lockfile.rpms` for openshift-enterprise-builder.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/logs?nvr=openshift-enterprise-builder-container-v4.22.0-202604140145.p2.gfcd4ce2.assembly.stream.el9&record_id=576c8901-c666-ba58-6b3c-2d5eafd2d4f1
**Seed-lockfile build #109:** test build succeeded, stream build failed with same error

## Analysis

The hermetic build fails with `No package matches 'git-lfs'` in the final stage. Seed-lockfile build #109 confirmed the test (open-network) build succeeds but the stream (hermetic) build fails because git-lfs is missing from the lockfile. The image had no `konflux` section — adding one with `git-lfs` in `lockfile.rpms` will ensure it's included in the lockfile.

## Changes

- Added `konflux.cachi2.lockfile.rpms` section with `git-lfs`

Generated with [Claude Code](https://claude.com/claude-code)