### PR TITLE
ART-15435: Add libasan and libubsan to ironic-agent lockfile.rpms

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -91,8 +91,10 @@ konflux:
       - libcbor
       - libedit
       - libfido2
+      - libasan
       - libgomp
       - libmpc
+      - libubsan
       - libnsl2
       - libnvme
       - libpkgconf


### PR DESCRIPTION
gcc requires libasan and libubsan which were not listed in lockfile.rpms, causing hermetic build failure on aarch64:

```
nothing provides libasan.so.6()(64bit) needed by gcc-11.5.0-14.el9.aarch64
nothing provides libubsan.so.1()(64bit) needed by gcc-11.5.0-14.el9.aarch64
```

Adds `libasan` and `libubsan` to `konflux.cachi2.lockfile.rpms` (matching ironic image which already has these listed).

Jira: https://issues.redhat.com/browse/ART-15435