### PR TITLE
ART-14936: Add NetworkManager to lockfile rpms for dpu-intel-ipu-vsp (4.22)

### DIFF
--- a/images/dpu-intel-ipu-vsp.yml
+++ b/images/dpu-intel-ipu-vsp.yml
@@ -74,6 +74,7 @@ konflux:
       - libubsan
       - libxcrypt-devel
       - make
+      - NetworkManager
 okd:
   content:
     source:


### PR DESCRIPTION
## Summary

Add `NetworkManager` to `konflux.cachi2.lockfile.rpms` for dpu-intel-ipu-vsp.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/logs?nvr=dpu-intel-ipu-vsp-container-v4.22.0-202604140145.p2.ga591ac3.assembly.stream.el9&record_id=ed1ba7e3-f628-2486-8ee2-9e8557a166c3
**Seed-lockfile build #110:** test build succeeded, stream build failed with same error

## Analysis

The hermetic build fails with `No package matches 'NetworkManager'` in the final stage. The existing `lockfile.rpms` only contains builder-stage packages (gcc, binutils, etc.) but not the final-stage packages. Adding `NetworkManager` will ensure it's included in the lockfile for the final stage.

## Changes

- Added `NetworkManager` to `konflux.cachi2.lockfile.rpms`

Generated with [Claude Code](https://claude.com/claude-code)