### PR TITLE
ART-18505: Remove unused corepack configuration from console (4.23)

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -45,8 +45,3 @@ konflux:
     aarch64: linux-d160-m2xlarge/arm64
   cachito:
     mode: removal
-  cachi2:
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/github/nodejs/corepack/releases/download/v0.34.6/corepack.tgz
-        filename: corepack-v0.34.6.tgz


### PR DESCRIPTION
The upstream console Dockerfile already uses direct yarn invocation:
```
  node .yarn/releases/yarn-4.12.0.cjs install --immutable
```

Removed:
- Unused corepack download from cachi2 artifact_lockfile
- Entire cachi2 section (now empty without corepack)

PLR: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-23/pipelineruns/ose-4-23-openshift-enterprise-console-67698