### PR TITLE
ART-14921: Fix installer-api-server

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -52,9 +52,11 @@ konflux:
       - git-core
       - git-core-doc
       - glibc
+      - glibc-common
       - glibc-gconv-extra
       - glibc-devel
       - glibc-headers
+      - glibc-minimal-langpack
       - kernel-headers
       - libasan
       - libatomic
@@ -70,6 +72,7 @@ konflux:
       - nmstate-devel
       - nmstate-libs
       - perl-Git
+      - postgresql-server
 okd:
   enabled_repos:
   - rhel-9-appstream-rpms


### PR DESCRIPTION
Add missing glibc packages and postgresql-server to the ose-agent-installer-api-server image configuration for OpenShift 4.22.

This is a backport of PR #10457 from openshift-5.0 to openshift-4.22.

Changes:
- Add glibc-common
- Add glibc-minimal-langpack
- Add postgresql-server
