### PR TITLE
Disable base image release for golang-1.26 builder

### DIFF
--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -26,6 +26,7 @@ from:
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds
 
+# revert after https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/18026 merges
 base_image_release:
   enabled: false
 

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -26,6 +26,9 @@ from:
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds
 
+base_image_release:
+  enabled: false
+
 name: openshift/golang-builder
 
 owners:


### PR DESCRIPTION
## Summary
- Disables base image release workflow for the golang builder image on the `rhel-9-golang-1.26` branch by setting `base_image_release.enabled: false`

## Test plan
- [ ] Verify doozer correctly reads the config and skips base image release for this image

🤖 Generated with [Claude Code](https://claude.com/claude-code)