### PR TITLE
[openshift-4.18] Pin libreswan in ose-ovn-kubernetes

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -52,3 +52,8 @@ name: openshift/ose-ovn-kubernetes-rhel9
 payload_name: ovn-kubernetes
 owners:
 - aos-networking-staff@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - libreswan-4.6-3.el9_0.3


### PR DESCRIPTION
Needed because upstream pins `libreswan-4.6-3.el9_0.3` in their [Dockerfile](https://github.com/openshift/ovn-kubernetes/blob/release-4.18/Dockerfile#L44)