### PR TITLE
Drop ec.1 ET advisories to skip RHCOS sweep

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -5,10 +5,7 @@ releases:
       basis:
         time: "2026-04-26T00:57:19+00:00"
       group:
-        advisories:
-          rpm: 166602
-          rhcos: 166603
-          microshift: 166604
+        advisories: {}
         release_jira: ART-14755
         shipment:
           advisories:


### PR DESCRIPTION
## Summary
- Set ec.1 `advisories` to `{}` so prepare-release skips the ET advisory step entirely
- RHCOS builds are from the 4.22 stream (tagged `rhaos-4.22-rhel-9-candidate`) and cannot be attached to a 5.0 advisory — there is no product version mapping for cross-version tags
- This matches ec.0's approach which also used `advisories: {}`

## Context
prepare-release-konflux [#862](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/862/) failed with:
```
OSError: Build rhcos-x86_64-4.22.9.8.202604252249-0 has Brew tags {'rhaos-4.22-rhel-9-candidate'},
but none of them has an associated Errata product version.
Available tag_pv_map keys: ['rhaos-5.0-rhel-8-candidate', 'rhaos-5.0-rhel-9-candidate',
'rhaos-5.0-ironic-rhel-9-candidate']
```

The three advisories (166602, 166603, 166604) were already created in Errata Tool by build #862 before it failed. They will remain as empty NEW_FILES advisories.