### PR TITLE
Pin perl-interpreter and xorg-x11-fonts NVRs for openvpn hermetic builds

### DIFF
--- a/images/openshift-migration-openvpn.yml
+++ b/images/openshift-migration-openvpn.yml
@@ -15,7 +15,7 @@ content:
       # so we inject it manually. Lockfile resolver picks perl 5.32 modular RPMs as highest EVR. See art-tools#2686
       - action: replace
         match: "dnf builddep -y pkcs11-helper*"
-        replacement: "dnf module enable -y perl:5.32 perl-IO-Socket-SSL:2.066 perl-libwww-perl:6.34 && dnf builddep -y pkcs11-helper*"
+        replacement: "dnf module disable -y freeradius && dnf module enable -y perl:5.32 perl-IO-Socket-SSL:2.066 perl-libwww-perl:6.34 && dnf builddep -y pkcs11-helper*"
       - action: replace
         match: "dnf clean all"
         replacement: "microdnf clean all"

--- a/images/openshift-migration-openvpn.yml
+++ b/images/openshift-migration-openvpn.yml
@@ -15,7 +15,7 @@ content:
       # so we inject it manually. Lockfile resolver picks perl 5.32 modular RPMs as highest EVR. See art-tools#2686
       - action: replace
         match: "dnf builddep -y pkcs11-helper*"
-        replacement: "dnf module enable -y perl:5.32 perl-IO-Socket-SSL perl-libwww-perl && dnf builddep -y pkcs11-helper*"
+        replacement: "dnf module enable -y perl:5.32 perl-IO-Socket-SSL:2.066 perl-libwww-perl:6.34 && dnf builddep -y pkcs11-helper*"
       - action: replace
         match: "dnf clean all"
         replacement: "microdnf clean all"
@@ -42,8 +42,8 @@ konflux:
       dnf_modules_enable: true
       modules:
         - perl:5.32
-        - perl-IO-Socket-SSL
-        - perl-libwww-perl
+        - perl-IO-Socket-SSL:2.066
+        - perl-libwww-perl:6.34
       enabled: true
       inspect_parent: false
       rpms:

--- a/images/openshift-migration-openvpn.yml
+++ b/images/openshift-migration-openvpn.yml
@@ -218,7 +218,7 @@ konflux:
         - perl-macros
         - perl-MIME-Base64
         - perl-Mozilla-CA
-        - perl-Net-SSLeay
+        - perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+6b8485cb  # Pinned to perl:5.32 context; bare name resolves to perl:5.24 context (higher EVR due to RPM segment comparison of context hash)
         - perl-parent
         - perl-PathTools
         - perl-Pod-Escapes

--- a/images/openshift-migration-openvpn.yml
+++ b/images/openshift-migration-openvpn.yml
@@ -11,6 +11,11 @@ content:
       - action: replace
         match: "dnf -y install cpio"
         replacement: "microdnf -y install cpio"
+      # Enable perl:5.32 module for hermetic builds - rebaser skips module enablement for EL8 (el_ver < 9 guard)
+      # so we inject it manually. Lockfile resolver picks perl 5.32 modular RPMs as highest EVR. See art-tools#2686
+      - action: replace
+        match: "dnf builddep -y pkcs11-helper*"
+        replacement: "dnf module enable -y perl:5.32 perl-IO-Socket-SSL perl-libwww-perl && dnf builddep -y pkcs11-helper*"
       - action: replace
         match: "dnf clean all"
         replacement: "microdnf clean all"
@@ -34,8 +39,11 @@ from:
 konflux:
   cachi2:
     lockfile:
-      dnf_modules_enable: false
-      modules: []  # Emptied: module metadata in lockfile causes DNF modular filtering in hermetic builds but rebaser skips module enablement for EL8, and lockfile RPMs are out of sync with module metadata versions. See art-tools#2686
+      dnf_modules_enable: true
+      modules:
+        - perl:5.32
+        - perl-IO-Socket-SSL
+        - perl-libwww-perl
       enabled: true
       inspect_parent: false
       rpms:

--- a/images/openshift-migration-openvpn.yml
+++ b/images/openshift-migration-openvpn.yml
@@ -34,11 +34,8 @@ from:
 konflux:
   cachi2:
     lockfile:
-      dnf_modules_enable: true
-      modules:
-        - perl
-        - perl-IO-Socket-SSL
-        - perl-libwww-perl
+      dnf_modules_enable: false
+      modules: []  # Emptied: module metadata in lockfile causes DNF modular filtering in hermetic builds but rebaser skips module enablement for EL8, and lockfile RPMs are out of sync with module metadata versions. See art-tools#2686
       enabled: true
       inspect_parent: false
       rpms:
@@ -284,7 +281,7 @@ konflux:
         - urw-base35-standard-symbols-ps-fonts
         - urw-base35-z003-fonts
         - xkeyboard-config
-        - xorg-x11-fonts-ISO8859-1-100dpi
+        - xorg-x11-fonts-ISO8859-1-100dpi-7.5-19.el8  # Pinned: bare name misparsed as NVR by doozer _detect_nvr_vs_name(), silently dropped. See art-tools#2686
         - xorg-x11-font-utils
         - xorg-x11-server-utils
         - xz

--- a/images/openshift-migration-operator.yml
+++ b/images/openshift-migration-operator.yml
@@ -11,7 +11,7 @@ content:
       # so we inject it manually. Lockfile resolver picks perl 5.32 modular RPMs as highest EVR. See art-tools#2686
       - action: replace
         match: "dnf -y install python3-boto3 nss_wrapper"
-        replacement: "dnf module enable -y perl:5.32 perl-IO-Socket-SSL:2.066 perl-libwww-perl:6.34 && dnf -y install python3-boto3 nss_wrapper"
+        replacement: "dnf module disable -y freeradius && dnf module enable -y perl:5.32 perl-IO-Socket-SSL:2.066 perl-libwww-perl:6.34 && dnf -y install python3-boto3 nss_wrapper"
 delivery:
   bundle_delivery_repo_name: rhmtc/openshift-migration-operator-bundle
   delivery_repo_names:

--- a/images/openshift-migration-operator.yml
+++ b/images/openshift-migration-operator.yml
@@ -23,11 +23,8 @@ from:
 konflux:
   cachi2:
     lockfile:
-      dnf_modules_enable: true
-      modules:
-        - perl:5.26
-        - perl-IO-Socket-SSL:2.066
-        - perl-libwww-perl:6.34
+      dnf_modules_enable: false
+      modules: []  # Emptied: module metadata in lockfile causes DNF modular filtering in hermetic builds but rebaser skips module enablement for EL8, and lockfile RPMs are out of sync with module metadata versions. See art-tools#2686
       enabled: true
       inspect_parent: false
 name: rhmtc/openshift-migration-rhel8-operator

--- a/images/openshift-migration-operator.yml
+++ b/images/openshift-migration-operator.yml
@@ -6,6 +6,12 @@ content:
         target: release-1.8
       url: git@github.com:openshift-priv/migtools-mig-operator.git
       web: https://github.com/migtools/mig-operator
+    modifications:
+      # Enable perl:5.32 module for hermetic builds - rebaser skips module enablement for EL8 (el_ver < 9 guard)
+      # so we inject it manually. Lockfile resolver picks perl 5.32 modular RPMs as highest EVR. See art-tools#2686
+      - action: replace
+        match: "dnf -y install python3-boto3 nss_wrapper"
+        replacement: "dnf module enable -y perl:5.32 perl-IO-Socket-SSL perl-libwww-perl && dnf -y install python3-boto3 nss_wrapper"
 delivery:
   bundle_delivery_repo_name: rhmtc/openshift-migration-operator-bundle
   delivery_repo_names:
@@ -23,8 +29,11 @@ from:
 konflux:
   cachi2:
     lockfile:
-      dnf_modules_enable: false
-      modules: []  # Emptied: module metadata in lockfile causes DNF modular filtering in hermetic builds but rebaser skips module enablement for EL8, and lockfile RPMs are out of sync with module metadata versions. See art-tools#2686
+      dnf_modules_enable: true
+      modules:
+        - perl:5.32
+        - perl-IO-Socket-SSL
+        - perl-libwww-perl
       enabled: true
       inspect_parent: false
 name: rhmtc/openshift-migration-rhel8-operator

--- a/images/openshift-migration-operator.yml
+++ b/images/openshift-migration-operator.yml
@@ -11,7 +11,7 @@ content:
       # so we inject it manually. Lockfile resolver picks perl 5.32 modular RPMs as highest EVR. See art-tools#2686
       - action: replace
         match: "dnf -y install python3-boto3 nss_wrapper"
-        replacement: "dnf module enable -y perl:5.32 perl-IO-Socket-SSL perl-libwww-perl && dnf -y install python3-boto3 nss_wrapper"
+        replacement: "dnf module enable -y perl:5.32 perl-IO-Socket-SSL:2.066 perl-libwww-perl:6.34 && dnf -y install python3-boto3 nss_wrapper"
 delivery:
   bundle_delivery_repo_name: rhmtc/openshift-migration-operator-bundle
   delivery_repo_names:
@@ -32,8 +32,8 @@ konflux:
       dnf_modules_enable: true
       modules:
         - perl:5.32
-        - perl-IO-Socket-SSL
-        - perl-libwww-perl
+        - perl-IO-Socket-SSL:2.066
+        - perl-libwww-perl:6.34
       enabled: true
       inspect_parent: false
 name: rhmtc/openshift-migration-rhel8-operator


### PR DESCRIPTION
openshift-migration-openvpn hermetic builds started failing on Apr 13 with no changes to the source Dockerfile or ocp-build-data config. 

1. perl-interpreter: The bare name resolves to the modular 5.32.x from appstream (searched before baseos alphabetically). In hermetic builds, DNF filters this out by modular filtering because module enablement is skipped for EL8 (rebaser.py el_ver < 9 guard). Pin to the non-modular 5.26.3-423.el8_10 from baseos-eus.

2. xorg-x11-fonts-ISO8859-1-100dpi: doozer's _detect_nvr_vs_name() misparses this package name as an NVR (name=xorg-x11-fonts-ISO8859, version=1, release=100dpi), causing it to be silently dropped from the lockfile. Pin to the full NVR 7.5-19.el8 to bypass the parser.

Both packages were previously supplied by rpms_from_build (from the old over-broad SBOM data), masking these bugs. The upstream Dockerfile (migtools/openvpn release-1.8) has not changed since before the last successful build on Apr 12.
