### PR TITLE
ART-16004 [openshift-4.15]: migrate golang streams to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.20.12-202604101100.p2.g6e050e4.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.20.12-202604101100.p2.g6e050e4.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -32,7 +32,7 @@ golang:
 
 ibm-rhel-8-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.20.12-202604101100.p2.g6e050e4.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.20.12-202604101100.p2.g6e050e4.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
@@ -40,7 +40,7 @@ ibm-rhel-8-golang-1.20:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.20.12-202604101907.p2.g5595e7d.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.20.12-202604101907.p2.g5595e7d.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -52,7 +52,7 @@ rhel-9-golang:
 
 ibm-rhel-9-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.20.12-202604101907.p2.g5595e7d.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.20.12-202604101907.p2.g5595e7d.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
## Summary
Migrate golang builder streams from quay.io to registry.redhat.io as part of the [ART-16004](https://redhat.atlassian.net/browse/ART-16004) registry migration initiative for OpenShift 4.15.

## Problem
**Before:** Golang builder streams (golang and rhel-9-golang) were sourced from quay.io/redhat-user-workloads which needs to be migrated to the official Red Hat registry.

**After:** Both golang builder streams now use registry.redhat.io/openshift/art-images-base, maintaining the same golang version v1.20.12 for consistency while supporting the registry migration requirements.

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)