### PR TITLE
Add acm-2.16 branch content: group.yml, streams.yml, images/*.yml

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,82 @@
+# DECISIONS.md — ACM 2.16 ocp-build-data Branch
+
+Product decisions and rationale for the `acm-2.16` branch configuration.
+Created as part of JIRA ticket [HYPBLD-847](https://redhat.atlassian.net/browse/HYPBLD-847).
+
+## Product Identity
+
+- **Decision**: `product: acm`, `name: acm-2.16`, `csv_namespace: open-cluster-management`
+- **Rationale**: Matches ART naming conventions (short lowercase names like `mta`, `aap`). Requires a corresponding entry in `PRODUCT_NAMESPACE_MAP` in art-tools (PR pending).
+- **Revisit**: When the art-tools PR is submitted and merged.
+
+## OCP Version Alignment
+
+- **Decision**: `MAJOR: 4`, `MINOR: 21` (OCP 4.21 infrastructure)
+- **Rationale**: ACM 2.16 aligns with OCP 4.21 per the product version alignment table. The distgit branch `rhaos-4.21-rhel-9` is shared Brew infrastructure tied to OCP releases. All layered products use OCP version numbers for MAJOR.MINOR.
+- **Source**: `acm-redhat-operators-config.yaml`, ART OLM Bundle docs.
+
+## OCP Target Versions
+
+- **Decision**: `OCP_TARGET_VERSIONS: ["4.18", "4.19", "4.20", "4.21", "4.22"]`
+- **Rationale**: Derived from `acm-mce-operator-catalogs/config/acm-redhat-operators-config.yaml` which defines ACM 2.16 catalogs.
+- **Revisit**: If catalog targets change before GA.
+
+## RHEL Version and Repos Configuration
+
+- **Decision**: RHEL 9.6 E4S, old-style inline repos in `group.yml`
+- **Rationale**: E4S matches OCP 4.21 infrastructure. Old-style inline repos used because no layered product has adopted new-style `repos/` folder yet (logging-6.5, mta-8.1, oadp-1.5 all use inline). ART ai-helper tooling does not mandate a specific style.
+- **Revisit**: If ART requests migration to `repos/` folder pattern.
+
+## Network Mode
+
+- **Decision**: `network_mode: open` (non-hermetic)
+- **Rationale**: Per ART guidance (May 12 meeting): "Get images building non-hermetic first, then hermetic, then tackle bundles."
+- **Revisit**: After initial builds succeed, migrate to `network_mode: hermetic`.
+
+## Git Source URLs
+
+- **Decision**: Use `git@github.com:stolostron/<repo>.git` directly (no openshift-priv mirrors)
+- **Rationale**: ACM repos are already public under `github.com/stolostron/`. No private mirrors exist. Verified: `grep -r "openshift-priv"` in KRD ACM tenant returns zero hits.
+- **Consequence**: `public_upstreams` section omitted from `group.yml`.
+
+## Distgit Component Naming
+
+- **Decision**: `acm-<component>-container` pattern for all ACM components
+- **Rationale**: Consistent with other layered products (`mta-*-container`, `ose-*-container`). Internal build infrastructure naming decided by HCM Build team.
+
+## Delivery Repo Names
+
+- **Decision**: `rhacm2/<component>-rhel9` pattern
+- **Rationale**: Matches existing ACM images in `registry.redhat.io/rhacm2/` namespace. Confirmed from ACM CSV OPERAND_IMAGE values and KRD ReleasePlanAdmission configs.
+
+## RHEL 8 Builders
+
+- **Decision**: `acm-cli` and `multicluster-operators-subscription` include both `rhel-9-golang` and `rhel-8-golang` builders
+- **Rationale**: Product requirement — ACM customers run on both RHEL 8 and RHEL 9 clusters. These components ship binaries for both platforms. ART supports this pattern (see OCP's `egress-router-cni.yml`).
+
+## Console Node.js Version
+
+- **Decision**: `rhel-9-nodejs-20` stream (Node.js 20)
+- **Rationale**: The `release-2.16` branch `Containerfile.acm.konflux` uses `nodejs-20-minimal`. Version-specific answers use the release-2.16 branch as the source of truth.
+
+## Bundle Component
+
+- **Decision**: `acm-operator-bundle` excluded from `images/*.yml`
+- **Rationale**: Per ART guidance (May 12 meeting): "Don't try to solve bundle complexity upfront." ACM's bundle architecture (separate repos) is incompatible with ART's standard `update-csv` flow.
+- **Revisit**: After images are building successfully.
+
+## Dependents (MCE→ACM ordering)
+
+- **Decision**: No `dependents:` field in any image config
+- **Rationale**: The `dependents` field only resolves within the same ocp-build-data branch. MCE and ACM are separate branches (`mce-2.11`, `acm-2.16`), so this field cannot express cross-product dependencies. OLM handles install-time ordering via `spec.dependencies` in the bundle CSV.
+
+## Owners
+
+- **Decision**: `acm-cicd@redhat.com` as temporary owner for all images
+- **Rationale**: HCM Build team DL used during bootstrap. ACM org should designate permanent owners.
+- **Revisit**: When ACM team provides long-term ownership contacts.
+
+## MR Approvers
+
+- **Decision**: Omitted from `group.yml`
+- **Rationale**: Optional field. Many products (OCP, AAP, Serverless) don't use it. Can be added later if ACM wants QE/DOCS sign-off on FBC release MRs.

--- a/group.yml
+++ b/group.yml
@@ -1,0 +1,81 @@
+freeze_automation: false
+name: acm-2.16
+csv_namespace: open-cluster-management
+product: acm
+version: 2.16.0
+
+vars:
+  GO_LATEST: "1.25"
+  GO_EXTRA: "1.25"
+  MAJOR: 4
+  MINOR: 21
+
+OCP_TARGET_VERSIONS: [
+  "4.18",
+  "4.19",
+  "4.20",
+  "4.21",
+  "4.22",
+]
+
+arches:
+- x86_64
+- aarch64
+- ppc64le
+- s390x
+
+operator_image_ref_mode: manifest-list
+
+konflux:
+  arches:
+  - x86_64
+  - aarch64
+  - ppc64le
+  - s390x
+  cachi2:
+    enabled: true
+    gomod_version_patch: true
+  sast:
+    enabled: true
+  network_mode: open
+
+assemblies:
+  enabled: true
+
+branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+
+urls:
+  brewhub: https://brewhub.engineering.redhat.com/brewhub
+  brew_image_host: registry-proxy.engineering.redhat.com
+  brew_image_namespace: rh-osbs
+
+repos:
+  rhel-9-baseos-rpms:
+    conf:
+      baseurl:
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
+    content_set:
+      default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6
+      aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_6
+      ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_6
+      s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_6
+    reposync:
+      enabled: false
+
+  rhel-9-appstream-rpms:
+    conf:
+      baseurl:
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
+    content_set:
+      default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_6
+      aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_6
+      ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_6
+      s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
+    reposync:
+      enabled: false

--- a/images/acm-cli.yml
+++ b/images/acm-cli.yml
@@ -1,0 +1,26 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/acm-cli.git
+      web: https://github.com/stolostron/acm-cli
+distgit:
+  component: acm-cli-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/acm-cli-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+    - stream: rhel-8-golang
+  stream: rhel9
+name: rhacm2/acm-cli-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-cli-container

--- a/images/cert-policy-controller.yml
+++ b/images/cert-policy-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/cert-policy-controller.git
+      web: https://github.com/stolostron/cert-policy-controller
+distgit:
+  component: acm-cert-policy-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/cert-policy-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/cert-policy-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-cert-policy-controller-container

--- a/images/cluster-backup-controller.yml
+++ b/images/cluster-backup-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/cluster-backup-operator.git
+      web: https://github.com/stolostron/cluster-backup-operator
+distgit:
+  component: acm-cluster-backup-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/cluster-backup-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/cluster-backup-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-cluster-backup-controller-container

--- a/images/cluster-permission.yml
+++ b/images/cluster-permission.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/cluster-permission.git
+      web: https://github.com/stolostron/cluster-permission
+distgit:
+  component: acm-cluster-permission-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/cluster-permission-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/cluster-permission-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-cluster-permission-container

--- a/images/config-policy-controller.yml
+++ b/images/config-policy-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/config-policy-controller.git
+      web: https://github.com/stolostron/config-policy-controller
+distgit:
+  component: acm-config-policy-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/config-policy-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/config-policy-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-config-policy-controller-container

--- a/images/console.yml
+++ b/images/console.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/console.git
+      web: https://github.com/stolostron/console
+distgit:
+  component: acm-console-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/console-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-nodejs-20
+  stream: rhel9
+name: rhacm2/console-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-console-container

--- a/images/endpoint-monitoring-operator.yml
+++ b/images/endpoint-monitoring-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: operators/endpointmetrics/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicluster-observability-operator.git
+      web: https://github.com/stolostron/multicluster-observability-operator
+distgit:
+  component: acm-endpoint-monitoring-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/endpoint-monitoring-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/endpoint-monitoring-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-endpoint-monitoring-operator-container

--- a/images/governance-policy-addon-controller.yml
+++ b/images/governance-policy-addon-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/governance-policy-addon-controller.git
+      web: https://github.com/stolostron/governance-policy-addon-controller
+distgit:
+  component: acm-governance-policy-addon-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/governance-policy-addon-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/governance-policy-addon-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-governance-policy-addon-controller-container

--- a/images/governance-policy-framework-addon.yml
+++ b/images/governance-policy-framework-addon.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/governance-policy-framework-addon.git
+      web: https://github.com/stolostron/governance-policy-framework-addon
+distgit:
+  component: acm-governance-policy-framework-addon-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/governance-policy-framework-addon-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/governance-policy-framework-addon-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-governance-policy-framework-addon-container

--- a/images/governance-policy-propagator.yml
+++ b/images/governance-policy-propagator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/governance-policy-propagator.git
+      web: https://github.com/stolostron/governance-policy-propagator
+distgit:
+  component: acm-governance-policy-propagator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/governance-policy-propagator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/governance-policy-propagator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-governance-policy-propagator-container

--- a/images/grafana-dashboard-loader.yml
+++ b/images/grafana-dashboard-loader.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: loaders/dashboards/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicluster-observability-operator.git
+      web: https://github.com/stolostron/multicluster-observability-operator
+distgit:
+  component: acm-grafana-dashboard-loader-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/grafana-dashboard-loader-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/grafana-dashboard-loader-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-grafana-dashboard-loader-container

--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/grafana.git
+      web: https://github.com/stolostron/grafana
+distgit:
+  component: acm-grafana-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/grafana-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/grafana-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-grafana-container

--- a/images/insights-client.yml
+++ b/images/insights-client.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/insights-client.git
+      web: https://github.com/stolostron/insights-client
+distgit:
+  component: acm-insights-client-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/insights-client-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/insights-client-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-insights-client-container

--- a/images/insights-metrics.yml
+++ b/images/insights-metrics.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/insights-metrics.git
+      web: https://github.com/stolostron/insights-metrics
+distgit:
+  component: acm-insights-metrics-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/insights-metrics-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/insights-metrics-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-insights-metrics-container

--- a/images/klusterlet-addon-controller.yml
+++ b/images/klusterlet-addon-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/klusterlet-addon-controller.git
+      web: https://github.com/stolostron/klusterlet-addon-controller
+distgit:
+  component: acm-klusterlet-addon-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/klusterlet-addon-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/klusterlet-addon-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-klusterlet-addon-controller-container

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/kube-rbac-proxy.git
+      web: https://github.com/stolostron/kube-rbac-proxy
+distgit:
+  component: acm-kube-rbac-proxy-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/kube-rbac-proxy-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/kube-rbac-proxy-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-kube-rbac-proxy-container

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/kube-state-metrics.git
+      web: https://github.com/stolostron/kube-state-metrics
+distgit:
+  component: acm-kube-state-metrics-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/kube-state-metrics-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/kube-state-metrics-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-kube-state-metrics-container

--- a/images/memcached-exporter.yml
+++ b/images/memcached-exporter.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/memcached_exporter.git
+      web: https://github.com/stolostron/memcached_exporter
+distgit:
+  component: acm-memcached-exporter-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/memcached-exporter-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/memcached-exporter-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-memcached-exporter-container

--- a/images/metrics-collector.yml
+++ b/images/metrics-collector.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: collectors/metrics/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicluster-observability-operator.git
+      web: https://github.com/stolostron/multicluster-observability-operator
+distgit:
+  component: acm-metrics-collector-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/metrics-collector-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/metrics-collector-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-metrics-collector-container

--- a/images/mtv-integrations.yml
+++ b/images/mtv-integrations.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/mtv-integrations.git
+      web: https://github.com/stolostron/mtv-integrations
+distgit:
+  component: acm-mtv-integrations-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/mtv-integrations-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/mtv-integrations-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-mtv-integrations-container

--- a/images/multicloud-integrations.yml
+++ b/images/multicloud-integrations.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicloud-integrations.git
+      web: https://github.com/stolostron/multicloud-integrations
+distgit:
+  component: acm-multicloud-integrations-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/multicloud-integrations-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/multicloud-integrations-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-multicloud-integrations-container

--- a/images/multicluster-observability-addon.yml
+++ b/images/multicluster-observability-addon.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicluster-observability-addon.git
+      web: https://github.com/stolostron/multicluster-observability-addon
+distgit:
+  component: acm-multicluster-observability-addon-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/multicluster-observability-addon-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/multicluster-observability-addon-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-multicluster-observability-addon-container

--- a/images/multicluster-observability-operator.yml
+++ b/images/multicluster-observability-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: operators/multiclusterobservability/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicluster-observability-operator.git
+      web: https://github.com/stolostron/multicluster-observability-operator
+distgit:
+  component: acm-multicluster-observability-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/multicluster-observability-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/multicluster-observability-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-multicluster-observability-operator-container

--- a/images/multicluster-operators-application.yml
+++ b/images/multicluster-operators-application.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicloud-operators-application.git
+      web: https://github.com/stolostron/multicloud-operators-application
+distgit:
+  component: acm-multicluster-operators-application-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/multicluster-operators-application-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/multicluster-operators-application-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-multicluster-operators-application-container

--- a/images/multicluster-operators-channel.yml
+++ b/images/multicluster-operators-channel.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicloud-operators-channel.git
+      web: https://github.com/stolostron/multicloud-operators-channel
+distgit:
+  component: acm-multicluster-operators-channel-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/multicluster-operators-channel-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/multicluster-operators-channel-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-multicluster-operators-channel-container

--- a/images/multicluster-operators-subscription.yml
+++ b/images/multicluster-operators-subscription.yml
@@ -1,0 +1,26 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicloud-operators-subscription.git
+      web: https://github.com/stolostron/multicloud-operators-subscription
+distgit:
+  component: acm-multicluster-operators-subscription-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/multicluster-operators-subscription-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+    - stream: rhel-8-golang
+  stream: rhel9
+name: rhacm2/multicluster-operators-subscription-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-multicluster-operators-subscription-container

--- a/images/multicluster-role-assignment.yml
+++ b/images/multicluster-role-assignment.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicluster-role-assignment.git
+      web: https://github.com/stolostron/multicluster-role-assignment
+distgit:
+  component: acm-multicluster-role-assignment-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/multicluster-role-assignment-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/multicluster-role-assignment-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-multicluster-role-assignment-container

--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -1,0 +1,28 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multiclusterhub-operator.git
+      web: https://github.com/stolostron/multiclusterhub-operator
+distgit:
+  component: acm-multiclusterhub-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/multiclusterhub-operator-rhel9
+for_payload: false
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/multiclusterhub-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-multiclusterhub-operator-container

--- a/images/must-gather.yml
+++ b/images/must-gather.yml
@@ -1,0 +1,26 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/must-gather.git
+      web: https://github.com/stolostron/must-gather
+distgit:
+  component: acm-must-gather-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/must-gather-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: ose-cli
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/must-gather-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-must-gather-container

--- a/images/node-exporter.yml
+++ b/images/node-exporter.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/node-exporter.git
+      web: https://github.com/stolostron/node-exporter
+distgit:
+  component: acm-node-exporter-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/node-exporter-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/node-exporter-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-node-exporter-container

--- a/images/observatorium-operator.yml
+++ b/images/observatorium-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/observatorium-operator.git
+      web: https://github.com/stolostron/observatorium-operator
+distgit:
+  component: acm-observatorium-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/observatorium-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/observatorium-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-observatorium-operator-container

--- a/images/observatorium.yml
+++ b/images/observatorium.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/observatorium.git
+      web: https://github.com/stolostron/observatorium
+distgit:
+  component: acm-observatorium-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/observatorium-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/observatorium-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-observatorium-container

--- a/images/prometheus-alertmanager.yml
+++ b/images/prometheus-alertmanager.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/prometheus-alertmanager.git
+      web: https://github.com/stolostron/prometheus-alertmanager
+distgit:
+  component: acm-prometheus-alertmanager-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/prometheus-alertmanager-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/prometheus-alertmanager-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-prometheus-alertmanager-container

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: cmd/prometheus-config-reloader/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/prometheus-operator.git
+      web: https://github.com/stolostron/prometheus-operator
+distgit:
+  component: acm-prometheus-config-reloader-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/prometheus-config-reloader-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/prometheus-config-reloader-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-prometheus-config-reloader-container

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/prometheus-operator.git
+      web: https://github.com/stolostron/prometheus-operator
+distgit:
+  component: acm-prometheus-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/prometheus-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/prometheus-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-prometheus-operator-container

--- a/images/prometheus.yml
+++ b/images/prometheus.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/prometheus.git
+      web: https://github.com/stolostron/prometheus
+distgit:
+  component: acm-prometheus-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/prometheus-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/prometheus-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-prometheus-container

--- a/images/rbac-query-proxy.yml
+++ b/images/rbac-query-proxy.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: proxy/Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/multicluster-observability-operator.git
+      web: https://github.com/stolostron/multicluster-observability-operator
+distgit:
+  component: acm-rbac-query-proxy-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/rbac-query-proxy-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/rbac-query-proxy-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-rbac-query-proxy-container

--- a/images/search-collector.yml
+++ b/images/search-collector.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/search-collector.git
+      web: https://github.com/stolostron/search-collector
+distgit:
+  component: acm-search-collector-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/search-collector-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/search-collector-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-search-collector-container

--- a/images/search-indexer.yml
+++ b/images/search-indexer.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/search-indexer.git
+      web: https://github.com/stolostron/search-indexer
+distgit:
+  component: acm-search-indexer-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/search-indexer-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/search-indexer-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-search-indexer-container

--- a/images/search-v2-api.yml
+++ b/images/search-v2-api.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/search-v2-api.git
+      web: https://github.com/stolostron/search-v2-api
+distgit:
+  component: acm-search-v2-api-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/search-v2-api-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/search-v2-api-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-search-v2-api-container

--- a/images/search-v2-operator.yml
+++ b/images/search-v2-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/search-v2-operator.git
+      web: https://github.com/stolostron/search-v2-operator
+distgit:
+  component: acm-search-v2-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/search-v2-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/search-v2-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-search-v2-operator-container

--- a/images/siteconfig.yml
+++ b/images/siteconfig.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/siteconfig.git
+      web: https://github.com/stolostron/siteconfig
+distgit:
+  component: acm-siteconfig-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/siteconfig-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/siteconfig-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-siteconfig-container

--- a/images/submariner-addon.yml
+++ b/images/submariner-addon.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/submariner-addon.git
+      web: https://github.com/stolostron/submariner-addon
+distgit:
+  component: acm-submariner-addon-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/submariner-addon-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/submariner-addon-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-submariner-addon-container

--- a/images/thanos-receive-controller.yml
+++ b/images/thanos-receive-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/thanos-receive-controller.git
+      web: https://github.com/stolostron/thanos-receive-controller
+distgit:
+  component: acm-thanos-receive-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/thanos-receive-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/thanos-receive-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-thanos-receive-controller-container

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/thanos.git
+      web: https://github.com/stolostron/thanos
+distgit:
+  component: acm-thanos-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/thanos-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/thanos-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-thanos-container

--- a/images/volsync-addon-controller.yml
+++ b/images/volsync-addon-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:stolostron/volsync-addon-controller.git
+      web: https://github.com/stolostron/volsync-addon-controller
+distgit:
+  component: acm-volsync-addon-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/volsync-addon-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/volsync-addon-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-volsync-addon-controller-container

--- a/streams.yml
+++ b/streams.yml
@@ -1,0 +1,17 @@
+---
+rhel-9-golang:
+  aliases:
+    - rhel-9-golang-{GO_LATEST}
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604211249.p2.g50071d5.el9
+
+rhel-8-golang:
+  image: registry.redhat.io/ubi8/go-toolset:1.25
+
+rhel-9-nodejs-20:
+  image: registry.redhat.io/ubi9/nodejs-20-minimal@sha256:a22d96776233a2830007c406874935ace3244abf0581515fbd797d5b1f7b00d5
+
+ose-cli:
+  image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21
+
+rhel9:
+  image: registry.redhat.io/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00


### PR DESCRIPTION
[HYPBLD-847](https://redhat.atlassian.net/browse/HYPBLD-847): Create ocp-build-data configuration for ACM 2.16.

- group.yml: product identity (acm), OCP 4.21 alignment, Go 1.25, 4 architectures, RHEL 9.6 E4S repos, OCP_TARGET_VERSIONS 4.18-4.22
- streams.yml: rhel-9-golang, rhel-8-golang, rhel-9-nodejs-20, ose-cli, rhel9 (ubi-minimal) base image definitions
- images/*.yml: 46 ACM component configurations with stolostron source URLs, acm-*-container distgit naming, rhacm2/*-rhel9 delivery repos
- DECISIONS.md: rationale for all product decisions

Signed-off-by: Brian Smith <briansmi@redhat.com>