### PR TITLE
Revert "mtc-1.8: Freeze automation due to known build failures"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: true
+freeze_automation: false
 name: mtc-1.8
 csv_namespace: rhmtc
 product: rhmtc


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#10049

Depends-On: https://github.com/openshift-eng/art-tools/pull/2798