### PR TITLE
nmstate-console-plugin: migrate Konflux build from yarn to npm (openshift-4.18)

### DIFF
--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -8,16 +8,12 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/nmstate-console-plugin.git
       web: https://github.com/openshift/nmstate-console-plugin
-    modifications:
-    - action: replace
-      match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
-      replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     ci_alignment:
       streams_prs:
         ci_build_root:
           stream: rhel-9-golang-ci-build-root
     pkg_managers:
-    - yarn
+    - npm
 dependents:
 - openshift-kubernetes-nmstate-operator
 distgit:
@@ -45,12 +41,9 @@ owners:
 - phoracek@redhat.com
 - fge@redhat.com
 konflux:
-  cachito:
-    mode: removal
+  vm_override:
+    aarch64: linux-d160-c4xlarge/arm64
   cachi2:
     lockfile:
       modules:
       - nginx:1.24
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz


### PR DESCRIPTION
## Summary
Backport to **openshift-4.18**: update `images/nmstate-console-plugin.yml` so the image uses **npm** with **cachi2** instead of **yarn** (same intent as openshift-eng/ocp-build-data#10376 for 4.21): drop yarn tarball modifications and artifact lockfile entry, set `pkg_managers` to `npm`, swap Konflux `cachito` removal for `vm_override` on aarch64. Keeps 4.18-specific `ci_build_root` (`rhel-9-golang-ci-build-root`) and `nginx:1.24` lockfile module.

## Upstream dependency
Aligns with **[openshift/nmstate-console-plugin#215](https://github.com/openshift/nmstate-console-plugin/pull/215)**.

**Merge order:** merge the upstream repo change first where applicable, then this PR.

## Problem
**Before:** Hermetic/Konflux path assumed yarn (yarn path modifications, Cachito removal, yarn tarball in `artifact_lockfile`).

**After:** npm + cachi2 lockfile; aarch64 uses `vm_override`.

## Related
- 4.21 merge: https://github.com/openshift-eng/ocp-build-data/pull/10376
- Upstream: https://github.com/openshift/nmstate-console-plugin/pull/215