### PR TITLE
[openshift-4.17] Enable ci_build_root sync for ose-frr

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -6,6 +6,10 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/frr.git
       web: https://github.com/openshift/frr
+    ci_alignment:
+      streams_prs:
+        ci_build_root:
+          stream: rhel-9-golang-ci-build-root
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-frr-container


### PR DESCRIPTION
This PR is an effort to bring on a consistency between the CI and build images used by OpenShift components.

https://github.com/openshift/release/pull/79098 will enable the component's CI to check for its branch specific .ci-operator.yaml for the build root image to use for testing.