### PR TITLE
streams: use registry.redhat.io for rhel-8/9-golang-1.24 builders [openshift-4.19]

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -38,7 +38,7 @@ rhel-8-golang:
 rhel-9-golang-1.24:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.13-202603271447.p2.g04d2cd5.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.p2.g04d2cd5.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -47,7 +47,7 @@ rhel-9-golang-1.24:
 rhel-8-golang-1.24:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.13-202603271447.p2.gcb9763d.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.p2.gcb9763d.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
## Summary

Point `rhel-8-golang-1.24` and `rhel-9-golang-1.24` `image:` at `registry.redhat.io/openshift/art-images-base` builder tags matching openshift-4.21 (same `v1.24.13-202603271447` NVR). No change to `upstream_image` or partner streams.

## Problem

**Before:** Those streams referenced `quay.io/redhat-user-workloads/.../art-images:golang-builder-v1.24.13-202603271447.*`.

**After:** Same build pulled from `registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.*`.

Related: (add ART ticket if your process requires one.)