### PR TITLE
Use stage pulp for current 9.8 content prior to GA

### DIFF
--- a/repos/rhel-9-appstream-rpms.yml
+++ b/repos/rhel-9-appstream-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/aarch64/appstream/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/ppc64le/appstream/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/s390x/appstream/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/appstream/os/
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/appstream/os/
     ci_alignment:
       localdev:
         enabled: true

--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/baseos/os/
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/ppc64le/baseos/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/s390x/baseos/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/baseos/os/
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/s390x/baseos/os/
     ci_alignment:
       localdev:
         enabled: true

--- a/repos/rhel-9-codeready-builder-rpms.yml
+++ b/repos/rhel-9-codeready-builder-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
     ci_alignment:
       localdev:
         enabled: true

--- a/repos/rhel-9-fast-datapath-rpms.yml
+++ b/repos/rhel-9-fast-datapath-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
     ci_alignment:
       localdev:
         enabled: true

--- a/repos/rhel-9-highavailability.yml
+++ b/repos/rhel-9-highavailability.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/aarch64/highavailability/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/ppc64le/highavailability/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/s390x/highavailability/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/highavailability/os/
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/aarch64/highavailability/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/ppc64le/highavailability/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/s390x/highavailability/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/highavailability/os/
     extra_options:
       gpgcheck: '1'
   content_set:

--- a/repos/rhel-9-nfv.yml
+++ b/repos/rhel-9-nfv.yml
@@ -1,10 +1,10 @@
 - conf:
     baseurl:
       # We only have x86_64 repo for nfv
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
     extra_options:
       gpgcheck: '1'
   content_set:

--- a/repos/rhel-9-rt-rpms.yml
+++ b/repos/rhel-9-rt-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
-      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
-      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
-      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
     extra_options:
       module_hotfixes: 1
   content_set:


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

/hold
until 4.22 rebuild is done and looks good