### PR TITLE
Exclude dpu-operator from 4.22 rc.3 assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -67,7 +67,10 @@ releases:
           component: rhcos
       members:
         rpms: []
-        images: []
+        images:
+          - distgit_key: dpu-operator
+            exclude: true
+            why: "dpu-marvell-cp-agent operand fails to build"
   rc.2:
     assembly:
       type: candidate


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED