### PR TITLE
Remove shipment URL from 4.19.30 assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -24,7 +24,6 @@ releases:
               live_id: 10095
             - kind: fbc
             - kind: image
-          url: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/479
         advisories!:
           rpm: 166720
           rhcos: 166721


### PR DESCRIPTION
## Problem

The `prepare-release-konflux` Jenkins job for 4.19.30 was failing with:
```
ValueError: MR state merged is not opened. This is not supported.
```

## Root Cause

The 4.19.30 assembly configuration in `releases.yml` had a `shipment!.url` pointing to the already-merged MR 479 (which was for 4.19.29):
```yaml
shipment!:
  url: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/479
```

The `prepare-release-konflux` job validates the shipment MR and expects it to be in "opened" state. Since MR 479 is already merged, the validation fails.

## Solution

Removed the `url:` line from the 4.19.30 shipment configuration. The `prepare-release-konflux` job will create a new shipment MR automatically when it runs.

## Testing

After this fix is merged, the `prepare-release-konflux` job for 4.19.30 should:
1. Pass the shipment validation (no existing MR to validate)
2. Create a new shipment MR in ocp-shipment-data for 4.19.30

## Related

- Failing Jenkins job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/866/console
- MR 479 (4.19.29, already merged): https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/479