### PR TITLE
ART-15440: Add libdrm to ironic lockfile for fwupd dependency

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -122,6 +122,7 @@ konflux:
       - libbytesize
       - libcbor
       - libcomps
+      - libdrm
       - libedit
       - libfido2
       - libgomp

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -57,6 +57,7 @@ konflux:
       - cpio
       - cpp
       - crypto-policies-scripts
+      - dbxtool
       - cryptsetup-libs
       - dbus
       - dbus-broker
@@ -97,6 +98,7 @@ konflux:
       - grub2-pc-modules
       - grub2-tools
       - grub2-tools-minimal
+      - hwdata
       - ima-evm-utils
       - inih
       - kbd
@@ -132,6 +134,7 @@ konflux:
       - libkcapi
       - libkcapi-hmaccalc
       - libmpc
+      - libpciaccess
       - libnsl2
       - libpkgconf
       - libseccomp


### PR DESCRIPTION
## Summary
- Add `libdrm` to `konflux.cachi2.lockfile.rpms` for ironic
- `fwupd` (already in lockfile) requires `libdrm.so.2` and `libdrm_amdgpu.so.1` which are provided by `libdrm`
- Without this, the hermetic build fails with `nothing provides libdrm.so.2()(64bit) needed by fwupd`

## References
- Jira: [ART-15440](https://issues.redhat.com/browse/ART-15440)
- Seed-lockfile [#198](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/198/) stream build failed for ironic with this error