### PR TITLE
ART-16004 [openshift-4.14]: use registry.redhat.io for nodejs stream base image

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -91,7 +91,7 @@ rhel9:
   mirror: true
 
 nodejs:
-  image: registry.access.redhat.com/ubi8/nodejs-18:1-86
+  image: registry.redhat.io/ubi8/nodejs-18:1-86
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
## Summary
- Update the `nodejs` stream `image` in `streams.yml` from `registry.access.redhat.com` to `registry.redhat.io` (same tag: `ubi8/nodejs-18:1-86`).

## Problem
**Before:** `image: registry.access.redhat.com/ubi8/nodejs-18:1-86`

**After:** `image: registry.redhat.io/ubi8/nodejs-18:1-86`

Related: [ART-16004](https://redhat.atlassian.net/browse/ART-16004)