### PR TITLE
Revert "MTA 8.1: lift automation freeze"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: false
+freeze_automation: true
 name: mta-8.1
 csv_namespace: mta
 product: mta


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#10071

:face_exhaling: _I forgot MTA had other reasons than just the rpm lockfile for being frozen._ 