### PR TITLE
ART-16004 [mtc-1.8]: migrate rhel-8-golang builder from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -23,7 +23,7 @@ ose-must-gather:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.11-202601072254.g1f0d617.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.p2.gcb9763d.el8
 
 rhel-8-builder:
   image: registry.redhat.io/ubi8/ubi:latest


### PR DESCRIPTION
## Summary
Updates `rhel-8-golang` in `streams.yml` to use the released **el8** golang builder on `registry.redhat.io/openshift/art-images-base` (`openshift-golang-builder-container-v1.24.13-202603271447.p2.gcb9763d.el8`) instead of the Konflux `quay.io/redhat-user-workloads/...` image.

## Problem
**Before:** `quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.11-202601072254.g1f0d617.el8` (non-hermetic tenant path).

**After:** `registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.p2.gcb9763d.el8` (released builder).

## Go version / release note
There is **no** corresponding `openshift-golang-builder-container` release on `registry.redhat.io` for the previous **v1.24.11** / `g1f0d617` builder we had pinned from quay; snapshot-to-release does not give a drop-in replacement at the same NVR. This PR therefore **bumps** the builder stream to **Go 1.24.13** (`gcb9763d`, el8) to match a published art-images-base tag.

**Merge only if** the MTC 1.8 product line can take that **1.24.11 → 1.24.13** golang toolchain bump (CI, compatibility, and release-owner sign-off). If a bump is not feasible, close this PR and keep investigating alternatives (e.g. a new 1.24.11 build released to art-images-base).

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)