### PR TITLE
ART-15693: Remove podman-catatonit lockfile entries for ose-frr (4.14)

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -28,5 +28,5 @@ konflux:
   cachi2:
     lockfile:
       rpms:
-      - catatonit
+      - podman
       - podman-catatonit

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -24,3 +24,8 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/frr-rhel9
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - catatonit

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -24,9 +24,4 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/frr-rhel9
-konflux:
-  cachi2:
-    lockfile:
-      rpms:
-      - podman-catatonit
-      - podman-2:4.2.0-11.el9_1
+konflux: {}

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -24,9 +24,3 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/frr-rhel9
-konflux:
-  cachi2:
-    lockfile:
-      rpms:
-      - podman
-      - podman-catatonit

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -28,4 +28,4 @@ konflux:
   cachi2:
     lockfile:
       rpms:
-      - catatonit
+      - podman-catatonit

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -28,4 +28,5 @@ konflux:
   cachi2:
     lockfile:
       rpms:
+      - catatonit
       - podman-catatonit

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -24,4 +24,3 @@ owners:
 delivery:
   delivery_repo_names:
   - openshift4/frr-rhel9
-konflux: {}

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -1,6 +1,10 @@
 content:
   source:
     dockerfile: Dockerfile.openshift
+    modifications:
+    - action: replace
+      match: "\tcatatonit"
+      replacement: "\tpodman-catatonit"
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -21,6 +25,11 @@ name: openshift/frr-rhel9
 name_in_bundle: metallb-frr-rhel9
 owners:
 - metallb-dev@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - podman-catatonit
 delivery:
   delivery_repo_names:
   - openshift4/frr-rhel9


### PR DESCRIPTION
## Summary

Remove `podman-catatonit` and `podman-2:4.2.0-11.el9_1` from `konflux.cachi2.lockfile.rpms` for `ose-frr`.

**Failing build:** [build history](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ose-frr$&group=openshift-4.14&assembly=stream&engine=konflux&dateRange=2026-01-21+to+2026-04-21&outcome=success&outcome=failure)
**Seed-lockfile test:** [#195](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%25252Fseed-lockfile/195/) — test (open-network) passed, stream (hermetic) failed

## Analysis

The `lockfile.rpms` list forces `podman-catatonit` into the lockfile. This package requires `podman = 2:4.2.0-11.el9_1`, but that exact version is not in the hermetic repo, causing:
```
nothing provides podman = 2:4.2.0-11.el9_1 needed by podman-catatonit-2:4.2.0-11.el9_1
```

The standalone `catatonit` package (epoch 3, from AppStream) satisfies the Dockerfile's `catatonit` requirement without pulling in `podman`. The open-network test build confirms this works.

## Changes

- Removed `podman-catatonit` and `podman-2:4.2.0-11.el9_1` from `konflux.cachi2.lockfile.rpms`

Generated with [Claude Code](https://claude.com/claude-code)