### PR TITLE
ART-14921: Add glibc-common and glibc-minimal-langpack to ose-agent-i…

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -50,8 +50,11 @@ konflux:
       - gcc-plugin-annobin
       - libstdc++-devel
       - glibc
-      - glibc-headers
+      - glibc-common
+      - glibc-gconv-extra
       - glibc-devel
+      - glibc-headers
+      - glibc-minimal-langpack
       - kernel-headers
       - libasan
       - libatomic
@@ -61,6 +64,9 @@ konflux:
       - libxcrypt-devel
       - make
       - nmstate-devel
+      - nmstate-libs
+      - perl-Git
+      - postgresql-server
 okd:
   enabled_repos:
   - rhel-9-appstream-rpms


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

With all these RPMs it could be done a seed-lockfile [#377](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/377/console) job for `ose-agent-installer-api-server` for openshift-5.0 with 
[ose-agent-installer-api-server-container-v5.0.0-202605071105.p2.gb8b5e5d.assembly.stream.el9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=ose-agent-installer-api-server-container-v5.0.0-202605071105.p2.gb8b5e5d.assembly.stream.el9&record_id=b28bb1cb-7456-fe99-5698-b79e25ecc14b&group=openshift-5.0&outcome=success&type=image)
This build was against PR [#2798 ](https://github.com/openshift-eng/art-tools/pull/2798) - that has to be merged.
