### PR TITLE
removed obsolete modifications

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -7,15 +7,6 @@ content:
       url: git@github.com:openshift-priv/console.git
       web: https://github.com/openshift/console
     modifications:
-    - action: replace
-      match: "./artifacts/corepack-${COREPACK_VERSION}.tar.gz"
-      replacement: "/cachi2/output/deps/generic/corepack-v${COREPACK_VERSION}.tgz"
-    - action: replace
-      match: "RUN container-entrypoint ./build-frontend.sh"
-      replacement: |
-        WORKDIR frontend
-        RUN node .yarn/releases/yarn-4.12.0.cjs install --immutable && \
-            node .yarn/releases/yarn-4.12.0.cjs build
     - action: command
       command: ["sh", "-c", "echo '\nsupportedArchitectures:\n  os: [\"linux\"]\n  cpu: [\"x64\", \"arm64\", \"s390x\", \"ppc64\"]' >> frontend/.yarnrc.yml"]
     pkg_managers:


### PR DESCRIPTION
(cherry picked from commit 5d668184c440dd1b612090cbf496a798bc355036)

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

The [PR](https://github.com/openshift/console/commit/ca9b15e50f2902935478ea1ae75ca4265c78e38b) removed 
what in images/openshift-enterprise-console.yml still is under modifications: action: replace 