### PR TITLE
[openshift-5.0] Migrate openshift/etcd to use release-* branch naming strategy

### DIFF
--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -17,7 +17,7 @@ content:
     dockerfile: Dockerfile.rhel
     git:
       branch:
-        target: openshift-{MAJOR}.{MINOR}
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/etcd.git
       web: https://github.com/openshift/etcd
     pkg_managers:

--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -18,7 +18,7 @@ content:
     dockerfile: Dockerfile.installer.art-cachi2
     git:
       branch:
-        target: openshift-{MAJOR}.{MINOR}
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/etcd.git
       web: https://github.com/openshift/etcd
     pkg_managers:


### PR DESCRIPTION
In https://github.com/openshift/release/pull/78495, I migrated the openshift/etcd repo to use `release-*` branch naming instead of `openshift-*`. This was a part of allowing changes/having CI run at the main branch in openshift/etcd; the repo-brancher is hardcoded to fast-forward main to `release-*`, so I migrated openshift/etcd from 5.0/4.23 on to use `release-*`.

This PR ensures we're building openshift/etcd from the correct branch at 5.0.