### PR TITLE
Update 4.21 software lifecycle to release phase

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -272,7 +272,7 @@ reconciliation_prs:
 # - 'release': for post GA time
 # - 'eol': For when a release will not formally ship anymore
 software_lifecycle:
-  phase: signing
+  phase: release
 
 external_scanners:
   sast_scanning:


### PR DESCRIPTION
## Summary

- Update `software_lifecycle.phase` from `signing` to `release` for 4.21

4.21 went GA on February 3, 2026 but the lifecycle phase was never updated. This caused the first-fix rule (`elliott find-bugs:second-fix`) to be incorrectly applied to 4.21 bugs (e.g. OCPBUGS-80783), closing CVE trackers that should remain open for a GA release.

## Test plan

- [x] Verified the change is correct per the [lifecycle phase documentation](https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.21/group.yml#L270-L273)