### PR TITLE
ART-16004 [openshift-4.20]: migrate golang streams from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.13-202604241621.p2.g867eb73.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202604241621.p2.g867eb73.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.13-202604221752.p2.gcb9763d.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202604221752.p2.gcb9763d.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
## Summary
Migrate golang builder image references in streams.yml from quay.io to registry.redhat.io to enable hermetic builds for OpenShift 4.20 golang infrastructure.

## Problem
**Before:** Golang builders used quay.io/redhat-user-workloads/ocp-art-tenant/art-images non-hermetic registry
- rhel-8-golang: quay.io/redhat-user-workloads/ocp-art-tenant/art-images (non-hermetic)
- rhel-9-golang: quay.io/redhat-user-workloads/ocp-art-tenant/art-images (non-hermetic)

**After:** Golang builders use registry.redhat.io trusted hermetic registry
- rhel-8-golang: registry.redhat.io/openshift/art-images-base (hermetic)
- rhel-9-golang: registry.redhat.io/openshift/art-images-base (hermetic)

Related: Hermetic Migration Initiative