### PR TITLE
Add modification to remove subscription-manager install for cli (4.20)

### DIFF
--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -10,6 +10,10 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+    modifications:
+    - action: replace
+      match: "RUN dnf install -y subscription-manager && dnf clean all && rm -rf /var/cache/dnf/*"
+      replacement: ""
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-cli-container


### PR DESCRIPTION
Backport from 4.21: in hermetic Konflux builds, the `dnf install subscription-manager`
step in the final stage fails because there is no network access. Remove the line via
doozer modification, matching the 4.21 config.

Fixes: [ART-18077](https://redhat.atlassian.net/browse/ART-18077)