### PR TITLE
ART-14888 [rhel-9-golang-1.23]: migrate to hermetic builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -11,8 +11,11 @@ vars:
   MINOR: 19
 
 konflux:
+  network_mode: hermetic
   cachi2:
     enabled: true
+    lockfile:
+      force: true
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -43,7 +43,6 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
-  network_mode: open
   content:
     source:
       modifications:

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -43,6 +43,7 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
+  network_mode: hermetic
   content:
     source:
       modifications:


### PR DESCRIPTION
## Summary
Migrate rhel-9-golang-1.23 golang builder to hermetic builds by adding network isolation configuration.

## Problem
**Before:** Missing `network_mode` - builder may have unrestricted network access during Konflux builds, preventing hermetic compliance

**After:** `network_mode: hermetic` - builder uses network isolation during builds, enabling hermetic compliance with pre-staged dependencies via cachi2

Related: [ART-14888](https://redhat.atlassian.net/browse/ART-14888)