### PR TITLE
ART-17454: Replace stale gcc-toolset, add file-libs and gcc-toolset-15-binutils for dpu-marvell-cp-agent

### DIFF
--- a/images/dpu-marvell-cp-agent.yml
+++ b/images/dpu-marvell-cp-agent.yml
@@ -66,6 +66,7 @@ konflux:
       - elfutils-libs
       - emacs-filesystem
       - expat
+      - file-libs
       - filesystem
       - findutils
       - fonts-srpm-macros
@@ -73,14 +74,11 @@ konflux:
       - gcc
       - gcc-c++
       - gcc-plugin-annobin
-      - gcc-toolset-13-gcc
-      - gcc-toolset-13-gcc-c++
-      - gcc-toolset-13-libstdc++-devel
-      - gcc-toolset-14-binutils
-      - gcc-toolset-14-gcc
-      - gcc-toolset-14-gcc-c++
-      - gcc-toolset-14-libstdc++-devel
-      - gcc-toolset-14-runtime
+      - gcc-toolset-15-binutils
+      - gcc-toolset-15-gcc
+      - gcc-toolset-15-gcc-c++
+      - gcc-toolset-15-libstdc++-devel
+      - gcc-toolset-15-runtime
       - gdb-gdbserver
       - gdbm-libs
       - git


### PR DESCRIPTION
## Summary
- Replace stale `gcc-toolset-13-*` and `gcc-toolset-14-*` entries with `gcc-toolset-15-*` in `konflux.cachi2.lockfile.rpms`
- Add `file-libs` to resolve version conflict (base image has 5.39-16, repos have 5.39-17)
- Add `gcc-toolset-15-binutils` which is required by `gcc-toolset-15-gcc` (>= 2.43)
- Same fix as PR #10097 for 4.22, applied to 5.0

## Error details
- `clang-libs-21.x` now depends on `gcc-toolset-15-gcc-c++` instead of older toolsets
- `nothing provides gcc-toolset-15-binutils >= 2.43 needed by gcc-toolset-15-gcc`
- `cannot install both file-libs-5.39-17 and file-libs-5.39-16 from @System`

## References
- Jira: [ART-17454](https://issues.redhat.com/browse/ART-17454)
- Seed-lockfile [#198](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/198/) stream build failed for dpu-marvell-cp-agent with these errors