### PR TITLE
ART-17448: Update rhel-9-golang-1.26 branch references from 1.25 to 1.26

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-name: rhel-9-golang-1.25
+name: rhel-9-golang-1.26
 
 arches:
 - x86_64

--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -7,7 +7,7 @@ ENV SUMMARY="RHEL9 based Go builder image for OpenShift ART" \
     GOPATH=${GOPATH:-/go} \
     GOMAXPROCS=8 \
     GOAMD64=v2 \
-    VERSION="1.25" \
+    VERSION="1.26" \
     GO_VERSION="${__doozer_version:-$VERSION}" \
     GODEBUG="disablethp=1"
 

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: openshift-golang-builder.Dockerfile
     git:
       branch:
-        target: rhel-9-golang-1.25
+        target: rhel-9-golang-1.26
       url: git@github.com:openshift-eng/ocp-build-data.git
     modifications:
     - &add_fips_wrapper
@@ -33,8 +33,8 @@ owners:
 
 # for CPaaS
 additional_tags:
-- 'rhel_9_golang_1.25'
-- 'rhel_9_1.25'
+- 'rhel_9_golang_1.26'
+- 'rhel_9_1.26'
 maintainer:
   component: Release
 


### PR DESCRIPTION
## Summary

- Update `group.yml` name from `rhel-9-golang-1.25` to `rhel-9-golang-1.26`
- Update `images/openshift-golang-builder.yml` git branch target and additional_tags from 1.25 to 1.26
- Update `images/openshift-golang-builder.Dockerfile` VERSION from `1.25` to `1.26`

This branch was cloned from `rhel-9-golang-1.25` and still had stale 1.25 references. These changes are needed so the `build/golang-builder` Jenkins job can build Go 1.26 builder images using this branch.

Part of making Go 1.26 available in CI for openshift-5.0 (RHEL 9 only).

Made with [Cursor](https://cursor.com)