### PR TITLE
ART-16004 [oadp-1.3]: migrate rhel-9-golang builder from quay.io to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -5,7 +5,7 @@ ose-cli:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081723.p2.gf28329a.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9
 
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163


### PR DESCRIPTION
## Summary
Migrates `rhel-9-golang` in `streams.yml` from the Konflux `quay.io/redhat-user-workloads/...` golang builder to the released builder on `registry.redhat.io/openshift/art-images-base`.

## Target image (validated candidate)
`registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9`

This replaces `golang-builder-v1.25.8-202604081723.p2.gf28329a.el9` from quay with the snapshot-to-released **openshift-golang-builder-container** tag at the same Go line (**v1.25.8**, **el9**), updated to the published NVR above.

## Problem
**Before:** `quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081723.p2.gf28329a.el9`

**After:** `registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9`

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)