### PR TITLE
[openshift-4.19] Remove redundant konflux.sast.enabled: true config

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -47,8 +47,6 @@ konflux:
       force: true
     enabled: true
     gomod_version_patch: true
-  sast:
-    enabled: true
   network_mode: hermetic
   # The number of times a build should be attempted before giving up.
   # Each failed attempt will result in a failed record in BigQuery

--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -40,6 +40,3 @@ enabled_repos:
 name: openshift/microshift-bootc-rhel9
 owners:
 - microshift-devel@redhat.com
-konflux:
-  sast:
-    enabled: true


### PR DESCRIPTION
## Summary
- Remove `konflux.sast.enabled: true` from `group.yml` (under the `konflux:` section)
- Remove the entire `konflux:` block from `images/microshift-bootc.yml` (it only contained `sast.enabled: true`)

The default for SAST in doozer is already `True`:
https://github.com/openshift-eng/art-tools/blob/main/doozer/doozerlib/backend/konflux_image_builder.py#L743

These explicit settings are no-ops and add noise.

## Test plan
- [ ] Verify doozer still enables SAST tasks by default (no behavior change expected)