### PR TITLE
ART-18155: Update nginx module stream from 1.24 to 1.26 for ose-network-tools (4.20)

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -42,7 +42,7 @@ konflux:
   cachi2:
     lockfile:
       modules:
-      - nginx:1.26
+      - nginx:1.24
       rpms:
       - nginx
     artifact_lockfile:

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -42,7 +42,7 @@ konflux:
   cachi2:
     lockfile:
       modules:
-      - nginx:1.24
+      - nginx:1.26
       rpms:
       - nginx
     artifact_lockfile:

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -50,7 +50,7 @@ konflux:
   cachi2:
     lockfile:
       modules:
-      - nginx:1.24
+      - nginx:1.26
       rpms:
       - nginx
     artifact_lockfile:

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -35,4 +35,4 @@ konflux:
   cachi2:
     lockfile:
       modules:
-      - nginx:1.24
+      - nginx:1.26


### PR DESCRIPTION
## Summary
- Update `nginx:1.24` to `nginx:1.26` module stream in `konflux.cachi2.lockfile.modules`
- The `nginx:1.24` module is no longer available in the RHEL 9.6 E4S repos used by 4.20
- Aligns with 4.21 and 4.22 which already use `nginx:1.26`

## Test plan
- [ ] Seed-lockfile test build with this PR data

Fixes: [ART-18155](https://redhat.atlassian.net/browse/ART-18155)