### PR TITLE
ART-18422: Pin imagebuilder to v1.2.20 for ci-openshift-build-root-extra.rhel9 (4.16)

### DIFF
--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile.extra
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile.extra
@@ -50,7 +50,7 @@ RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     go install golang.org/x/lint/golint@latest && \
     go install gotest.tools/gotestsum@v1.12.2 && \
     go install github.com/openshift/release/tools/gotest2junit@latest && \
-    go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
+    go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.20 && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \
     mkdir $GOPATH/bin && \


### PR DESCRIPTION
## Summary

Pin `openshift/imagebuilder` to v1.2.20 in the CI build root extra Dockerfile.
imagebuilder v1.2.21 bumped its `go.mod` to require Go >= 1.25.5, but openshift-4.16
uses Go 1.23.10 with `GOTOOLCHAIN=local`, causing all builds to fail.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ci-openshift-build-root-extra.rhel9$&group=openshift-4.16&assembly=stream&engine=konflux&dateRange=2026-02-10+to+2026-05-11&outcome=success&outcome=failure

## Analysis

The build fails at:
```
go: github.com/openshift/imagebuilder/cmd/imagebuilder@latest:
  github.com/openshift/imagebuilder@v1.2.21 requires go >= 1.25.5
  (running go 1.23.10; GOTOOLCHAIN=local)
```

v1.2.20 requires Go 1.23.3 (compatible with Go 1.23.10 in the 4.16 build env).

## Changes

- Pin `imagebuilder@latest` to `imagebuilder@v1.2.20` in `ci_images/rhel-9/ci-openshift-build-root/Dockerfile.extra`

Generated with [Claude Code](https://claude.com/claude-code)