### PR TITLE
Disable local-storage-operator and ptp-operator: bundle EC verificati…

### DIFF
--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -1,3 +1,5 @@
+# Disabled: Konflux bundle EC verification failing (2026-04-24)
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -2,6 +2,8 @@ arches:
 - x86_64
 - aarch64
 - ppc64le
+# Disabled: Konflux bundle EC verification failing (2026-04-24)
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.ocp


### PR DESCRIPTION
…on failing

Konflux bundle image builds succeed but Enterprise Contract verification PipelineRuns fail for both operators, causing prepare-release-konflux to finish UNSTABLE. Disabling until EC issues are resolved.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED