### PR TITLE
ART-18151: images/cluster-update-console-plugin: Add new OCP-payload image

### DIFF
--- a/images/cluster-update-console-plugin.yml
+++ b/images/cluster-update-console-plugin.yml
@@ -1,0 +1,45 @@
+cachito:
+  enabled: true
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/cluster-update-console-plugin.git
+      web: https://github.com/openshift/cluster-update-console-plugin
+    ci_alignment:
+      streams_prs:
+        ci_build_root:
+          member: ci-openshift-build-root-latest.rhel9
+    pkg_managers:
+    - npm
+    - gomod
+    okd_alignment:
+      dockerfile: Dockerfile
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: cluster-update-console-plugin-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: ose-cluster-update-console-plugin
+  delivery_repo_names:
+  - openshift5/ose-cluster-update-console-plugin-rhel9
+for_payload: true
+from:
+  builder:
+  - member: openshift-base-nodejs.rhel9
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-cluster-update-console-plugin-rhel9
+payload_name: cluster-update-console-plugin
+owners:
+- aos-team-ota@redhat.com
+konflux:
+  cachito:
+    mode: emulation


### PR DESCRIPTION
Expected to be tech-preview in 5.0 [OCPSTRAT-2241][1].  Pattern-matching off [monitoring-plugin][2] sibling for content.

[1]: https://redhat.atlassian.net/browse/OCPSTRAT-2241
[2]: https://github.com/openshift-eng/ocp-build-data/blob/5e8371363827862f985972eb4a5aa70c7f15c63c/images/monitoring-plugin.yml