### PR TITLE
ART-18505 [4.15]: Remove corepack dependency from console build

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -7,17 +7,12 @@ content:
       url: git@github.com:openshift-priv/console.git
       web: https://github.com/openshift/console
     modifications:
-    - action: replace
-      match: "./artifacts/corepack-${COREPACK_VERSION}.tar.gz"
-      replacement: "/cachi2/output/deps/generic/corepack-v${COREPACK_VERSION}.tgz"
-    - action: replace
-      match: "RUN container-entrypoint ./build-frontend.sh"
-      replacement: |
-        WORKDIR frontend
-        RUN node .yarn/releases/yarn-4.12.0.cjs install --immutable && \
-            node .yarn/releases/yarn-4.12.0.cjs build
     - action: command
-      command: ["sh", "-c", "echo '\nsupportedArchitectures:\n  os: [\"linux\"]\n  cpu: [\"x64\", \"arm64\", \"s390x\", \"ppc64\"]' >> frontend/.yarnrc.yml"]
+      command:
+      - sh
+      - -c
+      - "echo '\nsupportedArchitectures:\n  os: [\"linux\"]\n  cpu: [\"x64\", \"arm64\"\
+        , \"s390x\", \"ppc64\"]' >> frontend/.yarnrc.yml"
     pkg_managers:
     - yarn
 cachito:
@@ -29,7 +24,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
   component: openshift-enterprise-console-container
 delivery:
-  # Maps to honeybadger repo_name
   repo_name: ose-console
   delivery_repo_names:
   - openshift4/ose-console
@@ -41,7 +35,8 @@ from:
   member: openshift-enterprise-base
 labels:
   License: GPLv2+
-  io.k8s.description: This is a component of OpenShift Container Platform and provides a web console.
+  io.k8s.description: This is a component of OpenShift Container Platform and provides
+    a web console.
   io.k8s.display-name: OpenShift Console
   io.openshift.tags: openshift,console
 name: openshift/ose-console
@@ -54,8 +49,3 @@ konflux:
     aarch64: linux-d160-m2xlarge/arm64
   cachito:
     mode: removal
-  cachi2:
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/github/nodejs/corepack/releases/download/v0.34.6/corepack.tgz
-        filename: corepack-v0.34.6.tgz


### PR DESCRIPTION
This PR removes the corepack dependency from the console build configuration.

Corepack is a Node.js binary manager that has been causing build issues and is no longer needed for our build process.

## Changes
- Removed corepack from console image build dependencies

## Test
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/34204/