### PR TITLE
ART-18099: Add nginx to lockfile rpms for networking-console-plugin (4.20)

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -43,6 +43,8 @@ konflux:
     lockfile:
       modules:
       - nginx:1.24
+      rpms:
+      - nginx
     artifact_lockfile:
       resources:
       - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz


### PR DESCRIPTION
## Summary

The hermetic stream build fails with `No package matches 'nginx'` because nginx is installed via the `nginx:1.24` module stream in the final Dockerfile layer, but the module RPMs aren't captured in the SBOM-based lockfile.

The `modules: [nginx:1.24]` config enables the module stream in DNF, but the actual `nginx` RPM package still needs to be listed in `lockfile.rpms` for cachi2 to include it in the hermetic repo.

**Failing build:** [seed-lockfile #257 stream build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%25252Fseed-lockfile/257/)

## Changes

- Added `nginx` to `konflux.cachi2.lockfile.rpms`

Generated with [Claude Code](https://claude.com/claude-code)