### PR TITLE
ART-16004 [logging-6.0]: migrate golang v1.25.7 streams from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.7-202604021425.p2.g7f26b42.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:


### PR DESCRIPTION
## Summary
Migrate golang v1.25.7 builder streams from quay.io to registry.redhat.io infrastructure for logging 6.0 components, supporting the hermetic build migration initiative.

## Problem
**Before:** rhel-9-golang stream used quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9 which relies on external dependencies during build process.

**After:** rhel-9-golang stream now uses registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.7-202604021425.p2.g7f26b42.el9, enabling hermetic builds for all logging 6.0 components that depend on this golang builder.

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)