### PR TITLE
Align installer etcd artifacts with rhel-9-golang-1.19

### DIFF
--- a/images/ose-installer-etcd-artifacts.yml
+++ b/images/ose-installer-etcd-artifacts.yml
@@ -24,6 +24,8 @@ content:
       web: https://github.com/openshift/etcd
     pkg_managers:
     - gomod
+    # CI build root is still the default rhel-9-golang-ci-build-root (Go 1.21 on this branch).
+    # Align with builder stream `rhel-9-golang-1.19` in a follow-up if unit-test CI must use Go 1.19.
     ci_alignment:
       streams_prs:
         enabled: false
@@ -41,13 +43,12 @@ for_payload: false
 for_release: false
 from:
   builder:
-  # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
-  # approval to diverge from what kube apiserver uses for a given release.
-  - stream: etcd_rhel9_golang
-  - stream: etcd_rhel9_golang
-  - stream: etcd_rhel9_golang
-  - stream: etcd_rhel9_golang
-  - stream: etcd_rhel9_golang
+  # Pinned Go 1.19 on RHEL 9 via stream rhel-9-golang-1.19 (same art-images-base as openshift-4.12 rhel-9-golang).
+  - stream: rhel-9-golang-1.19
+  - stream: rhel-9-golang-1.19
+  - stream: rhel-9-golang-1.19
+  - stream: rhel-9-golang-1.19
+  - stream: rhel-9-golang-1.19
   member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+

--- a/streams.yml
+++ b/streams.yml
@@ -43,6 +43,18 @@ rhel-9-golang:
   upstream_image_mirror:
     - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
 
+# Go 1.19 on RHEL 9 (pinned); matches openshift-4.12 rhel-9-golang art-images-base image.
+rhel-9-golang-1.19:
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231941.p2.g805400d.el9
+  mirror: true
+  transform: rhel-9/golang
+  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  upstream_image_mirror:
+    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
+
 rhel-9-golang-1.22:
   image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.22.12-202605111509.p2.g6a298d3.el9
 
@@ -147,17 +159,6 @@ etcd_golang:
   # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
   upstream_image_mirror:
     - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-etcd-golang-1.19
-
-etcd_rhel9_golang:
-  image: openshift/golang-builder:v1.19.13-202408070451.g3172d57.el9
-  mirror: true
-  # No transform required as etcd does not yum install
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
-  upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-etcd-golang-1.19
 
 rhel8:
   # the most recent release at present. since we yum update this, it does not need to float.


### PR DESCRIPTION
## Summary
- Add `rhel-9-golang-1.19` stream (Go 1.19 on RHEL 9) using the same `registry.redhat.io/openshift/art-images-base` golang builder as `openshift-4.12` `rhel-9-golang`, and remove `etcd_rhel9_golang`.
- Point `ose-installer-etcd-artifacts` builder stages at `rhel-9-golang-1.19` and document that `ci_alignment` still uses `rhel-9-golang-ci-build-root` (Go 1.21) unless aligned in a follow-up.

## Test plan
- [ ] Confirm rebased Dockerfile parent count still matches metadata (`from.builder` + `member`).
- [ ] Run the usual ocp-build-data / ART validation your team uses for stream and image changes.