### PR TITLE
ART-16004 [logging-6.4]: migrate golang builder from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.7-202604021425.p2.g7f26b42.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:


### PR DESCRIPTION
## Summary
Migrate the rhel-9-golang stream in streams.yml from quay.io to registry.redhat.io so logging-6.4 builds use the hermetic openshift-golang-builder-container image.

## Problem
**Before:** Golang builder used quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.7-202602171210.g5015a16.el9 (non-hermetic).

**After:** Golang builder uses registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.7-202604021425.p2.g7f26b42.el9 (hermetic), preserving Go 1.25.7.

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)