### PR TITLE
ART-16004 [openshift-4.12]: migrate golang streams from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.19.13-202604231229.p2.g276c5af.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231229.p2.g276c5af.el8
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -32,7 +32,7 @@ golang:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.19.13-202604231941.p2.g805400d.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231941.p2.g805400d.el9
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -54,7 +54,7 @@ rhel-8-golang-ci-build-root:
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.
 etcd_golang:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.19.13-202604231229.p2.g276c5af.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231229.p2.g276c5af.el8
   mirror: false
   # No transform required as etcd does not yum install any packages.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.19


### PR DESCRIPTION
## Summary
Migrate golang builder image references in streams.yml from quay.io to registry.redhat.io to enable hermetic builds for OpenShift 4.12 golang infrastructure.

## Problem
**Before:** Golang builders used quay.io/redhat-user-workloads/ocp-art-tenant/art-images non-hermetic registry
- rhel-8-golang: quay.io/redhat-user-workloads/ocp-art-tenant/art-images (non-hermetic)
- rhel-9-golang: quay.io/redhat-user-workloads/ocp-art-tenant/art-images (non-hermetic)
- etcd_golang: quay.io/redhat-user-workloads/ocp-art-tenant/art-images (non-hermetic)

**After:** Golang builders use registry.redhat.io trusted hermetic registry
- rhel-8-golang: registry.redhat.io/openshift/art-images-base (hermetic)
- rhel-9-golang: registry.redhat.io/openshift/art-images-base (hermetic)
- etcd_golang: registry.redhat.io/openshift/art-images-base (hermetic)

Related: Hermetic Migration Initiative