### PR TITLE
ART-18075: Add missing lockfile rpms for ose-agent-installer-api-server (4.20)

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -47,18 +47,21 @@ konflux:
       - elfutils-debuginfod-client
       - gcc
       - gcc-c++
-      - libstdc++-devel
+      - gcc-plugin-annobin
       - glibc
-      - glibc-headers
       - glibc-devel
+      - glibc-headers
       - kernel-headers
       - libasan
       - libatomic
+      - libgomp
       - libmpc
+      - libstdc++-devel
       - libubsan
       - libxcrypt-devel
       - make
       - nmstate-devel
+      - nmstate-libs
 okd:
   enabled_repos:
   - rhel-9-appstream-rpms


### PR DESCRIPTION
## Summary

Add `gcc-plugin-annobin`, `libgomp`, and `nmstate-libs` to `konflux.cachi2.lockfile.rpms` for ose-agent-installer-api-server. Also sorted RPM entries alphabetically.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ose-agent-installer-api-server$&group=openshift-4.20&assembly=stream&engine=konflux

## Analysis

The hermetic build fails because non-final builder layer dependencies aren't in the lockfile:
- `gcc-plugin-annobin` — required by `gcc`
- `libgomp` — required by `gcc`  
- `nmstate-libs` — required by `nmstate-devel`

These packages exist in the repos but aren't captured by the SBOM since they're installed in non-final layers. They must be explicitly listed in the lockfile RPMs.

Verified by seed-lockfile test build #317 which succeeded with these RPMs added.

Generated with [Claude Code](https://claude.com/claude-code)