### PR TITLE
ART-16004 [logging-6.1]: migrate golang v1.25.7 streams from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.7-202604021425.p2.g7f26b42.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:


### PR DESCRIPTION
## Summary
Migrate golang v1.25.7 builder streams from quay.io to registry.redhat.io for the logging-6.1 branch to improve build reliability and follow standard registry practices.

## Problem
**Before:** rhel-9-golang stream references quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9

**After:** rhel-9-golang stream uses registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.7-202604021425.p2.g7f26b42.el9

This change builds upon the logging-6.1 bootstrap commit (d0fbc4b3a) already present in the logging-6.0 branch.

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)