### PR TITLE
[openshift-4.20] ART-17443: Build microshift-bootc hermetically

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -36,10 +36,5 @@ name: openshift/microshift-bootc-rhel9
 owners:
 - microshift-devel@redhat.com
 konflux:
-  network_mode: open
-  cachi2:
-    # For them, vendor modifications are necessary
-    # https://redhat-internal.slack.com/archives/C06Q309QUDV/p1745508906683839
-    enabled: false
   sast:
     enabled: true

--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -13,6 +13,11 @@ content:
     - action: replace
       match: "ARG BASE_IMAGE_TAG"
       replacement: "ARG BASE_IMAGE_TAG=9.6"
+    - action: replace
+      match: "RUN dnf install"
+      replacement: |
+        RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release && \
+            dnf install \
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
Switch microshift-bootc to `network_mode: hermetic`.

We need to manually import the GPG key because the bootc base images (such as `registry.redhat.io/rhel9-eus/rhel-9.6-bootc:9.6`) do not import it. Without this, dnf install fails during build with:

```
You have enabled checking of packages via GPG keys. This is a good thing.
However, you do not have any GPG public keys installed. You need to download
the keys for packages you wish to install and install them.
You can do that by running the command:
    rpm --import public.gpg.key
 
 
Alternatively you can specify the url to the key you would like to use
for a repository in the 'gpgkey' option in a repository section and DNF
will install it for you.
 
For more information contact your distribution or package provider.
 
Problem repository: [rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4]
```

[Test run](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-20/pipelineruns/ose-4-20-microshift-bootc-k2lfb)