### PR TITLE
ART-18353: Change pkg_managers from yarn to npm for networking-console-plugin (4.19)

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -13,7 +13,7 @@ content:
       match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
       replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     pkg_managers:
-    - yarn
+    - npm
     okd_alignment:
       dockerfile: Dockerfile
 distgit:


### PR DESCRIPTION
## Summary
- Backport of 270abb746 from openshift-4.20
- The upstream repo uses `package-lock.json` and `npm ci`, not yarn
- Hermeto fails with `PackageRejected: Unable to determine the yarn version` when `pkg_managers` is set to `yarn` because the repo has no `packageManager` field or `.yarnrc.yml`
- Changing to `npm` matches the actual package manager used by the project

## Test plan
- [ ] Verify next stream build of networking-console-plugin succeeds