### PR TITLE
ART-17458: Add glibc-gconv-extra to lockfile rpms for ose-agent-installer-utils (5.0)

### DIFF
--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -48,6 +48,7 @@ konflux:
       - gcc-plugin-annobin
       - libstdc++-devel
       - glibc
+      - glibc-gconv-extra
       - glibc-headers
       - glibc-devel
       - kernel-headers


### PR DESCRIPTION
## Summary

Add `glibc-gconv-extra` to `konflux.cachi2.lockfile.rpms` for ose-agent-installer-utils.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/logs?nvr=ose-agent-installer-utils-container-v5.0.0-202604201525.p2.g210b295.assembly.stream.el9&record_id=4b32e0cc-c871-0f09-31f2-80feebea7937

## Analysis

Build fails at `[1/2] STEP 11/12` (non-final layer) with:
```
package gcc-11.5.0-14.el9 requires libc.so.6(GLIBC_2.35)(64bit)
→ glibc-2.34-266.el9_8 requires (glibc-gconv-extra if redhat-rpm-config)
→ glibc-gconv-extra not in lockfile
```

After the RHEL 9.6→9.8 content set rebase, `glibc` gained a conditional dependency on `glibc-gconv-extra` when `redhat-rpm-config` is installed. The base image has `redhat-rpm-config`, so `glibc-gconv-extra` is now required.

## Changes

- Added `glibc-gconv-extra` to `konflux.cachi2.lockfile.rpms`

Generated with [Claude Code](https://claude.com/claude-code)