### PR TITLE
[openshift-4.12]: Bump golang 1.22 builder streams to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -87,5 +87,5 @@ nodejs:
 rhel-9-golang-1-22:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.22.12-202602122125.g388ceb2.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.22.12-202605111509.p2.g6a298d3.el9
 


### PR DESCRIPTION
## Summary
Updates golang **1.22** builder `image:` references in `streams.yml` to the rebuilt **openshift-golang-builder** tags under `registry.redhat.io/openshift/art-images-base`.

## Images
- **el9:** `openshift-golang-builder-container-v1.22.12-202605111509.p2.g6a298d3.el9`
- **el8:** `openshift-golang-builder-container-v1.22.12-202605111509.p2.g3a22db8.el8` (only where `rhel-8-golang` carries Go 1.22 under `GO_LATEST`)

## Scope
Primary golang streams only (`rhel-9-golang` / `rhel-8-golang` and standalone `rhel-9-golang-1-22` where applicable). IBM/partner mirrors are unchanged.

Related: *(add ART ticket if needed)*