### PR TITLE
ART-14887 [rhel-9-golang-1.22]: restore open network mode for golang-builder Konflux

### DIFF
--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -43,7 +43,7 @@ konflux:
     artifact_lockfile:
       resources:
       - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
-  network_mode: hermetic
+  network_mode: open
   content:
     source:
       modifications:


### PR DESCRIPTION
## Summary

Set `konflux.network_mode` back to `open` for `openshift-golang-builder` on the `rhel-9-golang-1.22` stream (was `hermetic` after #10013).

## Problem

**Before:** `konflux.network_mode: hermetic` for `images/openshift-golang-builder.yml`.

**After:** `konflux.network_mode: open` for the same image.

Related: [ART-14887](https://redhat.atlassian.net/browse/ART-14887)