### PR TITLE
ART-18153: bump yarn to 3.8.7 for agent-installer-ui (5.0)

### DIFF
--- a/images/agent-installer-ui.yml
+++ b/images/agent-installer-ui.yml
@@ -14,17 +14,17 @@ content:
       replacement: "if true; then"
     - action: replace
       match: npm install -g ${CACHED_YARN};
-      replacement: node .yarn/releases/yarn-3.4.1.cjs install --immutable;
+      replacement: node .yarn/releases/yarn-3.8.7.cjs install --immutable;
     - action: replace
       match: yarn install --immutable && yarn build:all;
-      replacement: node .yarn/releases/yarn-3.4.1.cjs build:all;
+      replacement: node .yarn/releases/yarn-3.8.7.cjs build:all;
     pkg_managers:
     - yarn
     artifacts:
       from_urls:
-      - target: 3.4.1.tar.gz
-        url: https://ocp-artifacts.engineering.redhat.com/github/yarnpkg/berry/archive/refs/tags/@yarnpkg/cli/3.4.1.tar.gz
-        sha256: d77eb555be73c3fc30b35b1a37fb85c098bac612e9239812708007d452b05731
+      - target: 3.8.7.tar.gz
+        url: https://ocp-artifacts.engineering.redhat.com/github/yarnpkg/berry/archive/refs/tags/@yarnpkg/cli/3.8.7.tar.gz
+        sha256: 589c2940e999efb2dd32a26ff5342e255295ade01bbd3395c8d4024a2546bf58
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
## Summary

Update yarn references from 3.4.1 to 3.8.7 for agent-installer-ui. Upstream bumped yarn
to 3.8.7 in commit `a2888d4` (`chore(deps): update yarn to v3.8.7`), but ocp-build-data
modifications still referenced the old `yarn-3.4.1.cjs` binary, causing build failures
with `Cannot find module '/app/.yarn/releases/yarn-3.4.1.cjs'`.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^agent-installer-ui$&group=openshift-5.0&assembly=stream&engine=konflux&dateRange=2026-01-28+to+2026-04-28&outcome=success&outcome=failure

## Analysis

The same fix was already applied to `openshift-4.23` in commit `788ecaef`. This PR
applies the identical change to `openshift-5.0`.

## Changes

- Updated Dockerfile modification replacements: `yarn-3.4.1.cjs` → `yarn-3.8.7.cjs`
- Updated artifact URL from `3.4.1.tar.gz` to `3.8.7.tar.gz` with correct sha256

Generated with [Claude Code](https://claude.com/claude-code)