### PR TITLE
ART-15967: Add gcc-toolset-15, file, file-libs, librepo to dpu-marvell-cp-agent lockfile.rpms

### DIFF
--- a/images/dpu-marvell-cp-agent.yml
+++ b/images/dpu-marvell-cp-agent.yml
@@ -73,14 +73,10 @@ konflux:
       - gcc
       - gcc-c++
       - gcc-plugin-annobin
-      - gcc-toolset-13-gcc
-      - gcc-toolset-13-gcc-c++
-      - gcc-toolset-13-libstdc++-devel
-      - gcc-toolset-14-binutils
-      - gcc-toolset-14-gcc
-      - gcc-toolset-14-gcc-c++
-      - gcc-toolset-14-libstdc++-devel
-      - gcc-toolset-14-runtime
+      - gcc-toolset-15-gcc
+      - gcc-toolset-15-gcc-c++
+      - gcc-toolset-15-libstdc++-devel
+      - gcc-toolset-15-runtime
       - gdb-gdbserver
       - gdbm-libs
       - git

--- a/repos/rhel-9-appstream-rpms.yml
+++ b/repos/rhel-9-appstream-rpms.yml
@@ -17,4 +17,6 @@
     ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_8
     s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_8
   name: rhel-9-appstream-rpms
+  reposync:
+    enabled: true
   type: external

--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -17,4 +17,6 @@
     ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_8
     s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_8
   name: rhel-9-baseos-rpms
+  reposync:
+    enabled: true
   type: external

--- a/repos/rhel-9-codeready-builder-rpms.yml
+++ b/repos/rhel-9-codeready-builder-rpms.yml
@@ -15,4 +15,6 @@
     ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_8
     s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_8
   name: rhel-9-codeready-builder-rpms
+  reposync:
+    enabled: true
   type: external

--- a/repos/rhel-9-highavailability.yml
+++ b/repos/rhel-9-highavailability.yml
@@ -12,4 +12,6 @@
     ppc64le: rhel-9-for-ppc64le-highavailability-e4s-rpms__9_DOT_8
     s390x: rhel-9-for-s390x-highavailability-e4s-rpms__9_DOT_8
   name: rhel-9-highavailability
+  reposync:
+    enabled: true
   type: external


### PR DESCRIPTION
The builder stage [1/2] STEP 11/16 runs `dnf update -y` which causes multiple version conflicts:

1. `nothing provides gcc-toolset-15-gcc-c++` needed by `clang-libs-21.1.8-2.el9` — clang/llvm packages want to update but the new versions depend on gcc-toolset-15
2. `cannot install both file-libs-5.39-17.el9 and file-libs-5.39-16.el9` — file-libs tries to update without file
3. Various llvm/clang/lld version conflicts tied to gcc-toolset-15

Adds `gcc-toolset-15-binutils`, `gcc-toolset-15-gcc`, `gcc-toolset-15-gcc-c++`, `gcc-toolset-15-libstdc++-devel`, `gcc-toolset-15-runtime`, `file`, `file-libs`, and `librepo` to resolve these conflicts.

Same fix as [ART-17454](https://redhat.atlassian.net/browse/ART-17454) (5.0 version of this image).

Jira: https://issues.redhat.com/browse/ART-15967