### PR TITLE
Pass --registry-config to microshift-rebase modification script

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -14,7 +14,7 @@ content:
     specfile: packaging/rpm/microshift.spec
     modifications:
     - action: command
-      command: microshift-rebase
+      command: microshift-rebase --registry-config={registry_config}
       env:
         RELEASE_NAME: "{release_name}"
 name: microshift


### PR DESCRIPTION
## Summary
- The `microshift-rebase` script was updated (49bab2597) to require `--registry-config` as a CLI argument, but `rpms/microshift.yml` was not updated to pass it
- This causes `build-microshift` to fail with `Missing required argument: --registry-config <path>`
- Adds `--registry-config={registry_config}` to the command invocation — the `{registry_config}` format variable is already available in the RPM modification context from `rpmcfg.py`

## Failed build
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift/3800/console