### PR TITLE
Revert PR : 10015

### DIFF
--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -43,7 +43,7 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
-  network_mode: hermetic
+  network_mode: open
   content:
     source:
       modifications:


### PR DESCRIPTION
Since, the recent golang builder failed hence reverting the change : https://github.com/openshift-eng/ocp-build-data/pull/10015/changes