### PR TITLE
Exclude local-storage-operator and ptp-operator from ec.1 assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -47,7 +47,13 @@ releases:
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:848b8124b8f2251e2e5834bb88172106996590e969665657ab0549631c10e2e5
       members:
         rpms: []
-        images: []
+        images:
+          - distgit_key: local-storage-operator
+            exclude: true
+            why: "Bundle EC verification failing: unpinned must-gather image reference"
+          - distgit_key: ptp-operator
+            exclude: true
+            why: "Bundle EC verification failing: unpinned must-gather image reference"
       permits:
         - code: CONFLICTING_INHERITED_DEPENDENCY
           component: rhcos


### PR DESCRIPTION
## Summary
- Exclude `local-storage-operator` and `ptp-operator` from ec.1 assembly members
- Both operators fail bundle EC verification due to unpinned must-gather image references in their CSV annotations (`olm.unpinned_references`)

## Context
Same root cause as 4.22 — the `operators.openshift.io/must-gather-image` annotation uses a tag reference instead of a pinned digest. Fixed on `release-4.22` by openshift/ptp-operator#695 and openshift/local-storage-operator#616, but equivalent fixes for `release-5.0` have not been submitted yet.

EC verify logs:
- local-storage-operator: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/openshift-5-0-ec-ose-5-0-local-storage-operator-bundle-rc6tm
- ptp-operator: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/openshift-5-0-ec-ose-5-0-ptp-operator-bundle-n75z2