### PR TITLE
4.14.64: prepare-release fix: pin 23 containers for operator bunle compatibility

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -14,9 +14,13 @@ releases:
         shipment:
           advisories:
             - kind: image
+              live_id: 8407
             - kind: extras
+              live_id: 8408
             - kind: metadata
+              live_id: 8409
             - kind: fbc
+          url: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/467
         release_date: 2026-Apr-23
         upgrades: 4.13.19,4.13.21,4.13.22,4.13.23,4.13.24,4.13.25,4.13.26,4.13.27,4.13.28,4.13.29,4.13.30,4.13.31,4.13.32,4.13.33,4.13.34,4.13.35,4.13.36,4.13.37,4.13.38,4.13.39,4.13.40,4.13.41,4.13.42,4.13.43,4.13.44,4.13.45,4.13.46,4.13.48,4.13.49,4.13.50,4.13.51,4.13.52,4.13.53,4.13.54,4.13.55,4.13.56,4.13.57,4.13.58,4.13.59,4.13.60,4.13.61,4.13.62,4.13.63,4.13.64,4.13.65,4.14.0,4.14.1,4.14.2,4.14.3,4.14.4,4.14.5,4.14.6,4.14.7,4.14.8,4.14.9,4.14.10,4.14.11,4.14.12,4.14.13,4.14.14,4.14.15,4.14.16,4.14.17,4.14.18,4.14.19,4.14.20,4.14.21,4.14.22,4.14.23,4.14.24,4.14.25,4.14.26,4.14.27,4.14.28,4.14.29,4.14.30,4.14.31,4.14.32,4.14.33,4.14.34,4.14.35,4.14.36,4.14.37,4.14.38,4.14.39,4.14.40,4.14.41,4.14.42,4.14.43,4.14.44,4.14.45,4.14.46,4.14.48,4.14.49,4.14.50,4.14.51,4.14.52,4.14.53,4.14.54,4.14.55,4.14.56,4.14.57,4.14.58,4.14.59,4.14.60,4.14.61,4.14.62,4.14.63
       rhcos:
@@ -40,7 +44,123 @@ releases:
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:db60676050fff4c76a81ca39d566bdc2d63698f8ba640debf9b4a67eacabb755
       members:
         rpms: []
-        images: []
+
+        images:
+          - distgit_key: kube-rbac-proxy
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: kube-rbac-proxy-container-v4.14.0-202604140121.p2.gb8b8259.assembly.stream.el8
+          - distgit_key: node-feature-discovery
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: node-feature-discovery-container-v4.14.0-202604140121.p2.ga679fac.assembly.stream.el8
+          - distgit_key: local-storage-diskmaker
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: local-storage-diskmaker-container-v4.14.0-202604130126.p2.g1f4c027.assembly.stream.el9
+          - distgit_key: ose-local-storage-mustgather
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ose-local-storage-mustgather-container-v4.14.0-202604130126.p2.g1f4c027.assembly.stream.el9
+          - distgit_key: csi-livenessprobe
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: csi-livenessprobe-container-v4.14.0-202604140121.p2.ga9bcbde.assembly.stream.el8
+          - distgit_key: csi-node-driver-registrar
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: csi-node-driver-registrar-container-v4.14.0-202604140121.p2.g9dcaa7f.assembly.stream.el8
+          - distgit_key: csi-provisioner
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: csi-provisioner-container-v4.14.0-202604140121.p2.ge18ed7f.assembly.stream.el8
+          - distgit_key: ose-aws-efs-csi-driver
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ose-aws-efs-csi-driver-container-v4.14.0-202604140121.p2.g67eddc2.assembly.stream.el8
+          - distgit_key: ose-csi-external-resizer
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ose-csi-external-resizer-container-v4.14.0-202604140121.p2.g59a701a.assembly.stream.el8
+          - distgit_key: ose-csi-external-snapshotter
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ose-csi-external-snapshotter-container-v4.14.0-202604140121.p2.ga683453.assembly.stream.el8
+          - distgit_key: ose-gcp-filestore-csi-driver
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ose-gcp-filestore-csi-driver-container-v4.14.0-202604140121.p2.g4f42f91.assembly.stream.el8
+          - distgit_key: ose-metallb
+            why: Pin earlier build to match operator bundle references
+            metadata:
+              is:
+                nvr: ose-metallb-container-v4.14.0-202604130126.p2.g772cd97.assembly.stream.el9
+          - distgit_key: cloud-event-proxy
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: cloud-event-proxy-container-v4.14.0-202604140121.p2.ge0c0de7.assembly.stream.el8
+          - distgit_key: ose-linuxptp-daemon
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ose-linuxptp-daemon-container-v4.14.0-202604140121.p2.g0289c4c.assembly.stream.el9
+          - distgit_key: ose-secrets-store-csi-driver
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ose-secrets-store-csi-driver-container-v4.14.0-202604140121.p2.g4b5bd4b.assembly.stream.el8
+          - distgit_key: ose-vertical-pod-autoscaler
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ose-vertical-pod-autoscaler-container-v4.14.0-202604140121.p2.gd030dba.assembly.stream.el8
+          - distgit_key: ose-clusterresourceoverride
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ose-clusterresourceoverride-container-v4.14.0-202604140121.p2.g61de9ca.assembly.stream.el8
+          - distgit_key: ib-sriov-cni
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: ib-sriov-cni-container-v4.14.0-202604140121.p2.g15cc64c.assembly.stream.el8
+          - distgit_key: sriov-cni
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: sriov-cni-container-v4.14.0-202604140121.p2.g06859a6.assembly.stream.el9
+          - distgit_key: sriov-dp-admission-controller
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: sriov-dp-admission-controller-container-v4.14.0-202604140121.p2.g424fc86.assembly.stream.el8
+          - distgit_key: sriov-network-config-daemon
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: sriov-network-config-daemon-container-v4.14.0-202604140121.p2.g4feb637.assembly.stream.el8
+          - distgit_key: sriov-network-device-plugin
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: sriov-network-device-plugin-container-v4.14.0-202604140121.p2.ga1cbb4e.assembly.stream.el8
+          - distgit_key: sriov-network-webhook
+            why: Pin later build because operator bundles reference newer version
+            metadata:
+              is:
+                nvr: sriov-network-webhook-container-v4.14.0-202604140121.p2.g4feb637.assembly.stream.el8
   4.14.63:
     assembly:
       type: standard


### PR DESCRIPTION
  Pin 23 container builds for 4.14.64 to fix verify_attached_operators                                                                                                                                           
                                                                                                                                                                                                                 
  Build 803 of prepare-release-konflux failed because operator bundles                                                                                                                                           
  referenced container versions that were not in the release payload.                                                                                                                                            
                                                                                                                                                                                                                 
  This pins the following containers to match operator bundle references:                                                                                                                                        
  - CSI components (csi-livenessprobe, csi-node-driver-registrar, etc.)                                                                                                                                          
  - SR-IOV network operator components (6 containers)                                                                                                                                                            
  - Storage operator components (local-storage-diskmaker, mustgather)                                                                                                                                            
  - Infrastructure components (kube-rbac-proxy, node-feature-discovery)                                                                                                                                          
  - Platform operators (PTP, MetalLB, VPA, secrets-store, etc.)                                                                                                                                                  
                                                                                                                                                                                                                 
  Most containers were rebuilt on 2026-04-14 but operator bundles still                                                                                                                                          
  referenced older builds from 2026-04-08 to 2026-04-13, causing the                                                                                                                                             
  verification check to fail.                                                                                                                                                                                    
                                                                                                                                                                                                                 
  Fixes: prepare-release-konflux build 803