### PR TITLE
ART-18086: Add nginx to lockfile rpms for nmstate-console-plugin (4.20)

### DIFF
--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -51,6 +51,8 @@ konflux:
     lockfile:
       modules:
       - nginx:1.24
+      rpms:
+      - nginx
     artifact_lockfile:
       resources:
       - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz


### PR DESCRIPTION
## Summary

Same issue as [ART-18099](https://redhat.atlassian.net/browse/ART-18099) (networking-console-plugin). The hermetic stream build fails with `No package matches 'nginx'` because nginx is installed via the `nginx:1.24` module stream in the final Dockerfile layer, but the module RPMs aren't captured in the SBOM-based lockfile.

**Failing build:** [seed-lockfile #260 stream build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%25252Fseed-lockfile/260/)

## Changes

- Added `nginx` to `konflux.cachi2.lockfile.rpms`

Generated with [Claude Code](https://claude.com/claude-code)