### PR TITLE
logging-6.2: add OCP_RELEASE_NOTES_VERSION to group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -27,6 +27,8 @@ OCP_TARGET_VERSIONS: [
   "4.20",
 ]
 
+OCP_RELEASE_NOTES_VERSION: "4.18"
+
 arches:
 - x86_64
 - ppc64le


### PR DESCRIPTION
Add OCP release notes version to group.yml

see https://access.redhat.com/errata/RHSA-2026:11800