### PR TITLE
ART-16004 [openshift-4.13]: migrate golang streams from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.19.13-202604231229.p2.g276c5af.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231229.p2.g276c5af.el8
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -32,7 +32,7 @@ golang:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.19.13-202604231941.p2.g805400d.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231941.p2.g805400d.el9
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -56,7 +56,7 @@ rhel-9-golang-ci-build-root:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 etcd_rhel9_golang:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.19.13-202604231941.p2.g805400d.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231941.p2.g805400d.el9
   mirror: false
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
## Summary
Migrate golang builder image references in streams.yml from quay.io to registry.redhat.io to enable hermetic builds for OpenShift 4.13 golang infrastructure.

## Problem
**Before:** Golang builders used quay.io/redhat-user-workloads/ocp-art-tenant/art-images non-hermetic registry
- rhel-8-golang: quay.io/redhat-user-workloads/ocp-art-tenant/art-images (non-hermetic)
- rhel-9-golang: quay.io/redhat-user-workloads/ocp-art-tenant/art-images (non-hermetic)

**After:** Golang builders use registry.redhat.io trusted hermetic registry
- rhel-8-golang: registry.redhat.io/openshift/art-images-base (hermetic)
- rhel-9-golang: registry.redhat.io/openshift/art-images-base (hermetic)

Related: Hermetic Migration Initiative