### PR TITLE
Fix OKD agent-installer-node-agent build on CentOS Stream 10

### DIFF
--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -34,3 +34,10 @@ name: openshift/ose-agent-installer-node-agent-rhel9
 payload_name: agent-installer-node-agent
 owners:
 - ocp-agent-team@redhat.com
+okd:
+  content:
+    source:
+      modifications:
+      - action: replace
+        match: dhclient
+        replacement: dhcpcd


### PR DESCRIPTION
Replace dhclient with dhcpcd in OKD-specific Dockerfile modifications.

The dhclient package has been removed from CentOS Stream 10 / RHEL 10. The modern replacement is dhcpcd, which provides equivalent DHCP client functionality.

This modification is scoped to OKD builds only via the okd: field, as OKD uses CentOS Stream 10 as its base, while RHEL builds still have access to dhclient.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fokd/905/