### PR TITLE
Add block-copyfail image to installer-ove-ui-4.21

### DIFF
--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -1,0 +1,24 @@
+content:
+  source:
+    path: .
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: main
+      url: git@github.com:mrunalp/block-copyfail.git
+      web: https://github.com/mrunalp/block-copyfail
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: block-copyfail-container
+delivery:
+  repo_name: block-copyfail
+  delivery_repo_names:
+  - ocp-art-tenant/block-copyfail
+for_payload: false
+from:
+  builder:
+  - stream: fedora
+  stream: ubi9-minimal
+name: ocp-art-tenant/block-copyfail
+owners:
+- aos-team-art@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -2,5 +2,11 @@
 agent-preinstall-image-builder:
   image: registry.ci.openshift.org/ocp/4.21:agent-preinstall-image-builder
 
+fedora:
+  image: registry.fedoraproject.org/fedora:latest
+
 scratch:
   image: scratch
+
+ubi9-minimal:
+  image: registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
## Summary
- Adds a new `block-copyfail` image definition sourced from [mrunalp/block-copyfail](https://github.com/mrunalp/block-copyfail)
- Multi-stage build: Fedora builder (C/BPF toolchain with clang, llvm, bpftool) and `ubi9/ubi-minimal` runtime base
- Adds `fedora` and `ubi9-minimal` streams to `streams.yml`

## Files Changed
- `streams.yml` -- added `fedora` and `ubi9-minimal` streams
- `images/block-copyfail.yml` -- new image definition

## Test plan
- [ ] Verify streams resolve correctly in a Konflux build
- [ ] Verify block-copyfail image builds successfully

Made with [Cursor](https://cursor.com)