### PR TITLE
ART-15451: Add systemd and glibc-gconv-extra to azure-file-csi-driver lockfile.rpms

### DIFF
--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -39,3 +39,11 @@ name: openshift/ose-azure-file-csi-driver-rhel9
 payload_name: azure-file-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - cifs-utils
+      - device-mapper-libs
+      - glibc-gconv-extra
+      - samba-client-libs


### PR DESCRIPTION
## Summary
- Adds `glibc-gconv-extra`, `systemd`, `systemd-libs` to `lockfile.rpms`
- These are transitive dependencies needed by `nfs-utils`, `device-mapper`, `samba-client-libs`, and `samba-common` in the final Dockerfile stage

## Root cause
The hermetic stream build fails at [2/2] STEP 10/18 (`yum install cifs-utils util-linux nfs-utils e2fsprogs xfsprogs ca-certificates`) with multiple `nothing provides` errors:
- `systemd` needed by nfs-utils and device-mapper
- `glibc-gconv-extra` needed by samba-client-libs
- `systemd-standalone-tmpfiles or systemd` needed by samba-common

These packages are in the base image but not captured in the SBOM-based lockfile, so they're missing from the hermetic repo.

Jira: https://issues.redhat.com/browse/ART-15451