### PR TITLE
ART-15440: Add dnf-data to ironic lockfile.rpms

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -123,6 +123,7 @@ konflux:
       - libbytesize
       - libcbor
       - libcomps
+      - libdrm
       - libedit
       - libfido2
       - libgomp

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -66,6 +66,7 @@ konflux:
       - device-mapper-libs
       - dmidecode
       - dnf
+      - dnf-data
       - dnf-plugins-core
       - dosfstools
       - dracut

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -134,6 +134,7 @@ konflux:
       - libkcapi-hmaccalc
       - libmpc
       - libnsl2
+      - libpciaccess
       - libpkgconf
       - libseccomp
       - libss


### PR DESCRIPTION
python3-dnf requires dnf-data but it was not listed in lockfile.rpms for non-final layer resolution, causing hermetic build failure at [1/3] STEP 11/11:

```
nothing provides dnf-data = 4.14.0-34.el9_8 needed by python3-dnf-4.14.0-34.el9_8
```

Adds `dnf-data` to `konflux.cachi2.lockfile.rpms` so it is available in the hermetic repo for builder stages.

Jira: https://issues.redhat.com/browse/ART-15440