### PR TITLE
ART-14953: Add nmstate-libs to lockfile rpms for ose-agent-installer-api-server

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -61,6 +61,7 @@ konflux:
       - libxcrypt-devel
       - make
       - nmstate-devel
+      - nmstate-libs
 okd:
   enabled_repos:
   - rhel-9-appstream-rpms


### PR DESCRIPTION
## Summary
- Add `nmstate-libs` to `konflux.cachi2.lockfile.rpms` for `ose-agent-installer-api-server`

The Dockerfile installs `nmstate-libs` in a non-final builder stage, but it was not listed
in `konflux.cachi2.lockfile.rpms`. This causes hermetic Konflux builds to fail with
`Unable to find a match: nmstate-libs` on aarch64.

Same fix as PR #10208 (4.20) — backported to 5.0.

## Test plan
- [ ] Trigger seed-lockfile test build with this PR's data branch
- [ ] Verify the build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)