### PR TITLE
Fix CRB repo: revert from e4s to eus for RHEL 9.6

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -277,20 +277,20 @@ repos:
   rhel-9-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/codeready-builder/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/codeready-builder/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/codeready-builder/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/codeready-builder/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/codeready-builder/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/codeready-builder/os/
       ci_alignment:
         profiles:
         - el9
         localdev:
           enabled: true
     content_set:
-      default: codeready-builder-for-rhel-9-x86_64-e4s-rpms__9_DOT_6
-      aarch64: codeready-builder-for-rhel-9-aarch64-e4s-rpms__9_DOT_6
-      ppc64le: codeready-builder-for-rhel-9-ppc64le-e4s-rpms__9_DOT_6
-      s390x: codeready-builder-for-rhel-9-s390x-e4s-rpms__9_DOT_6
+      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_6
+      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_6
+      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_6
+      s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_6
     reposync:
       enabled: false
 


### PR DESCRIPTION
## Summary
- Reverts `rhel-9-codeready-builder-rpms` URLs and content sets from `e4s` back to `eus` for RHEL 9.6
- The E4S repository set does not include CodeReady Builder (only BaseOS, AppStream, HA, SAP NetWeaver, SAP Solutions are published under e4s)
- The e4s CRB URL (`/content/e4s/rhel9/9.6/x86_64/codeready-builder/os/`) returns **404**, breaking `beta:images:konflux:rebase` for all ~250 images ([build #32012](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/32012/consoleFull))

Ref: https://access.redhat.com/solutions/6970108

## Test plan
- [ ] Verify EUS URL returns valid repomd.xml: `/content/eus/rhel9/9.6/x86_64/codeready-builder/os/repodata/repomd.xml`
- [ ] Trigger a new `ocp4-konflux` build and confirm rebase completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)