### PR TITLE
Exclude failing operators from assembly 4.20.20

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -66,15 +66,15 @@ releases:
       members:
         rpms: []
         images:
-          - distgit_key: local-storage-mustgather
+          - distgit_key: local-storage-operator
             exclude: true
-            why: "Excluding due to failing Konflux builds preventing bundle creation (ART-18158)"
-          - distgit_key: ose-frr
+            why: "Bundle build failing due to missing operand ose-local-storage-mustgather-rhel9"
+          - distgit_key: ose-metallb-operator
             exclude: true
-            why: "Operand of ose-metallb-operator, Konflux build failing (ART-18158)"
-          - distgit_key: ose-must-gather
+            why: "Bundle build failing due to missing operand frr-rhel9"
+          - distgit_key: ose-support-log-gather-operator
             exclude: true
-            why: "Required by ose-support-log-gather-operator, Konflux build failing (ART-18158)"
+            why: "Bundle build failing due to missing operand ose-must-gather-rhel9"
   4.20.19:
     assembly:
       type: standard


### PR DESCRIPTION
Exclude local-storage-operator, ose-metallb-operator, and ose-support-log-gather-operator from assembly 4.20.20 due to bundle build failures caused by missing operands in Konflux.

This allows prepare-release-konflux to complete successfully without deferred bundle build failures.

Successful build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/856/