### PR TITLE
ART-17749 Update golang-builder image version to 1.26.2

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -38,7 +38,7 @@ rhel-8-golang:
 rhel-9-golang-extra:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.1-202604202010.p2.g43aca9a.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.2-202605152147.p2.gb1b9903.el9
   mirror: true
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 


### PR DESCRIPTION
This is a partial change as part of https://github.com/openshift-eng/ocp-build-data/pull/10631
