### PR TITLE
ART-18085: Add libgomp to lockfile rpms for ose-agent-installer-utils (4.20)

### DIFF
--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -45,6 +45,7 @@ konflux:
       - elfutils-debuginfod-client
       - gcc
       - gcc-c++
+      - gcc-plugin-annobin
       - glibc
       - glibc-devel
       - glibc-headers

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -45,14 +45,15 @@ konflux:
       - elfutils-debuginfod-client
       - gcc
       - gcc-c++
-      - libstdc++-devel
       - glibc
-      - glibc-headers
       - glibc-devel
+      - glibc-headers
       - kernel-headers
       - libasan
       - libatomic
+      - libgomp
       - libmpc
+      - libstdc++-devel
       - libubsan
       - libxcrypt-devel
       - make


### PR DESCRIPTION
## Summary

Add `libgomp` to `konflux.cachi2.lockfile.rpms` for ose-agent-installer-utils.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ose-agent-installer-utils$&group=openshift-4.20&assembly=stream&engine=konflux

## Analysis

The hermetic build fails with `nothing provides libgomp = 11.5.0-5.el9_5 needed by gcc-11.5.0-5.el9_5` in a non-final builder layer. The `gcc` package is already in `lockfile.rpms` but its dependency `libgomp` is missing. Since this is a non-final layer, the SBOM doesn't capture it — it must be explicitly listed. Also sorted the RPM list alphabetically.

## Changes

- Added `libgomp` to `konflux.cachi2.lockfile.rpms`
- Sorted RPM entries alphabetically

Generated with [Claude Code](https://claude.com/claude-code)