### PR TITLE
mtc-1.8: Freeze automation due to known build failures

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: false
+freeze_automation: true
 name: mtc-1.8
 csv_namespace: rhmtc
 product: rhmtc


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C07RAB68T5G/p1776348608450779

Signed-off-by: Franco Bladilo <fbladilo@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED