### PR TITLE
ART-17448: Enable Go 1.26 extra golang builder for CI (openshift-5.0)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -24,7 +24,7 @@ vars:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
   GO_LATEST: "1.25"
-  #GO_EXTRA: "1.25"  # ovn-kubernetes or other components require Go 1.25
+  GO_EXTRA: "1.26"
 
 compliance:
   rpm_shim:

--- a/images/ci-openshift-build-root-extra.rhel9.yml
+++ b/images/ci-openshift-build-root-extra.rhel9.yml
@@ -1,5 +1,3 @@
-# No extra golang at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-golang-builder-extra.rhel9.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel9.yml
@@ -1,5 +1,3 @@
-# No extra golang at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/streams.yml
+++ b/streams.yml
@@ -35,6 +35,13 @@ rhel-8-golang:
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
 
+rhel-9-golang-extra:
+  aliases:
+    - rhel-9-golang-{GO_EXTRA}
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.1-202604202010.p2.g43aca9a.el9
+  mirror: false
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
 partner-rhel-8-golang-1.25:
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081607.p2.g2aa6a05.el8
   mirror: true


### PR DESCRIPTION
## Summary

- Set `GO_EXTRA: "1.26"` in `group.yml` (was commented out)
- Add `rhel-9-golang-extra` stream in `streams.yml` with the Konflux-built Go 1.26 builder image pullspec from [build #400](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/400/)
- Enable `ci-openshift-golang-builder-extra.rhel9.yml` (removed `mode: disabled`)
- Enable `ci-openshift-build-root-extra.rhel9.yml` (removed `mode: disabled`)

This makes Go 1.26 available in CI for openshift-5.0 (RHEL 9 only) via `registry.ci.openshift.org` using the extra golang path. `GO_LATEST` remains `"1.25"` -- no change to the default builder.

**Builder pullspec:** `quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.1-202604202010.p2.g43aca9a.el9`

**Scope:** RHEL 9 only, no RHEL 10, no openshift-4.23, no Brew production consumers.

Made with [Cursor](https://cursor.com)