### PR TITLE
ART-17449 Switch go latest to 1.26

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -23,8 +23,8 @@ vars:
   #               aliases:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
-  GO_LATEST: "1.25"
-  GO_EXTRA: "1.26"
+  GO_LATEST: "1.26"
+  GO_EXTRA: "1.25"
 
 compliance:
   rpm_shim:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ART-17449

TODO: remove 1.25 when no longer in use

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED