### PR TITLE
ART-17448: Add custom-rhel-98-golang-rpms repo for Go 1.26

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -41,13 +41,29 @@ repos:
     conf:
       extra_options:
         module_hotfixes: 1
-        includepkgs: module-build-macros golang* goversioninfo
+        includepkgs: module-build-macros goversioninfo
       baseurl:
         aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
         ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
         s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
         x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
     # These content sets are not used, so just putting something here
+    content_set:
+      default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
+      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
+      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
+      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
+      optional: true
+  custom-rhel-98-golang-rpms:
+    conf:
+      extra_options:
+        module_hotfixes: 1
+        includepkgs: golang*
+      baseurl:
+        aarch64: https://download.devel.redhat.com/brewroot/repos/rhel-9.8.0-z-build/latest/aarch64/
+        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhel-9.8.0-z-build/latest/ppc64le/
+        s390x: https://download.devel.redhat.com/brewroot/repos/rhel-9.8.0-z-build/latest/s390x/
+        x86_64: https://download.devel.redhat.com/brewroot/repos/rhel-9.8.0-z-build/latest/x86_64/
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
       aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -16,6 +16,7 @@ content:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-golang-rpms
+- custom-rhel-98-golang-rpms
 # for clang
 - rhel-9-appstream-rpms
 - rhel-9-codeready-builder-rpms


### PR DESCRIPTION
## Summary

- Add `custom-rhel-98-golang-rpms` repo pointing at `rhel-9.8.0-z-build` brewroot for `golang*` packages
- Remove `golang*` from existing `rhel-9-golang-rpms` `includepkgs` (keeps `module-build-macros` and `goversioninfo`)
- Add `custom-rhel-98-golang-rpms` to `enabled_repos` in `openshift-golang-builder.yml`

## Problem

The `golang-1.26.1-1.el9_8` RPM lives in the `rhel-9.8.0-z-build` Brew tag, not in `rhaos-4.22-rhel-9-build`. The Konflux builder image build fails with `No match for argument: golang-*1.26*` because the current repos do not contain Go 1.26.

## Precedent

Follows the same pattern as [1fe9fd209](https://github.com/openshift-eng/ocp-build-data/commit/1fe9fd209) which added `rhel-97-golang-rpms` for RHEL 9.7 golang on the `rhel-9-golang-1.25` branch, and `rhel-810-golang-rpms` for RHEL 8.10 golang.
