### PR TITLE
ART-17454: Add gcc-toolset-15 and librepo to dpu-marvell-cp-agent lockfile.rpms

### DIFF
--- a/images/dpu-marvell-cp-agent.yml
+++ b/images/dpu-marvell-cp-agent.yml
@@ -66,6 +66,8 @@ konflux:
       - elfutils-libs
       - emacs-filesystem
       - expat
+      - file
+      - file-libs
       - filesystem
       - findutils
       - fonts-srpm-macros

--- a/images/dpu-marvell-cp-agent.yml
+++ b/images/dpu-marvell-cp-agent.yml
@@ -81,6 +81,11 @@ konflux:
       - gcc-toolset-14-gcc-c++
       - gcc-toolset-14-libstdc++-devel
       - gcc-toolset-14-runtime
+      - gcc-toolset-15-binutils
+      - gcc-toolset-15-gcc
+      - gcc-toolset-15-gcc-c++
+      - gcc-toolset-15-libstdc++-devel
+      - gcc-toolset-15-runtime
       - gdb-gdbserver
       - gdbm-libs
       - git
@@ -122,6 +127,7 @@ konflux:
       - libdb
       - libdnf
       - libdnf-plugin-subscription-manager
+      - librepo
       - libeconf
       - libfdisk
       - libgcc


### PR DESCRIPTION
## Summary
- Adds `gcc-toolset-15-binutils`, `gcc-toolset-15-gcc`, `gcc-toolset-15-gcc-c++`, `gcc-toolset-15-libstdc++-devel`, `gcc-toolset-15-runtime` to lockfile.rpms (clang-libs-21.1.8-2.el9 in RHEL 9.8 now requires gcc-toolset-15-gcc-c++)
- Adds `librepo` to lockfile.rpms (python3-librepo-1.19.0-1.el9 requires librepo)

## Root cause
The hermetic build fails at [1/2] STEP 11/16 (`dnf update -y && dnf install gawk gcc g++ libconfig-devel -y`). The `dnf update` pulls in updated packages from RHEL 9.8 content sets whose new dependencies are not pre-fetched by cachi2.

Jira: [ART-17454](https://redhat.atlassian.net/browse/ART-17454)