### PR TITLE
Add ose-smb-csi-driver-operator to ose-csi-external-resizer dependents

### DIFF
--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -24,6 +24,7 @@ delivery:
   - openshift4/ose-csi-external-resizer-rhel9
 dependents:
 - ose-gcp-filestore-csi-driver-operator
+- ose-smb-csi-driver-operator
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
The SMB CSI driver operator's CSV references ose-csi-external-resizer as a related image, so it needs to be listed in the dependents to satisfy bidirectional dependency validation during rebase.
