### PR TITLE
[openshift-4.19]: Bump golang 1.23 builder streams (202605111554)

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202604271455.p2.gbf0298b.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202605111554.p2.gbf0298b.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202604271455.p2.gdc331c7.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202605111554.p2.gdc331c7.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
## Summary
Retags **openshift-golang-builder** **v1.23.10** `image:` on primary streams **`rhel-9-golang`** and **`rhel-8-golang`** (`GO_LATEST`) from build **`202604271455`** to **`202605111554`**.

**Partner / IBM mirror streams** (`partner-rhel-{8,9}-golang-1.23`) are intentionally **unchanged** per ART scope.

## Scope
Two `image:` lines in `streams.yml`; upstream CI reconciliation fields unchanged.

Related: *(ART ticket if needed)*