### PR TITLE
Logging 6.2: vector RPM lockfile pin update

### DIFF
--- a/images/vector.yml
+++ b/images/vector.yml
@@ -41,12 +41,11 @@ konflux:
       - automake
       - binutils
       - binutils-gold
-      - cargo
       - cargo-1.84.1-1.el9
       - checkpolicy
-      - clang
-      - clang-libs
-      - clang-resource-filesystem
+      - clang-19.1.7-2.el9
+      - clang-libs-19.1.7-2.el9
+      - clang-resource-filesystem-19.1.7-2.el9
       - cmake
       - cmake-data
       - cmake-filesystem
@@ -114,10 +113,9 @@ konflux:
       - libutempter
       - libuv
       - libxcrypt-devel
-      - lld
-      - lld-libs
-      - llvm
-      - llvm-libs
+      - lld-19.1.7-2.el9
+      - lld-libs-19.1.7-2.el9
+      - llvm-19.1.7-2.el9
       - llvm-libs-19.1.7-2.el9
       - llvm-toolset-19.1.7-2.el9
       - m4
@@ -353,11 +351,8 @@ konflux:
       - python3-setuptools
       - python3-setuptools-wheel
       - redhat-rpm-config
-      - rust
       - rust-1.84.1-1.el9
-      - rust-std-static
       - rust-std-static-1.84.1-1.el9
-      - rust-toolset-1.84.1
       - rust-toolset-1.84.1-1.el9
       - scl-utils
       - systemd


### PR DESCRIPTION
Continuation of https://github.com/openshift-eng/ocp-build-data/pull/10136

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED