### PR TITLE
ART-14950: added missing rpm to lockfile

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -111,6 +111,7 @@ konflux:
       - kpartx
       - less
       - libdrm
+      - libdrm-amdgpu
       - libasan
       - libatasmart
       - libatomic


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

seed-lockfile job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%25252Fseed-lockfile/248/console 