### PR TITLE
Pin openshift RPM to stream assembly for 4.21

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1623,6 +1623,14 @@ releases:
         - code: FAILED_CONSISTENCY_REQUIREMENT
           component: '*'
       members:
+        rpms:
+          - distgit_key: openshift
+            why: Pin openshift RPM
+            metadata:
+              is:
+                el8: openshift-4.21.0-202604030310.p2.gdfffacd.assembly.stream.el8
+                el9: openshift-4.21.0-202604030310.p2.gdfffacd.assembly.stream.el9
+                el10: openshift-4.21.0-202604030310.p2.gdfffacd.assembly.stream.el10
         images:
           - distgit_key: '*'
             why: Exclude rpm updates that should not cause mass rebuilds


### PR DESCRIPTION
## Summary
- Pin the openshift RPM builds from 4.21.13 to the stream assembly

## Test plan
- [ ] Verify assembly defines work correctly with pinned RPM