### PR TITLE
nmstate-console-plugin: migrate Konflux build from yarn to npm (openshift-4.21)

### DIFF
--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -8,16 +8,12 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/nmstate-console-plugin.git
       web: https://github.com/openshift/nmstate-console-plugin
-    modifications:
-    - action: replace
-      match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
-      replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     ci_alignment:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
     pkg_managers:
-    - yarn
+    - npm
 dependents:
 - openshift-kubernetes-nmstate-operator
 distgit:
@@ -45,12 +41,9 @@ owners:
 - phoracek@redhat.com
 - fge@redhat.com
 konflux:
-  cachito:
-    mode: removal
+  vm_override:
+    aarch64: linux-d160-c4xlarge/arm64
   cachi2:
     lockfile:
       modules:
       - nginx:1.26
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz


### PR DESCRIPTION
## Summary
Update `images/nmstate-console-plugin.yml` so the image uses **npm** with **cachi2** instead of **yarn**: drop yarn tarball modifications and artifact lockfile entry, set `pkg_managers` to `npm`, and adjust Konflux settings (remove Cachito removal mode, add `vm_override` for aarch64).

## Upstream dependency
This build-data change goes with the console plugin’s migration work in **[openshift/nmstate-console-plugin#215](https://github.com/openshift/nmstate-console-plugin/pull/215)**.

**Merge order:** merge **openshift/nmstate-console-plugin#215** first; after that lands, merge **this** `ocp-build-data` PR.

## Problem
**Before:** Hermetic/Konflux path assumed yarn (modifications to yarn tarball path, Cachito removal, yarn artifact in `cachi2_lockfile` resources).

**After:** Build aligns with npm + cachi2 lockfile workflow; aarch64 uses the configured `vm_override`.

**JIRA:** Add `ART-XXXXX` to the PR title when you have the tracking ticket (template: `ART-XXXXX [openshift-4.21]: …`).

## Related
- Upstream: https://github.com/openshift/nmstate-console-plugin/pull/215
- Link the ART ticket here once assigned.