### PR TITLE
[openshift-4.13] Enable ci_build_root sync for ose-network-interface-bond-cni

### DIFF
--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -6,6 +6,10 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/bond-cni.git
       web: https://github.com/openshift/bond-cni
+    ci_alignment:
+      streams_prs:
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
This PR is an effort to bring on a consistency between the CI and build images used by OpenShift components.

https://github.com/openshift/release/pull/79098 will enable the component's CI to check for its branch specific .ci-operator.yaml for the build root image to use for testing.