### PR TITLE
Add missing lockfile RPMs for dpu-marvell-cp-agent 4.22

### DIFF
--- a/images/dpu-marvell-cp-agent.yml
+++ b/images/dpu-marvell-cp-agent.yml
@@ -66,6 +66,8 @@ konflux:
       - elfutils-libs
       - emacs-filesystem
       - expat
+      - file
+      - file-libs
       - filesystem
       - findutils
       - fonts-srpm-macros
@@ -73,6 +75,7 @@ konflux:
       - gcc
       - gcc-c++
       - gcc-plugin-annobin
+      - gcc-toolset-15-binutils
       - gcc-toolset-15-gcc
       - gcc-toolset-15-gcc-c++
       - gcc-toolset-15-libstdc++-devel
@@ -127,6 +130,7 @@ konflux:
       - libksba
       - libmount
       - libmount-devel
+      - librepo
       - libnghttp2
       - libomp
       - libomp-devel


### PR DESCRIPTION
[Test seed-lockfile run](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/397/console)
[Hermetic Konflux build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-dpu-marvell-cp-agent-bv249)