### PR TITLE
Add RHCOS conflict permits for ec.1 assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -50,6 +50,11 @@ releases:
       members:
         rpms: []
         images: []
+      permits:
+        - code: CONFLICTING_INHERITED_DEPENDENCY
+          component: rhcos
+        - code: CONFLICTING_GROUP_RPM_INSTALLED
+          component: rhcos
   ec.0:
     assembly:
       type: preview


### PR DESCRIPTION
## Summary
- Add `CONFLICTING_INHERITED_DEPENDENCY` and `CONFLICTING_GROUP_RPM_INSTALLED` permits for RHCOS to the ec.1 assembly
- RHCOS builds use 4.22 stream RPMs while the 5.0 assembly expects 5.0 RPMs, causing build-sync-konflux to fail with `viable: false`
- These same permits were already present in ec.0's assembly definition

## Context
build-sync-konflux [#19715](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-sync-konflux/19715/) failed because RHCOS images contain 4.22 RPMs (e.g., `cri-o-1.35.2-9.rhaos4.22`, `openshift-4.22.0-...`) while the ec.1 assembly expects 5.0 versions. This is expected until RHCOS produces its own 5.0 stream builds.