### PR TITLE
Revert "Logging 6.3: lift automation freeze"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,3 @@
-freeze_automation: false
 name: logging-6.3
 csv_namespace: openshift-logging
 product: openshift-logging

--- a/group.yml
+++ b/group.yml
@@ -1,3 +1,4 @@
+freeze_automation: true
 name: logging-6.3
 csv_namespace: openshift-logging
 product: openshift-logging


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#10068

https://github.com/openshift-eng/ocp-build-data/pull/10136#issuecomment-4299355495


@xperimental , it looks like this one hasn't yet received your touches like the other releases.  No rush or concern from ART; whenever you want to get around to it.  Stopping the automation for now.