### PR TITLE
ART-18334: Add FBC_DISABLE_CHANNEL_SKIPS

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -19,6 +19,8 @@ vars:
   MAJOR: 4
   MINOR: 21
 
+  FBC_DISABLE_CHANNEL_SKIPS: true
+
 OCP_TARGET_VERSIONS: [
   "4.19",
   "4.20",


### PR DESCRIPTION
Add FBC_DISABLE_CHANNEL_SKIPS var to disable skips in OLM channel entries

Logging use replaces + skipRange for their OLM upgrade path and do not want skips: entries in FBC channel definitions.  This variable is consumed by doozer's FBC rebase logic to suppress writing skips to olm.channel entries for non-OpenShift groups that opt in.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED