### PR TITLE
logging-6.3: add OCP_RELEASE_NOTES_VERSION to group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -26,6 +26,8 @@ OCP_TARGET_VERSIONS: [
   "4.20",
 ]
 
+OCP_RELEASE_NOTES_VERSION: "4.19"
+
 arches:
 - x86_64
 - ppc64le


### PR DESCRIPTION
Add OCP_RELEASE_NOTES_VERSION to group.yml

see https://access.redhat.com/errata/RHSA-2026:4939