### PR TITLE
ART-14891 [rhel-10-golang-1.24]: migrate to hermetic builds

### DIFF
--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -43,7 +43,7 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
-  network_mode: open
+  network_mode: hermetic
   content:
     source:
       modifications:


### PR DESCRIPTION
## Summary
Migrate rhel-10-golang-1.24 golang builder to hermetic builds by updating network isolation configuration.

## Problem
**Before:** `network_mode: open` - builder has network access during Konflux builds, preventing hermetic compliance

**After:** `network_mode: hermetic` - builder uses network isolation during builds, enabling hermetic compliance with pre-staged dependencies via cachi2

Related: [ART-14891](https://redhat.atlassian.net/browse/ART-14891)