### PR TITLE
ART-18353: switch networking-console-plugin pkg_managers from yarn to npm (4.19)

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -13,7 +13,7 @@ content:
       match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
       replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     pkg_managers:
-    - yarn
+    - npm
     okd_alignment:
       dockerfile: Dockerfile
 distgit:


### PR DESCRIPTION
## Summary

Switch `pkg_managers` from `yarn` to `npm` for networking-console-plugin on openshift-4.19.

Same fix as PR for [ART-18521](https://redhat.atlassian.net/browse/ART-18521) (openshift-4.18). The upstream source uses `package-lock.json`
(npm), not `yarn.lock`. The hermeto/yarn prefetch handler fails because it cannot determine
the yarn version. This aligns with openshift-4.20 which already uses `pkg_managers: [npm]`.

**Failing build:** https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^networking-console-plugin$&group=openshift-4.19&assembly=stream&engine=konflux&outcome=failure

## Analysis

The hermeto prefetch step fails with:
```
ERROR PackageRejected: Unable to determine the yarn version to use to process the request
```

The upstream repo has `package-lock.json` (npm) across all branches. The 4.20 config
already uses `pkg_managers: [npm]` and builds fine.

## Changes

- Changed `content.source.pkg_managers` from `[yarn]` to `[npm]`

Generated with [Claude Code](https://claude.com/claude-code)