### PR TITLE
ART-18505: Remove unused corepack configuration from console

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -49,8 +49,3 @@ konflux:
     aarch64: linux-d160-m2xlarge/arm64
   cachito:
     mode: removal
-  cachi2:
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/github/nodejs/corepack/releases/download/v0.34.6/corepack.tgz
-        filename: corepack-v0.34.6.tgz


### PR DESCRIPTION
The upstream console Dockerfile already uses direct yarn invocation:
```
node .yarn/releases/yarn-4.12.0.cjs install --immutable
```

Removed:
- Dead Dockerfile modification trying to replace non-existent corepack pattern
- Unused corepack download from cachi2 artifact_lockfile
- Entire cachi2 section (now empty without corepack)

[openshift-enterprise-console-container-v5.0.0-202605081254.p2.g2291108.assembly.test.el9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=openshift-enterprise-console-container-v5.0.0-202605081254.p2.g2291108.assembly.test.el9&record_id=e95bf22e-03a5-aecf-7a5f-b2b282f94c43&group=openshift-5.0&outcome=success&type=image) proves that corepack is actually not needed for builds. We can remove the policy exception requestead in [konflux-release-data MR#17755](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/17755/)

