### PR TITLE
ART-18104: Add lockfile rpms for csi-driver-nfs (4.20)

### DIFF
--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -34,5 +34,10 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-csi-driver-nfs-rhel9
 payload_name: csi-driver-nfs
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - keyutils
 owners:
 - osasinfra-dev@redhat.com


### PR DESCRIPTION
## Summary

Add `konflux.cachi2.lockfile.rpms: [keyutils]` to `csi-driver-nfs.yml`, matching the openshift-4.21 configuration.

**Jira:** [ART-18104](https://redhat.atlassian.net/browse/ART-18104)

## Analysis

The hermetic build fails with `No package matches 'nfs-utils'`. The lockfile needs regeneration via seed-lockfile, and the `keyutils` package (installed in a non-final build layer) must be explicitly listed in `konflux.cachi2.lockfile.rpms` to be available in hermetic builds.

This change matches what was already applied in the openshift-4.21 branch.

## Changes

- `images/csi-driver-nfs.yml`: Added `konflux.cachi2.lockfile.rpms: [keyutils]`

Generated with [Claude Code](https://claude.com/claude-code)