### PR TITLE
Add versioned dependency for llvm-toolset

### DIFF
--- a/images/vector.yml
+++ b/images/vector.yml
@@ -119,7 +119,7 @@ konflux:
       - llvm
       - llvm-libs
       - llvm-libs-19.1.7-2.el9
-      - llvm-toolset
+      - llvm-toolset-19.1.7-2.el9
       - m4
       - make
       - man-db


### PR DESCRIPTION
- [ ] Depends on viaq/vector#262
- [ ] I have just added the version number to the `llvm-toolset` dependency. This package should install the correct versions of both `lld` and `clang`.

/cc @rayfordj 
/label tide/merge-method-squash
