### PR TITLE
ART-18133: Add lockfile rpms for ovn-kubernetes-base (4.20)

### DIFF
--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -30,5 +30,10 @@ labels:
   io.k8s.display-name: ovn kubernetes base
   io.openshift.tags: openshift
 name: openshift/ose-ovn-kubernetes-base
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - libatomic
 owners:
 - aos-networking-staff@redhat.com


### PR DESCRIPTION
## Summary
- Adds `lockfile.rpms: [libatomic]` to `ovn-kubernetes-base.yml`, matching the 4.21 configuration
- `libatomic` is installed in a non-final layer of the ovn-kubernetes-base image and needs explicit inclusion in the hermetic lockfile after the RHEL 9.6 content migration

## Context
The ose-ovn-kubernetes build ([ART-18133](https://redhat.atlassian.net/browse/ART-18133)) is failing with `No package matches 'iputils'` due to stale lockfile repo URLs. Seed-lockfile build [#272](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/272/) Phase 1 succeeded but Phase 2 failed on transient repo access. This PR aligns the ovn-kubernetes-base config with 4.21 to prevent future lockfile issues.

## Test plan
- [ ] Trigger seed-lockfile for ose-ovn-kubernetes to regenerate lockfile with current repos
- [ ] Verify ovn-kubernetes-base builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)