### PR TITLE
ART-18724: Pin imagebuilder to v1.2.20 for ci-openshift-build-root (4.19)

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -54,7 +54,7 @@ RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     go install golang.org/x/lint/golint@latest && \
     go install gotest.tools/gotestsum@v1.12.3 && \
     go install github.com/openshift/release/tools/gotest2junit@latest && \
-    go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
+    go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.20 && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \
     mkdir $GOPATH/bin && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -54,7 +54,7 @@ RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     go install golang.org/x/lint/golint@latest && \
     go install gotest.tools/gotestsum@v1.12.3 && \
     go install github.com/openshift/release/tools/gotest2junit@latest && \
-    go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
+    go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.20 && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \
     mkdir $GOPATH/bin && \


### PR DESCRIPTION
## Summary

Pin `imagebuilder` to v1.2.20 in both RHEL 8 and RHEL 9 ci-openshift-build-root Dockerfiles.

**Failing builds:** [ci-openshift-build-root-extra.rhel8](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ci-openshift-build-root-extra.rhel8$&group=openshift-4.19&assembly=stream&engine=konflux&dateRange=2026-02-17+to+2026-05-18&outcome=success&outcome=failure), [ci-openshift-build-root-extra.rhel9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ci-openshift-build-root-extra.rhel9$&group=openshift-4.19&assembly=stream&engine=konflux&dateRange=2026-02-17+to+2026-05-18&outcome=success&outcome=failure), [ci-openshift-build-root-latest.rhel8](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ci-openshift-build-root-latest.rhel8$&group=openshift-4.19&assembly=stream&engine=konflux&dateRange=2026-02-17+to+2026-05-18&outcome=success&outcome=failure), [ci-openshift-build-root-latest.rhel9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?name=^ci-openshift-build-root-latest.rhel9$&group=openshift-4.19&assembly=stream&engine=konflux&dateRange=2026-02-17+to+2026-05-18&outcome=success&outcome=failure)

## Analysis

`imagebuilder@latest` resolves to v1.2.21 which requires Go >= 1.25.5. The build environment has Go 1.24.13 with `GOTOOLCHAIN=local`, causing the build to fail:

```
go: github.com/openshift/imagebuilder@v1.2.21 requires go >= 1.25.5 (running go 1.24.13; GOTOOLCHAIN=local)
```

This affects all 4 ci-openshift-build-root images (extra.rhel8, extra.rhel9, latest.rhel8, latest.rhel9) across all architectures.

## Changes

- `ci_images/rhel-8/ci-openshift-build-root/Dockerfile`: Pin `imagebuilder@latest` to `imagebuilder@v1.2.20`
- `ci_images/rhel-9/ci-openshift-build-root/Dockerfile`: Pin `imagebuilder@latest` to `imagebuilder@v1.2.20`

Same fix as #10492 (4.16).

Fixes: [ART-18724](https://redhat.atlassian.net/browse/ART-18724), ART-18723, ART-18722, [ART-18721](https://redhat.atlassian.net/browse/ART-18721)

Generated with [Claude Code](https://claude.com/claude-code)