### PR TITLE
logging-6.2: vector: pin 'rust-toolset-1.84.1-1.el9' package

### DIFF
--- a/images/vector.yml
+++ b/images/vector.yml
@@ -42,6 +42,7 @@ konflux:
       - binutils
       - binutils-gold
       - cargo
+      - cargo-1.84.1-1.el9
       - checkpolicy
       - clang
       - clang-libs
@@ -117,6 +118,7 @@ konflux:
       - lld-libs
       - llvm
       - llvm-libs
+      - llvm-libs-19.1.7-2.el9
       - llvm-toolset
       - m4
       - make
@@ -352,9 +354,11 @@ konflux:
       - python3-setuptools-wheel
       - redhat-rpm-config
       - rust
+      - rust-1.84.1-1.el9
       - rust-std-static
-      - rust-toolset
+      - rust-std-static-1.84.1-1.el9
       - rust-toolset-1.84.1
+      - rust-toolset-1.84.1-1.el9
       - scl-utils
       - systemd
       - systemtap-sdt-devel


### PR DESCRIPTION
Backport of #9639

/label tide/merge-method-squash