### PR TITLE
ART-18091: Fix ose-smb-csi-driver build for 4.20

### DIFF
--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -24,6 +24,7 @@ delivery:
   - openshift4/ose-csi-external-resizer-rhel9
 dependents:
 - ose-gcp-filestore-csi-driver-operator
+- ose-smb-csi-driver-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -34,5 +34,10 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-smb-csi-driver-rhel9
 name_in_bundle: smb-csi-driver-container-rhel9
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - keyutils
 owners:
 - aos-storage-staff@redhat.com


### PR DESCRIPTION
## Summary
- Add `ose-smb-csi-driver-operator` to `ose-csi-external-resizer` dependents (backport from 4.21)
  - Fixes Doozer rebase validation error: `Related image contains ose-csi-external-resizer but this does not have ose-smb-csi-driver-operator in dependents`
- Add `keyutils` to `ose-smb-csi-driver` lockfile rpms (backport from 4.21)

## Test plan
- [ ] Trigger seed-lockfile build with this PR's data branch to verify the rebase succeeds and the image builds

Jira: [ART-18091](https://redhat.atlassian.net/browse/ART-18091)