### PR TITLE
ART-18091: Fix ose-smb-csi-driver build - add csi-external-resizer dependent and lockfile rpms (4.20)

### DIFF
--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -24,6 +24,7 @@ delivery:
   - openshift4/ose-csi-external-resizer-rhel9
 dependents:
 - ose-gcp-filestore-csi-driver-operator
+- ose-smb-csi-driver-operator
 for_payload: true
 from:
   builder:

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -34,5 +34,10 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-smb-csi-driver-rhel9
 name_in_bundle: smb-csi-driver-container-rhel9
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - keyutils
 owners:
 - aos-storage-staff@redhat.com


### PR DESCRIPTION
## Summary

Fix ose-smb-csi-driver build failure by:
1. Adding `ose-smb-csi-driver-operator` to `ose-csi-external-resizer.yml` dependents (matching openshift-4.21)
2. Adding `konflux.cachi2.lockfile.rpms: [keyutils]` to `ose-smb-csi-driver.yml` (matching openshift-4.21)

**Jira:** [ART-18091](https://redhat.atlassian.net/browse/ART-18091) (ose-smb-csi-driver), also fixes [ART-18066](https://redhat.atlassian.net/browse/ART-18066) (ose-smb-csi-driver-operator)

## Analysis

The seed-lockfile pipeline fails during rebase with:
```
ValueError: Related image contains ose-csi-external-resizer but this does not have ose-smb-csi-driver-operator in dependents
```

This is because `ose-smb-csi-driver-operator` references `ose-csi-external-resizer` as a related image, but the dependency graph in ocp-build-data doesn't include `ose-smb-csi-driver-operator` in `ose-csi-external-resizer`'s dependents list. The openshift-4.21 branch already has this fix.

The `keyutils` lockfile RPM addition matches 4.21 and ensures non-final-layer RPMs are available in hermetic builds.

## Changes

- `images/ose-csi-external-resizer.yml`: Added `ose-smb-csi-driver-operator` to `dependents`
- `images/ose-smb-csi-driver.yml`: Added `konflux.cachi2.lockfile.rpms: [keyutils]`

Generated with [Claude Code](https://claude.com/claude-code)