### PR TITLE
feat(streams): migrate golang v1.25.7 stream from quay.io to registry.redhat.io for logging-6.3

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.7-202604021425.p2.g7f26b42.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:


### PR DESCRIPTION
## Summary
- Migrate rhel-9-golang stream from quay.io to registry.redhat.io
- Update golang builder image to v1.25.7-202604021425.p2.g7f26b42.el9
- Support hermetic migration initiative by using official Red Hat registry

## Changes
- Updated `streams.yml` to use `registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.7-202604021425.p2.g7f26b42.el9`
- Removed dependency on quay.io for golang builder images

## Test plan
- [ ] Verify build system accepts new golang stream source
- [ ] Confirm hermetic builds work with registry.redhat.io source
- [ ] Validate no regression in golang-based component builds
- [ ] Check CI pipeline builds complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)