### PR TITLE
Add block-copyfail image to openshift-4.21

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -217,6 +217,8 @@ public_upstreams:
   public: "https://github.com/openshift-eng/ocp-build-data"
 - private: "https://github.com/openshift-priv/assisted-installer-ui"
   public: "https://github.com/openshift-assisted/assisted-installer-ui"
+- private: "https://github.com/openshift-priv/block-copyfail"
+  public:  "https://github.com/mrunalp/block-copyfail"
 
 default_image_build_method: osbs2
 image_build_log_scanner:

--- a/group.yml
+++ b/group.yml
@@ -218,7 +218,7 @@ public_upstreams:
 - private: "https://github.com/openshift-priv/assisted-installer-ui"
   public: "https://github.com/openshift-assisted/assisted-installer-ui"
 - private: "https://github.com/openshift-priv/block-copyfail"
-  public:  "https://github.com/mrunalp/block-copyfail"
+  public:  "https://github.com/openshift/block-copyfail"
 
 default_image_build_method: osbs2
 image_build_log_scanner:

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -3,6 +3,7 @@ content:
     path: .
     dockerfile: Dockerfile
     git:
+      allow_unprotected_branch: true
       branch:
         target: main
       url: git@github.com:openshift-priv/block-copyfail.git

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -30,3 +30,4 @@ owners:
 - aos-team-art@redhat.com
 konflux:
   network_mode: open
+  image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/ocp-block-copy-fail

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -28,5 +28,4 @@ name: openshift4/ose-block-copyfail-rhel9
 owners:
 - aos-team-art@redhat.com
 konflux:
-  no_shell: true
   network_mode: open

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -29,3 +29,4 @@ owners:
 - aos-team-art@redhat.com
 konflux:
   no_shell: true
+  network_mode: open

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -1,3 +1,6 @@
+# This is a custom image that was added only for the purpose of releasing a fix for a CVE. This build should not be
+# swept in regular releases. Keeping it in mode: disabled for historical context.
+mode: disabled
 content:
   source:
     path: .

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -19,7 +19,7 @@ for_release: false
 from:
   builder:
   - stream: rhel9-custom
-  stream: rhel9-minimal-custom
+  member: openshift-enterprise-base-rhel9
 name: openshift4/ose-block-copyfail-rhel9
 owners:
 - aos-team-art@redhat.com

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -29,5 +29,7 @@ name: openshift4/ose-block-copyfail-rhel9
 owners:
 - aos-team-art@redhat.com
 konflux:
-  network_mode: open
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/supplemental-tools
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -16,6 +16,10 @@ delivery:
   - openshift4/ose-block-copyfail-rhel9
 for_payload: false
 for_release: false
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
 from:
   builder:
   - stream: rhel9-custom

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -20,6 +20,7 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
 - rhel-9-server-ose-rpms-embargoed
+- codeready-builder-rpms
 from:
   builder:
   - stream: rhel9-custom

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -19,7 +19,7 @@ for_release: false
 from:
   builder:
   - stream: rhel9-custom
-  stream: rhel9
+  stream: rhel9-minimal-custom
 name: openshift4/ose-block-copyfail-rhel9
 owners:
 - aos-team-art@redhat.com

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -30,4 +30,4 @@ owners:
 - aos-team-art@redhat.com
 konflux:
   network_mode: open
-  image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/ocp-block-copy-fail
+  image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/supplemental-tools

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -6,7 +6,7 @@ content:
       branch:
         target: main
       url: git@github.com:openshift-priv/block-copyfail.git
-      web: https://github.com/mrunalp/block-copyfail
+      web: https://github.com/openshift/block-copyfail
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: block-copyfail-container

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -1,0 +1,27 @@
+content:
+  source:
+    path: .
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: main
+      url: git@github.com:openshift-priv/block-copyfail.git
+      web: https://github.com/mrunalp/block-copyfail
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: block-copyfail-container
+delivery:
+  repo_name: block-copyfail
+  delivery_repo_names:
+  - openshift4/ose-block-copyfail-rhel9
+for_payload: false
+for_release: false
+from:
+  builder:
+  - stream: fedora
+  stream: rhel9
+name: openshift4/ose-block-copyfail-rhel9
+owners:
+- aos-team-art@redhat.com
+konflux:
+  no_shell: true

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -18,7 +18,7 @@ for_payload: false
 for_release: false
 from:
   builder:
-  - stream: fedora
+  - stream: rhel9-custom
   stream: rhel9
 name: openshift4/ose-block-copyfail-rhel9
 owners:

--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -20,7 +20,7 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
 - rhel-9-server-ose-rpms-embargoed
-- codeready-builder-rpms
+- rhel-9-codeready-builder-rpms
 from:
   builder:
   - stream: rhel9-custom

--- a/streams.yml
+++ b/streams.yml
@@ -125,5 +125,5 @@ centos_stream10:
   mirror_manifest_list: true
 
 rhel9-custom:
-  # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
-  image: registry.redhat.io/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00
+  image: registry.redhat.io/ubi9:latest
+  mirror: false

--- a/streams.yml
+++ b/streams.yml
@@ -124,6 +124,6 @@ centos_stream10:
   mirror: true
   mirror_manifest_list: true
 
-fedora:
-  image: registry.fedoraproject.org/fedora:latest
-  mirror: false
+rhel9-custom:
+  # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
+  image: registry.redhat.io/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00

--- a/streams.yml
+++ b/streams.yml
@@ -123,3 +123,7 @@ centos_stream10:
   upstream_image: registry.ci.openshift.org/ocp/builder:stream10
   mirror: true
   mirror_manifest_list: true
+
+fedora:
+  image: registry.fedoraproject.org/fedora:latest
+  mirror: false

--- a/streams.yml
+++ b/streams.yml
@@ -127,3 +127,7 @@ centos_stream10:
 rhel9-custom:
   image: registry.redhat.io/ubi9:latest
   mirror: false
+
+rhel9-minimal-custom:
+  image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+  mirror: false


### PR DESCRIPTION
## Summary
- Adds a new `block-copyfail` image definition sourced from `openshift-priv/block-copyfail` (public: [mrunalp/block-copyfail](https://github.com/mrunalp/block-copyfail))
- Multi-stage build: Fedora builder (C/BPF toolchain with clang, llvm, bpftool) and `rhel9` (ubi-minimal) runtime base
- Incorporates the same changes already merged on `installer-ove-ui-4.21`: `openshift-priv` git URL, `openshift4/ose-block-copyfail-rhel9` naming, `no_shell: true`, and `public_upstreams` mapping

## Files Changed
- `images/block-copyfail.yml` -- new image definition
- `streams.yml` -- added `fedora` stream for builder stage
- `group.yml` -- added `public_upstreams` mapping for block-copyfail

## Test plan
- [ ] Verify fedora stream resolves correctly
- [ ] Verify block-copyfail image builds successfully

Made with [Cursor](https://cursor.com)