### PR TITLE
ART-18148: bump GO_LATEST to 1.25

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -23,7 +23,7 @@ vars:
   #               aliases:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
-  GO_LATEST: "1.24"
+  GO_LATEST: "1.25"
   GO_EXTRA: "1.25"  # ovn-kubernetes or other components require Go 1.25
 
 compliance:

--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.p2.g04d2cd5.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.9-202604271607.p2.ge9dad93.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.p2.gcb9763d.el8
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.9-202604242241.p2.g2aa6a05.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Jenkins job golang-builder [#441](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/441/console) failed with
`08:57:00  ValueError: When --tag-builds is set, the provided golang build major.minor (1.25) must match openshift-4.21 group.yml GO_LATEST major.minor (1.24).`

This PR bumps up GO_LATEST to 1.25