### PR TITLE
4.22 rc.2: exclude disabled operators at assembly basis time

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -67,7 +67,16 @@ releases:
           component: rhcos
       members:
         rpms: []
-        images: []
+        images:
+          - distgit_key: local-storage-operator
+            exclude: true
+            why: "Disabled at assembly basis time (2026-04-27); re-enabled by ocp-build-data#10260 on 2026-04-29"
+          - distgit_key: ptp-operator
+            exclude: true
+            why: "Disabled at assembly basis time (2026-04-27); re-enabled by ocp-build-data#10260 on 2026-04-29"
+          - distgit_key: dpu-operator
+            exclude: true
+            why: "Disabled at assembly basis time (2026-04-27); re-enabled by ocp-build-data#10263 on 2026-04-29"
   rc.1:
     assembly:
       type: candidate


### PR DESCRIPTION
```
09:33:10  2026-04-30 07:33:05,674 pyartcd.pipelines.prepare_release_konflux WARNING Bundle rebase-and-build completed with 2 failure(s) and 0 success(es)
09:33:10  2026-04-30 07:33:05,674 pyartcd.pipelines.prepare_release_konflux ERROR Failed to build bundle for operator=local-storage-operator, operator_nvr=local-storage-operator-container-v4.22.0-202604221745.p2.gf61c701.assembly.stream.el9: Konflux bundle image build for local-storage-operator failed
09:33:10  2026-04-30 07:33:05,674 pyartcd.pipelines.prepare_release_konflux ERROR Failed to build bundle for operator=ptp-operator, operator_nvr=ose-ptp-operator-container-v4.22.0-202604241447.p2.g9531cc1.assembly.stream.el9: Konflux bundle image build for ptp-operator failed
09:33:10  2026-04-30 07:33:05,674 pyartcd.pipelines.prepare_release_konflux INFO Returning 0 successful bundle build(s)
09:33:10  2026-04-30 07:33:05,674 pyartcd.pipelines.prepare_release_konflux INFO Verify_attached_operators ...
09:33:10  2026-04-30 07:33:10,257 pyartcd.pipelines.prepare_release_konflux WARNING Verify_attached_operators check failed with the following errors:
09:33:10  Bundle dpu-operator-bundle-container-v4.22.0.202603110549.p2.g1ab76b5.assembly.stream.el9-1 references operand dpu-daemon-container-v4.22.0-202603110549.p2.g1ab76b5.assembly.stream.el9, which is not in the release.
09:33:10  Bundle dpu-operator-bundle-container-v4.22.0.202603110549.p2.g1ab76b5.assembly.stream.el9-1 references operand dpu-intel-ipu-p4sdk-container-v4.22.0-202603110549.p2.g1ab76b5.assembly.stream.el9, which is not in the release.
09:33:10  Bundle dpu-operator-bundle-container-v4.22.0.202603110549.p2.g1ab76b5.assembly.stream.el9-1 references operand dpu-intel-ipu-vsp-container-v4.22.0-202603110549.p2.g1ab76b5.assembly.stream.el9, which is not in the release.
09:33:10  Bundle dpu-operator-bundle-container-v4.22.0.202603110549.p2.g1ab76b5.assembly.stream.el9-1 references operand dpu-intel-netsec-vsp-container-v4.22.0-202603110549.p2.g1ab76b5.assembly.stream.el9, which is not in the release.
09:33:10  Bundle dpu-operator-bundle-container-v4.22.0.202603110549.p2.g1ab76b5.assembly.stream.el9-1 references operand dpu-marvell-cp-agent-container-v4.22.0-202603110549.p2.g1ab76b5.assembly.stream.el9, which is not in the release.
09:33:10  Bundle dpu-operator-bundle-container-v4.22.0.202603110549.p2.g1ab76b5.assembly.stream.el9-1 references operand dpu-marvell-vsp-container-v4.22.0-202603110549.p2.g1ab76b5.assembly.stream.el9, which is not in the release.
09:33:10  Bundle dpu-operator-bundle-container-v4.22.0.202603110549.p2.g1ab76b5.assembly.stream.el9-1 references operand dpu-network-resources-injector-container-v4.22.0-202603110549.p2.g1ab76b5.assembly.stream.el9, which is not in the release.
```