### PR TITLE
ART-14953: Add nmstate-libs to ose-agent-installer-api-server lockfile.rpms

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -61,6 +61,7 @@ konflux:
       - libxcrypt-devel
       - make
       - nmstate-devel
+      - nmstate-libs
 okd:
   enabled_repos:
   - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -50,6 +50,7 @@ konflux:
       - gcc-plugin-annobin
       - libstdc++-devel
       - glibc
+      - glibc-gconv-extra
       - glibc-headers
       - glibc-devel
       - kernel-headers

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -63,6 +63,7 @@ konflux:
       - make
       - nmstate-devel
       - nmstate-libs
+      - postgresql-server
 okd:
   enabled_repos:
   - rhel-9-appstream-rpms


### PR DESCRIPTION
The Dockerfile installs `nmstate-libs` explicitly in the builder stage ([1/2] STEP 13/17), but it was not listed in `lockfile.rpms`, causing the hermetic build to fail:

```
RUN . /cachi2/cachi2.env && dnf install -y gcc nmstate-devel nmstate-libs git && dnf clean all
Error: Unable to find a match: nmstate-libs
```

The package exists in RHEL 9.8 as `nmstate-libs-2.2.58-1.el9` (subpackage of `nmstate`). `nmstate-devel` was already listed — `nmstate-libs` was missed.

Jira: https://issues.redhat.com/browse/ART-14953