### PR TITLE
ART-18313: Set logging-6.3 EOL

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -199,3 +199,6 @@ repos:
       s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_6
     reposync:
       enabled: false
+
+software_lifecycle:
+  phase: eol


### PR DESCRIPTION
Set software_lifecycle phase to eol (and adjust freeze_automation if applicable) for the logging-6.3 stream.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED