### PR TITLE
logging-6.5: add OCP_RELEASE_NOTES_VERSION to group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -26,6 +26,8 @@ OCP_TARGET_VERSIONS: [
   "4.22",
 ]
 
+OCP_RELEASE_NOTES_VERSION: "4.21"
+
 arches:
 - x86_64
 - ppc64le


### PR DESCRIPTION
see https://access.redhat.com/errata/RHBA-2026:6393