### PR TITLE
ART-18521: switch networking-console-plugin pkg_managers from yarn to npm (4.18)

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -13,7 +13,7 @@ content:
       match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
       replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     pkg_managers:
-    - yarn
+    - npm
     okd_alignment:
       dockerfile: Dockerfile
 distgit:


### PR DESCRIPTION
## Summary

Switch `pkg_managers` from `yarn` to `npm` for networking-console-plugin on openshift-4.18.

The upstream source uses `package-lock.json` (npm), not `yarn.lock`. The hermeto/yarn
prefetch handler fails because it cannot determine the yarn version — there is no
`packageManager` in `package.json` and no `.yarnrc.yml` in the repo.

This aligns with openshift-4.20 which already uses `pkg_managers: [npm]` and builds
successfully.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^networking-console-plugin$&group=openshift-4.18&assembly=stream&engine=konflux&outcome=failure

## Analysis

The hermeto prefetch step fails with:
```
ERROR PackageRejected: Unable to determine the yarn version to use to process the request
Ensure that either yarnPath is defined in .yarnrc.yml or that packageManager is defined in package.json
```

The upstream repo has `package-lock.json` (npm) across all branches (4.18, 4.19, 4.20).
The 4.20 ocp-build-data config already uses `pkg_managers: [npm]` and builds fine.

## Changes

- Changed `content.source.pkg_managers` from `[yarn]` to `[npm]`

Generated with [Claude Code](https://claude.com/claude-code)