### PR TITLE
Add promotion_permits for 4.21.14 assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -22,6 +22,9 @@ releases:
         advisories!:
           rpm: 166757
           rhcos: 166758
+      promotion_permits:
+        - code: BLOCKER_BUGS
+          why: Per ART-18321
       rhcos:
         rhel-coreos:
           images:


### PR DESCRIPTION
## Summary
- Add `promotion_permits` with `BLOCKER_BUGS` code to the 4.21.14 assembly definition
- Allows promote-assembly job to proceed despite open blocker bug OCPBUGS-84947
- Justification: per [ART-18321](https://redhat.atlassian.net/browse/ART-18321)

## Test plan
- [ ] CI validation passes on releases.yml
- [ ] promote-assembly job proceeds past blocker bug check

🤖 Generated with [Claude Code](https://claude.com/claude-code)