### PR TITLE
ART-17448: Set mirror: true for rhel-9-golang-extra stream

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -39,7 +39,7 @@ rhel-9-golang-extra:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.1-202604202010.p2.g43aca9a.el9
-  mirror: false
+  mirror: true
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.25:


### PR DESCRIPTION
## Summary
- Sets `mirror: true` on the `rhel-9-golang-extra` stream in `streams.yml` so that the Go 1.26 extra builder image is synced to `registry.ci.openshift.org` by the `sync-ci-images` job.

## Context
The Go 1.26 extra builder was added in #10099 with `mirror: false`, which prevents `doozer images:streams mirror` from pushing it to CI. Changing to `mirror: true` allows the `sync-ci-images` scheduled job to pick it up.

[ART-17448](https://redhat.atlassian.net/browse/ART-17448)

Made with [Cursor](https://cursor.com)