### PR TITLE
drop bug OCPBUGS-84779 as it does not belong in release 4.12.90

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -70,6 +70,8 @@ releases:
       issues:
         include:
           - id: OCPBUGS-85297
+        exclude:
+          - id: OCPBUGS-84779
   4.12.89:
     assembly:
       type: standard


### PR DESCRIPTION
drop bug OCPBUGS-84779 as it does not belong in release 4.12.90
It was showing up in the advisory 