### PR TITLE
4.16.61 - Clean up releases.yml by removing unused advisories

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -13,16 +13,11 @@ releases:
           rpms:
             - el9: kernel-5.14.0-427.124.1.el9_4
               why: Pin kernel to match pinned RHCOS (5.14.0-427.124.1.el9_4)
+              non_gc_tag: hotfix
         shipment!:
           advisories:
             - kind: image
               live_id: 13735
-            - kind: extras
-              live_id: 10105
-            - kind: metadata
-              live_id: 10106
-            - kind: fbc
-            - kind: image
           url: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/502
         advisories!:
           rpm: 166730
@@ -59,12 +54,6 @@ releases:
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4618b54800ce9294ca09e3cf7cb9492c8cd37d75291bd529f6c7ac4ba2d4dcf5
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a992d870a2e44888dfd362a3f39be5d8c94953a6e7a04abcad18d41100e0be47
       members:
-        rpms:
-          - distgit_key: kernel
-            why: Pin kernel to 5.14.0-427.124.1.el9_4 for hotfix assembly
-            metadata:
-              is:
-                el9: kernel-5.14.0-427.124.1.el9_4
         images:
           - distgit_key: driver-toolkit
             why: Pin driver-toolkit to stream build with kernel 5.14.0-427.124.1.el9_4 (nightly 4.16.0-0.nightly-2026-05-05-061134 / ART build history)


### PR DESCRIPTION
Removed unnecessary advisories and RPM pinning details from the releases configuration.