### PR TITLE
ART-15967: Add file, file-libs, librepo to dpu-marvell-cp-agent lockfile.rpms

### DIFF
--- a/images/dpu-marvell-cp-agent.yml
+++ b/images/dpu-marvell-cp-agent.yml
@@ -66,6 +66,8 @@ konflux:
       - elfutils-libs
       - emacs-filesystem
       - expat
+      - file
+      - file-libs
       - filesystem
       - findutils
       - fonts-srpm-macros
@@ -130,6 +132,7 @@ konflux:
       - libnghttp2
       - libomp
       - libomp-devel
+      - librepo
       - librhsm
       - libselinux
       - libselinux-devel


### PR DESCRIPTION
The hermetic build fails with `cannot install both file-libs-5.39-17.el9 and file-libs-5.39-16.el9 from @System` because the base image has the older `file-libs` but the lockfile resolves dependencies to the newer version during `dnf update -y`.

Adding `file`, `file-libs`, and `librepo` to `lockfile.rpms` ensures the seeder captures the correct versions. This matches the `openshift-5.0` config for `dpu-marvell-cp-agent` which builds successfully.

PR #10097 replaced gcc-toolset versions but did not include these packages despite the description mentioning them.

Jira: https://issues.redhat.com/browse/ART-15967