### PR TITLE
Logging 6.4: freeze_automation

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,3 +1,4 @@
+freeze_automation: true
 name: logging-6.4
 csv_namespace: openshift-logging
 product: openshift-logging


### PR DESCRIPTION
In a build loop due to failing vector on RPM not available.

[Slack thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1776348597750609)

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED