### PR TITLE
logging-6.2: Update golang-builder and ubi9-minimal image

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604081723.p2.gf28329a.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604211249.p2.g50071d5.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:
@@ -10,4 +10,4 @@ ose-cli-artifacts:
 
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
-  image: registry.redhat.io/ubi9/ubi-minimal@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
+  image: registry.redhat.io/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00


### PR DESCRIPTION
/label tide/merge-method-squash
