### PR TITLE
CORENET-6909: disable art bumps for ovnk 4.21

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -11,10 +11,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ovn-kubernetes.git
       web: https://github.com/openshift/ovn-kubernetes
-    ci_alignment:
-      streams_prs:
-        ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
     pkg_managers:
     - gomod
 distgit:

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -7,10 +7,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ovn-kubernetes.git
       web: https://github.com/openshift/ovn-kubernetes
-    ci_alignment:
-      streams_prs:
-        ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
     pkg_managers: []
 distgit:
   component: ose-ovn-kubernetes-base-container

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -10,10 +10,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ovn-kubernetes.git
       web: https://github.com/openshift/ovn-kubernetes
-    ci_alignment:
-      streams_prs:
-        ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
     pkg_managers:
     - gomod
 distgit:


### PR DESCRIPTION
openshift/ovn-kubernetes will be doing a full code sync from 4.23/5.0 to 4.22 and to 4.21 so we no longer need the automated bumps for 4.21