### PR TITLE
ART-16004: Migrate golang v1.23.10 streams from quay.io to registry.redhat.io for OpenShift 4.19

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202603131509.p2.gd0321dd.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202604271455.p2.gbf0298b.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202603131509.p2.gdc331c7.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202604271455.p2.gdc331c7.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
## Summary
Migrate golang v1.23.10 streams from quay.io to registry.redhat.io for OpenShift 4.19.

## Problem
**Before:** OpenShift 4.19 golang streams use quay.io/redhat-user-workloads registry
**After:** OpenShift 4.19 golang streams use registry.redhat.io/openshift/art-images-base registry

## Build Details
Using different NVRs because the current ones don't pass conformance testing. This migration uses newer conformance-passing builds:

**Build Reference:** https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/424/

**RPM Versions:**
- golang-1.23.10-13.el8
- golang-1.23.10-13.el9

**Image Updates:**
- rhel-8-golang: v1.23.10-202603131509.p2.gdc331c7.el8 → v1.23.10-202604271455.p2.gdc331c7.el8
- rhel-9-golang: v1.23.10-202603131509.p2.gd0321dd.el9 → v1.23.10-202604271455.p2.gbf0298b.el9

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)