### PR TITLE
ART-15451: Add systemd-pam, systemd-rpm-macros to azure-file-csi-driver lockfile.rpms

### DIFF
--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -49,4 +49,6 @@ konflux:
       - nfs-utils
       - samba-client-libs
       - systemd
+      - systemd-pam
+      - systemd-rpm-macros
       - xfsprogs

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -46,4 +46,7 @@ konflux:
       - cifs-utils
       - device-mapper-libs
       - glibc-gconv-extra
+      - nfs-utils
       - samba-client-libs
+      - systemd
+      - xfsprogs


### PR DESCRIPTION
Add `systemd-pam` and `systemd-rpm-macros` to `konflux.cachi2.lockfile.rpms` for
`azure-file-csi-driver` on openshift-5.0.

The hermetic stream build fails because `nfs-utils` requires `systemd`, which in turn
requires `systemd-pam` and `systemd-rpm-macros` — packages not captured by the SBOM
(non-final layer dependencies).

Seed-lockfile build [#232](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%25252Fseed-lockfile/232/) confirmed the fix: Phase 1 and Phase 2 both succeeded, image listed under "Solved".

Jira: [ART-15451](https://redhat.atlassian.net/browse/ART-15451)