### PR TITLE
Skip clair-scan task for installer-ove-ui builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -18,6 +18,8 @@ konflux:
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   privileged_nested: true
   additional_secret: ove-ui-image-pull-secret
+  skip_tasks:
+  - clair-scan
   build_step_resources:
     memory: "8Gi"
   build_args:


### PR DESCRIPTION
## Summary
- Adds skip_tasks: [clair-scan] to the konflux section in group.yml for the installer-ove-ui-4.21 group
- This removes the clair-scan Tekton task from PipelineRuns for this group builds

## Context
The clair-scan task is not needed for these builds. This uses the new generic skip_tasks mechanism in doozer to remove named tasks from PipelineRuns at build time.

## Test plan
- [ ] Verify doozer picks up skip_tasks from group config and removes clair-scan from the PipelineRun

Made with [Cursor](https://cursor.com)