### PR TITLE
[openshift-4.12] CORENET-6055: ovn-kubernetes: Remove exemptions for now unpinned OVN rpms.

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -15,16 +15,6 @@ enabled_repos:
 - rhel-8-fast-datapath-rpms
 - rhel-8-server-ose-rpms-embargoed
 
-# Generally doozer scan-sources will detect all possible change factors automatically and trigger rebuilds.
-# However, certain images may consume RPMs in unexpected way that make it programmatically impossible to
-# detect they were used.
-scan_sources:
-  # ovn-kubernetes uses pins in the Dockerfile.
-  # We should configure exemptions for those known pins to avoid meaningless rebuild.
-  # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
-  exempt_rpms:
-  - ovn*
-
 for_payload: true
 from:
   builder:

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -19,16 +19,6 @@ enabled_repos:
 - rhel-8-fast-datapath-rpms
 - rhel-8-server-ose-rpms-embargoed
 
-# Generally doozer scan-sources will detect all possible change factors automatically and trigger rebuilds.
-# However, certain images may consume RPMs in unexpected way that make it programmatically impossible to
-# detect they were used.
-scan_sources:
-  # ovn-kubernetes uses pins in the Dockerfile.
-  # We should configure exemptions for those known pins to avoid meaningless rebuild.
-  # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
-  exempt_rpms:
-  - ovn*
-
 for_payload: false
 for_release: false
 from:

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -18,16 +18,6 @@ enabled_repos:
 - rhel-8-fast-datapath-rpms
 - rhel-8-server-ose-rpms-embargoed
 
-# Generally doozer scan-sources will detect all possible change factors automatically and trigger rebuilds.
-# However, certain images may consume RPMs in unexpected way that make it programmatically impossible to
-# detect they were used.
-scan_sources:
-  # ovn-kubernetes uses pins in the Dockerfile.
-  # We should configure exemptions for those known pins to avoid meaningless rebuild.
-  # https://github.com/openshift/ovn-kubernetes/blob/e236fea83d62de8b60b9456770a3e0b525830051/Dockerfile.base#L22
-  exempt_rpms:
-  - ovn*
-
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
ovn* RPMs are no longer pinned in ovn-kubernetes images in order to facilitate timely CVE and bug fix delivery. Remove from exemptions.

4.12 ovn-k PR that removed the OVN pin: https://github.com/openshift/ovn-kubernetes/pull/3075

(cherry-pick of https://github.com/openshift-eng/ocp-build-data/pull/10061)