### PR TITLE
ART-18325: Add missing non-final layer RPMs for ose-agent-installer-utils (4.23)

### DIFF
--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -46,19 +46,24 @@ konflux:
       - gcc
       - gcc-c++
       - gcc-plugin-annobin
-      - libstdc++-devel
       - glibc
-      - glibc-headers
       - glibc-devel
+      - glibc-gconv-extra
+      - glibc-headers
       - kernel-headers
       - libasan
       - libatomic
+      - libgcc
       - libgomp
       - libmpc
+      - libstdc++
+      - libstdc++-devel
       - libubsan
       - libxcrypt-devel
       - make
+      - NetworkManager-config-server
       - nmstate-devel
+      - nmstate-libs
 okd:
   enabled_repos:
   - rhel-9-appstream-rpms


### PR DESCRIPTION
## Summary

Add missing RPMs to `konflux.cachi2.lockfile.rpms` for the non-final (builder) stage of ose-agent-installer-utils. The hermetic build fails in stage [1/2] with `Unable to find a match: nmstate-libs` because several packages installed in the builder stage are not listed in the lockfile config.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ose-agent-installer-utils$&group=openshift-4.23&assembly=stream&engine=konflux&dateRange=2026-02-10+to+2026-05-11&outcome=success&outcome=failure

## Analysis

The SBOM only captures RPMs from the final Dockerfile stage. Packages installed in non-final stages must be explicitly listed in `konflux.cachi2.lockfile.rpms`. The openshift-4.22 branch already has the complete list; this PR aligns 4.23 with 4.22.

## Changes

Added to `konflux.cachi2.lockfile.rpms`:
- `glibc-gconv-extra`
- `libgcc`
- `libstdc++`
- `NetworkManager-config-server`
- `nmstate-libs`

Also sorted existing entries alphabetically for consistency.

Generated with [Claude Code](https://claude.com/claude-code)