### PR TITLE
Add ose-smb-csi-driver-operator to ose-csi-external-resizer dependents

### DIFF
--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -24,6 +24,7 @@ delivery:
   - openshift4/ose-csi-external-resizer-rhel9
 dependents:
 - ose-gcp-filestore-csi-driver-operator
+- ose-smb-csi-driver-operator
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
## Summary
- Adds `ose-smb-csi-driver-operator` to the `dependents` list in `ose-csi-external-resizer.yml`

## Problem
The SMB CSI driver operator's CSV references `ose-csi-external-resizer` as a related image. During rebase, Doozer validates that dependency relationships are bidirectional and fails with:
```
ValueError: Related image contains ose-csi-external-resizer but this does not have ose-smb-csi-driver-operator in dependents
```

## Solution
Add the missing bidirectional dependency to satisfy the validation check.

## Test plan
Rebase `ose-smb-csi-driver-operator` should complete successfully without dependency validation errors.