### PR TITLE
ART-16004 [openshift-5.0]: point golang builder streams at registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604150744.p2.gf28329a.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081607.p2.g2aa6a05.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604081607.p2.g2aa6a05.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
## Summary

Update the `rhel-9-golang` and `rhel-8-golang` streams so their `image` references use `registry.redhat.io/openshift/art-images-base` with the `openshift-golang-builder-container-*` tags, instead of the Konflux tenant images on `quay.io/redhat-user-workloads/ocp-art-tenant/art-images`.

## Problem

**Before:** Golang builder streams referenced `quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-...` for RHEL 9 and RHEL 8.

**After:** The same builder versions are referenced from `registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-...` for both streams, keeping `mirror: false` and existing comments/behavior intact.

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)

Made with [Cursor](https://cursor.com)