### PR TITLE
Restore rhel-98-* repos for users pinning to 9.8

### DIFF
--- a/repos/rhel-98-appstream.yml
+++ b/repos/rhel-98-appstream.yml
@@ -1,0 +1,22 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/appstream/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_8
+    default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_8
+    ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_8
+    s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_8
+  name: rhel-98-appstream
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-98-baseos.yml
+++ b/repos/rhel-98-baseos.yml
@@ -1,0 +1,22 @@
+- conf:
+    baseurl:
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/baseos/os/
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/s390x/baseos/os/
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el9
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_8
+    default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_8
+    ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_8
+    s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_8
+  name: rhel-98-baseos
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-98-early-kernel.yml
+++ b/repos/rhel-98-early-kernel.yml
@@ -1,0 +1,15 @@
+- conf:
+    baseurl:
+      x86_64:  https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/el9/latest/x86_64/os
+      aarch64: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/el9/latest/aarch64/os
+      ppc64le:  https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/el9/latest/ppc64le/os
+      s390x: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/el9/latest/s390x/os
+    extra_options:
+      includepkgs: kernel,kernel-*,toolbox*
+      gpgcheck: '1'
+  content_set:
+    optional: true
+  name: rhel-98-early-kernel
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-98-highavailability.yml
+++ b/repos/rhel-98-highavailability.yml
@@ -1,0 +1,17 @@
+- conf:
+    baseurl:
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/aarch64/highavailability/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/ppc64le/highavailability/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/s390x/highavailability/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/highavailability/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    aarch64: rhel-9-for-aarch64-highavailability-e4s-rpms__9_DOT_8
+    default: rhel-9-for-x86_64-highavailability-e4s-rpms__9_DOT_8
+    ppc64le: rhel-9-for-ppc64le-highavailability-e4s-rpms__9_DOT_8
+    s390x: rhel-9-for-s390x-highavailability-e4s-rpms__9_DOT_8
+  name: rhel-98-highavailability
+  reposync:
+    enabled: true
+  type: external

--- a/repos/rhel-98-nfv.yml
+++ b/repos/rhel-98-nfv.yml
@@ -1,0 +1,15 @@
+- conf:
+    baseurl:
+      # We only have x86_64 repo for nfv
+      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+    extra_options:
+      gpgcheck: '1'
+  content_set:
+    default: rhel-9-for-x86_64-nfv-e4s-rpms__9_DOT_8
+  name: rhel-98-nfv
+  reposync:
+    enabled: true
+  type: external


### PR DESCRIPTION
## Summary

- Restores the 5 `rhel-98-*` repo files deleted in [9ef08f2](https://github.com/openshift-eng/ocp-build-data/commit/9ef08f201f20f87e2be56041e094076e82503eb0)
- File content is now identical to the current `rhel-9-*` repos (e4s/eus 9.8 CDN paths via rhsm-pulp), only the `name` field differs
- `rhel-9-*` repos already track 9.8, but some users/images explicitly reference the `rhel-98-*` names to pin to 9.8

| Restored file | Mirrors |
|---|---|
| `repos/rhel-98-baseos.yml` | `rhel-9-baseos-rpms.yml` |
| `repos/rhel-98-appstream.yml` | `rhel-9-appstream-rpms.yml` |
| `repos/rhel-98-highavailability.yml` | `rhel-9-highavailability.yml` |
| `repos/rhel-98-nfv.yml` | `rhel-9-nfv.yml` |
| `repos/rhel-98-early-kernel.yml` | (plashets-based, unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)