### PR TITLE
ART-16004 [logging-6.2]: Migrate golang v1.25.8 streams from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081723.p2.gf28329a.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604081723.p2.gf28329a.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:


### PR DESCRIPTION
## Summary
Migrate golang builder v1.25.8 streams from quay.io to registry.redhat.io for logging-6.2 branch as part of the ongoing hermetic migration initiative.

## Problem
**Before:** rhel-9-golang stream was using quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081723.p2.gf28329a.el9

**After:** rhel-9-golang stream now uses registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604081723.p2.gf28329a.el9

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)