### PR TITLE
ART-18075: Add nmstate-libs to lockfile rpms for ose-agent-installer-api-server (4.20)

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -61,6 +61,7 @@ konflux:
       - libxcrypt-devel
       - make
       - nmstate-devel
+      - nmstate-libs
 okd:
   enabled_repos:
   - rhel-9-appstream-rpms


### PR DESCRIPTION
## Summary

Add `nmstate-libs` to `konflux.cachi2.lockfile.rpms` for `ose-agent-installer-api-server`.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ose-agent-installer-api-server$&group=openshift-4.20&assembly=stream&engine=konflux

## Analysis

The hermetic Konflux build fails with `Unable to find a match: nmstate-libs` in the builder (non-final) stage. The Dockerfile installs `gcc`, `nmstate-devel`, `nmstate-libs`, and `git` in a non-final builder stage. Since the SBOM only captures final-stage RPMs, non-final stage RPMs must be listed in `konflux.cachi2.lockfile.rpms`.

Most builder-stage RPMs (gcc, nmstate-devel, etc.) were already listed, but `nmstate-libs` was missing.

## Changes

- Added `nmstate-libs` to `konflux.cachi2.lockfile.rpms`

Generated with [Claude Code](https://claude.com/claude-code)