### PR TITLE
exclude OCPBUGS-82024 in release 4.17.54 for prepare-release

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -39,7 +39,9 @@ releases:
       issues:
         include:
           - id: OCPBUGS-76196
+        exclude:
           - id: OCPBUGS-82024
+            # why: "RPM tracker bug (ovn24.03) cannot be translated by attach-cve-flaws in Konflux mode. RPM fix is already on the RPM advisory."
       members:
         rpms: []
         images: []


### PR DESCRIPTION
Prepare release 4.17.54:
Fix for ValueError: Component ovn24.03 could not be translated 

exclude OCPBUGS-82024
RPM tracker bug (ovn24.03) cannot be translated by attach-cve-flaws in Konflux mode. RPM fix is already on the RPM advisory.