### PR TITLE
Update versions from 4.21 to 4.22 on installer-ove-ui-4.22 branch

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,10 +1,10 @@
-name: installer-ove-ui-4.21
+name: installer-ove-ui-4.22
 product: installer-ove-ui
-version: "4.21"
+version: "4.22"
 
 vars:
   MAJOR: 4
-  MINOR: 21
+  MINOR: 22
 
 
 arches:
@@ -24,9 +24,9 @@ konflux:
     memory: "8Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
-  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.21.5-x86_64"
-  - "MAJOR_MINOR_VERSION=4.21"
-  - "PATCH_VERSION=5"
+  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.22.0-rc.0-x86_64"
+  - "MAJOR_MINOR_VERSION=4.22"
+  - "PATCH_VERSION=0"
   - "ARCH=x86_64"
 
 assemblies:

--- a/streams.yml
+++ b/streams.yml
@@ -1,6 +1,6 @@
 ---
 agent-preinstall-image-builder:
-  image: registry.ci.openshift.org/ocp/4.21:agent-preinstall-image-builder
+  image: registry.ci.openshift.org/ocp/4.22:agent-preinstall-image-builder
 
 scratch:
   image: scratch


### PR DESCRIPTION
## Summary

- Updates all version references from 4.21 to 4.22 on the `installer-ove-ui-4.22` branch
- The branch was created from `installer-ove-ui-4.21` and still had all 4.21 values

## Changes

- `group.yml`: Updated name, version, MINOR, RELEASE_VALUE, MAJOR_MINOR_VERSION, PATCH_VERSION
- `streams.yml`: Updated agent-preinstall-image-builder stream from ocp/4.21 to ocp/4.22

## Reference

Uses version values from upstream [agent-installer-utils PR #295](https://github.com/openshift/agent-installer-utils/pull/295):
- RELEASE_VALUE: `quay.io/openshift-release-dev/ocp-release:4.22.0-rc.0-x86_64`
- PATCH_VERSION: `0`

Made with [Cursor](https://cursor.com)