### PR TITLE
feat(images): migrate golang v1.25.7 streams from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.7-202604021425.p2.g7f26b42.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:


### PR DESCRIPTION
## Summary
- Migrate golang v1.25.7 streams from quay.io to registry.redhat.io in logging-6.4 branch
- Updates rhel-9-golang stream to use registry.redhat.io/openshift/art-images-base image location
- Follows the same migration pattern established in recent golang stream migrations

## Test plan
- [ ] Verify stream configuration is valid
- [ ] Confirm builds continue to work with new image location
- [ ] Check that golang v1.25.7 functionality is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)