### PR TITLE
ART-18158: Add jq to lockfile rpms for ose-must-gather (4.20)

### DIFF
--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -23,6 +23,11 @@ dependents:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - jq
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
## Summary

- Add `jq` to `konflux.cachi2.lockfile.rpms` for ose-must-gather

**Failing build:** https://art-build-history.engineering.redhat.com/build?group=openshift-4.20&image_name=ose-must-gather
**Jira:** https://issues.redhat.com/browse/ART-18158

## Analysis

The ose-must-gather Dockerfile installs `jq` via `yum install -y jq` in the final stage (from the `cli` parent image). In hermetic builds, the entitlement certificates are not available, so `jq` can't be resolved from RHEL repos unless it's explicitly listed in the lockfile.

All 4 architectures fail at STEP 10/16 with:
```
(microdnf): librhsm-WARNING: Found 0 entitlement certificates
error: No package matches 'jq'
```

The `jq` package is available in `rhel-9-appstream-rpms` (RHEL 9.6 E4S) for all architectures. Adding it to `konflux.cachi2.lockfile.rpms` ensures the seed-lockfile pipeline includes it in the lockfile.

## Changes

- Added `konflux.cachi2.lockfile.rpms: [jq]` to `images/ose-must-gather.yml`

Generated with [Claude Code](https://claude.com/claude-code)