### PR TITLE
include OCPBUGS-76196 and OCPBUGS-82024 in release 4.17.54 for prepare-release

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -36,6 +36,10 @@ releases:
             aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:98142eeedc28cee4578a93b6ef9b679d863de6651200273502a19190136801b6
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:898d526816064ebf7c7133d194a90734c25b0dc5256936dd8420bc6365fbf96e
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7a648ecaa22e51fd5a0ce7fe2683401c52b34bbf9691c90db8bc8653c214f0f9
+      issues:
+        include:
+          - id: OCPBUGS-76196
+          - id: OCPBUGS-82024
       members:
         rpms: []
         images: []


### PR DESCRIPTION
prepare release for 4.17.54 failed with the error:
_ValueError: No attached builds found in advisories for tracker bugs (bug, package): [('OCPBUGS-76196', 'ignition'), ('OCPBUGS-82024', 'ovn24.03')]. Either attach builds or explicitly include/exclude the bug ids in the assembly definition_

However, the builds that fixed these 2 issues are included in the nightly so this PR includes the 2 Jiras.