### PR TITLE
ART-16004 [openshift-4.21]: point rhel-8/9 golang streams at registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.13-202603271447.p2.g04d2cd5.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.p2.g04d2cd5.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.13-202603271447.p2.gcb9763d.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.p2.gcb9763d.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
## Summary
Update `rhel-9-golang` and `rhel-8-golang` stream image references in `streams.yml` to use `registry.redhat.io/openshift/art-images-base` with the expected golang builder image tags, instead of the Konflux `quay.io/redhat-user-workloads/ocp-art-tenant/art-images` paths.

## Problem
**Before:** The `rhel-9-golang` and `rhel-8-golang` `image:` values pointed at Konflux `quay.io/redhat-user-workloads` art-images (per-stream builder digests).

**After:** Both streams use `registry.redhat.io` / `openshift/art-images-base` image references (`openshift-golang-builder-container-...` tags) aligned with the published RHEL 9 and RHEL 8 golang builder content for this release line.

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)

Made with [Cursor](https://cursor.com)