### PR TITLE
Add missing lockfile rpms for ironic (ART-18044)

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -98,6 +98,7 @@ konflux:
       - grub2-pc-modules
       - grub2-tools
       - grub2-tools-minimal
+      - hwdata
       - ima-evm-utils
       - inih
       - kbd

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -56,6 +56,7 @@ konflux:
       - binutils-gold
       - cpio
       - cpp
+      - dbxtool
       - crypto-policies-scripts
       - cryptsetup-libs
       - dbus
@@ -108,6 +109,7 @@ konflux:
       - kmod-libs
       - kpartx
       - less
+      - libdrm
       - libasan
       - libatasmart
       - libatomic

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -134,6 +134,7 @@ konflux:
       - libkcapi-hmaccalc
       - libmpc
       - libnsl2
+      - libpciaccess
       - libpkgconf
       - libseccomp
       - libss


### PR DESCRIPTION
Add `dbxtool`, `hwdata`, `libdrm`, and `libpciaccess` to ironic lockfile rpms.

These packages are transitive dependencies needed during the hermetic build but were
not being captured in the lockfile. The build fails with dependency resolution errors
like `nothing provides libdrm.so.2()(64bit)` etc.

Seed-lockfile test build [#185](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/185/) confirmed the fix — stream build [succeeded](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=ironic-container-v4.22.0-202604202146.p2.g208ccd1.assembly.stream.el9&record_id=da9b8551-415f-6220-078a-e594e01a9a78&group=openshift-4.22&outcome=success&type=image).

[ART-18044](https://redhat.atlassian.net/browse/ART-18044) / [ART-14950](https://redhat.atlassian.net/browse/ART-14950)