### PR TITLE
Fix microshift-bootc Konflux build: add pkg_managers to skip rpm prefetch

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -39,6 +39,10 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-fast-datapath-rpms
 - rhel-9-server-microshift-rpms
+konflux:
+  cachi2:
+    lockfile:
+      force: false
 name: openshift/microshift-bootc-rhel9
 owners:
 - microshift-devel@redhat.com

--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -42,7 +42,10 @@ enabled_repos:
 konflux:
   cachi2:
     lockfile:
-      enabled: false
+      rpms:
+      - firewalld
+      - microshift
+      - microshift-release-info
 name: openshift/microshift-bootc-rhel9
 owners:
 - microshift-devel@redhat.com

--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -23,6 +23,8 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/microshift.git
       web: https://github.com/openshift/microshift
+    pkg_managers:
+    - gomod
     ci_alignment:
       streams_prs:
         enabled: false

--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -42,7 +42,7 @@ enabled_repos:
 konflux:
   cachi2:
     lockfile:
-      force: false
+      enabled: false
 name: openshift/microshift-bootc-rhel9
 owners:
 - microshift-devel@redhat.com


### PR DESCRIPTION
## Summary
- `build-microshift-bootc` #295 fails at `prefetch-dependencies`: hermeto requires `rpms.lock.yaml` but none exists
- Root cause: doozer auto-adds `{"type":"rpm"}` to cachi2 input because `enabled_repos` are defined, but RPMs are installed via `dnf install` at build time, not prefetched via cachi2
- Fix: add `pkg_managers: [gomod]` under `content.source` to explicitly control prefetch types, matching the pattern used by other images (e.g. `cluster-etcd-operator`)

## Error from build #295
```
ERROR LockfileNotFound: Required files not found: rpms.lock.yaml
hermeto fetch-deps command failed: exit status 13
```

## Test plan
- [ ] Retrigger `build-microshift-bootc` for 4.20.23 assembly and verify `prefetch-dependencies` succeeds
- [ ] Verify gomod prefetch still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)