### PR TITLE
ART-16004 [openshift-4.18]: Bump golang 1.22 builder streams to registry.redhat.io

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.22.12-202603181325.p2.g388ceb2.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.22.12-202605111509.p2.g6a298d3.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -33,7 +33,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.22.12-202603181325.p2.g3a22db8.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.22.12-202605111509.p2.g3a22db8.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.

--- a/streams.yml
+++ b/streams.yml
@@ -46,7 +46,7 @@ rhel-8-golang:
 rhel-9-golang-1.23:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202603131509.p2.gd0321dd.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202605111554.p2.gbf0298b.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -59,7 +59,7 @@ rhel-9-golang-1.23:
 rhel-8-golang-1.23:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202603131509.p2.gdc331c7.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202605111554.p2.gdc331c7.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.


### PR DESCRIPTION
## Summary
Updates golang **1.22** builder `image:` references in `streams.yml` to the rebuilt **openshift-golang-builder** tags under `registry.redhat.io/openshift/art-images-base`.

## Images
- **el9:** `openshift-golang-builder-container-v1.22.12-202605111509.p2.g6a298d3.el9`
- **el8:** `openshift-golang-builder-container-v1.22.12-202605111509.p2.g3a22db8.el8` (only where `rhel-8-golang` carries Go 1.22 under `GO_LATEST`)

## Scope
Primary golang streams only (`rhel-9-golang` / `rhel-8-golang` and standalone `rhel-9-golang-1-22` where applicable). IBM/partner mirrors are unchanged.

Related: *(add ART ticket if needed)*