### PR TITLE
ART-18719: Pin imagebuilder to v1.2.20 for ci-openshift-build-root (4.21)

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -54,7 +54,7 @@ RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     go install golang.org/x/lint/golint@latest && \
     go install gotest.tools/gotestsum@latest && \
     go install github.com/openshift/release/tools/gotest2junit@latest && \
-    go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
+    go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.20 && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \
     mkdir $GOPATH/bin && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -54,7 +54,7 @@ RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     go install golang.org/x/lint/golint@latest && \
     go install gotest.tools/gotestsum@latest && \
     go install github.com/openshift/release/tools/gotest2junit@latest && \
-    go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
+    go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.20 && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \
     mkdir $GOPATH/bin && \


### PR DESCRIPTION
## Summary

Pin `imagebuilder` from `@latest` to `@v1.2.20` in ci-openshift-build-root Dockerfiles (rhel8 and rhel9).

**Failing builds:**
- [ci-openshift-build-root-latest.rhel9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ci-openshift-build-root-latest.rhel9$&group=openshift-4.21&assembly=stream&engine=konflux&dateRange=2026-02-12+to+2026-05-13&outcome=success&outcome=failure) ([ART-18719](https://redhat.atlassian.net/browse/ART-18719))
- [ci-openshift-build-root-latest.rhel8](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ci-openshift-build-root-latest.rhel8$&group=openshift-4.21&assembly=stream&engine=konflux&dateRange=2026-02-12+to+2026-05-13&outcome=success&outcome=failure) ([ART-18718](https://redhat.atlassian.net/browse/ART-18718))

## Analysis

`imagebuilder` v1.2.21 bumped its `go.mod` to require Go >= 1.25.5, but the builder image provides Go 1.24.13. The Dockerfile uses `go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest`, which resolves to v1.2.21 and fails with:

```
go: github.com/openshift/imagebuilder@v1.2.21 requires go >= 1.25.5 (running go 1.24.13; GOTOOLCHAIN=local)
```

v1.2.20 requires Go 1.23.3 which is compatible.

## Changes

- `ci_images/rhel-8/ci-openshift-build-root/Dockerfile`: `@latest` → `@v1.2.20`
- `ci_images/rhel-9/ci-openshift-build-root/Dockerfile`: `@latest` → `@v1.2.20`

Generated with [Claude Code](https://claude.com/claude-code)