### PR TITLE
ART-15400: Add nginx to lockfile rpms for ose-network-tools (4.22)

### DIFF
--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -39,3 +39,4 @@ konflux:
       rpms:
       - gcc-plugin-annobin
       - llvm-filesystem
+      - nginx


### PR DESCRIPTION
## Summary

Add `nginx` to `konflux.cachi2.lockfile.rpms` for ose-network-tools.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/logs?nvr=ose-network-tools-container-v4.22.0-202604141325.p2.g5c4b905.assembly.stream.el9&record_id=cd7418ee-3a24-d1a5-4d7d-097276df61eb

## Analysis

The hermetic build fails with `No package matches 'nginx'` in the final stage [3/3] STEP 14/20. The Dockerfile enables the `nginx:1.26` module stream and installs `nginx`. The module is already listed in `lockfile.modules` but the `nginx` package itself needs to be in `lockfile.rpms` to be included in the hermetic lockfile.

## Changes

- Added `nginx` to `konflux.cachi2.lockfile.rpms`

Generated with [Claude Code](https://claude.com/claude-code)