### PR TITLE
ART-14921: Add glibc-common and glibc-minimal-langpack to ose-agent-installer-api-server lockfile.rpms

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -72,6 +72,7 @@ konflux:
       - nmstate-devel
       - nmstate-libs
       - perl-Git
+      - postgresql-server
 okd:
   enabled_repos:
   - rhel-9-appstream-rpms

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -52,9 +52,11 @@ konflux:
       - git-core
       - git-core-doc
       - glibc
+      - glibc-common
       - glibc-gconv-extra
       - glibc-devel
       - glibc-headers
+      - glibc-minimal-langpack
       - kernel-headers
       - libasan
       - libatomic


### PR DESCRIPTION
The builder stage [1/2] STEP 13/17 fails on all arches (ppc64le, s390x, x86_64, aarch64):

```
package gcc-11.5.0-14.el9 requires libc.so.6(GLIBC_2.35)(64bit), but none of the providers can be installed
- nothing provides glibc-common = 2.34-266.el9_8 needed by glibc-2.34-266.el9_8
- nothing provides glibc-langpack = 2.34-266.el9_8 needed by glibc-2.34-266.el9_8
```

The lockfile already has `glibc-gconv-extra` (which provides GLIBC_2.35 content), but `glibc-common` and a langpack subpackage are required as dependencies of the `glibc` package itself. Adding `glibc-common` and `glibc-minimal-langpack`.

**Note:** Even with this fix, the final stage [2/2] still has a separate module issue with `postgresql-server` (postgresql:16 module) that blocks all arches.

Jira: https://issues.redhat.com/browse/ART-14921