### PR TITLE
Exclude OCPBUGS-82076 from 4.21.16

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -81,6 +81,10 @@ releases:
           component: ose-tools
         - code: CONFLICTING_INHERITED_DEPENDENCY
           component: rhcos
+      issues:
+        exclude:
+          - id: OCPBUGS-82076
+            # why: Bug looks like CVE tracker but is missing required metadata. We don't ship this image.
       members:
         rpms: []
         images: []


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED