### PR TITLE
ART-14887 [rhel-9-golang-1.22]: migrate openshift-golang-builder to hermetic builds

### DIFF
--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -43,7 +43,7 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
-  network_mode: open
+  network_mode: hermetic
   content:
     source:
       modifications:


### PR DESCRIPTION
## Summary

Set `konflux.network_mode` to `hermetic` for `images/openshift-golang-builder.yml` on the `rhel-9-golang-1.22` stream branch so golang builder Konflux builds use network isolation aligned with hermetic policy.

## Problem
**Before:** The golang builder Konflux stanza used `network_mode: open`, allowing network access during image builds.

**After:** Konflux uses `network_mode: hermetic` for this builder configuration, complying with hermetic build requirements tracked under ART.

Related: [ART-14887](https://redhat.atlassian.net/browse/ART-14887)