### PR TITLE
ART-16004 [openshift-4.22]: point golang builder streams at registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081723.p2.gf28329a.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081607.p2.g2aa6a05.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604081607.p2.g2aa6a05.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
## Summary
Updates the rhel-8-golang and rhel-9-golang entry in `streams.yml` to use the openshift/art-images-base image references on registry.redhat.io instead of the redhat-user-workloads quay image paths, keeping builder stream definitions aligned with published catalog image names.

## Problem
**Before:** Stream images pointed at `quay.io/redhat-user-workloads/ocp-art-tenant/art-images:...` for RHEL8 and RHEL9 golang builders.

**After:** Stream images use `registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-...` for the same builder tags.

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)