### PR TITLE
Revert "Logging 6.0: lift automation freeze"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: false
+freeze_automation: true
 name: logging-6.0
 csv_namespace: openshift-logging
 product: openshift-logging


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#10067

Need to address vector rpm lockfile.

```
 Failed to build images: ['vector']
```

[logging-6-0-vector-l6mjv/logs](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/art-logging-tenant/applications/logging-6-0/pipelineruns/logging-6-0-vector-l6mjv/logs)
```
  error: No package matches 'llvm-toolset-17.0.6'
```