### PR TITLE
Point PTP images to downstream monorepo for 4.22

### DIFF
--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -7,8 +7,9 @@ content:
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/cloud-event-proxy.git
-      web: https://github.com/redhat-cne/cloud-event-proxy
+      url: git@github.com:redhat-cne/downstream-ptp-operator-monorepo.git
+      web: https://github.com/redhat-cne/downstream-ptp-operator-monorepo
+    path: pkg/cloud-event-proxy
     ci_alignment:
       streams_prs:
         ci_build_root:

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -8,8 +8,9 @@ content:
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/linuxptp-daemon.git
-      web: https://github.com/openshift/linuxptp-daemon
+      url: git@github.com:redhat-cne/downstream-ptp-operator-monorepo.git
+      web: https://github.com/redhat-cne/downstream-ptp-operator-monorepo
+    path: pkg/linuxptp-daemon
     ci_alignment:
       streams_prs:
         ci_build_root:

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -8,8 +8,8 @@ content:
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/ptp-operator.git
-      web: https://github.com/openshift/ptp-operator
+      url: git@github.com:redhat-cne/downstream-ptp-operator-monorepo.git
+      web: https://github.com/redhat-cne/downstream-ptp-operator-monorepo
     path: must-gather
     ci_alignment:
       streams_prs:

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -8,8 +8,8 @@ content:
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/ptp-operator.git
-      web: https://github.com/openshift/ptp-operator
+      url: git@github.com:redhat-cne/downstream-ptp-operator-monorepo.git
+      web: https://github.com/redhat-cne/downstream-ptp-operator-monorepo
     ci_alignment:
       streams_prs:
         enabled: true


### PR DESCRIPTION
## Summary

Port of #9947 (openshift-4.21) to openshift-4.22.

- Update git source URLs for `cloud-event-proxy`, `linuxptp-daemon`, `ptp-operator`, and `ptp-operator-must-gather` to use the consolidated monorepo at `redhat-cne/downstream-ptp-operator-monorepo`
- Add `path:` fields for subproject locations (`pkg/cloud-event-proxy`, `pkg/linuxptp-daemon`)

## Ref

- Source PR: #9947
- JIRA: [ART-14776](https://redhat.atlassian.net/browse/ART-14776)
- Parent: [CNF-22004](https://redhat.atlassian.net/browse/CNF-22004)

🤖 Generated with [Claude Code](https://claude.com/claude-code)