### PR TITLE
NO-JIRA [openshift-4.14]: Align etcd builder with rhel-9-golang-1.19

### DIFF
--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -23,6 +23,7 @@ content:
       web: https://github.com/openshift/etcd
     pkg_managers:
     - gomod
+    # CI build root uses rhel-9-golang-ci-build-root (Go 1.20 on this branch).
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -32,9 +33,8 @@ distgit:
 for_payload: true
 from:
   builder:
-  # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
-  # approval to diverge from what kube apiserver uses for a given release.
-  - stream: etcd_rhel9_golang
+  # Pinned Go 1.19 on RHEL 9 via stream rhel-9-golang-1.19 (same art-images-base as openshift-4.12 rhel-9-golang).
+  - stream: rhel-9-golang-1.19
   member: openshift-enterprise-base-rhel9
 labels:
   License: Apache 2.0

--- a/streams.yml
+++ b/streams.yml
@@ -43,6 +43,18 @@ rhel-9-golang:
   upstream_image_mirror:
     - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
 
+# Go 1.19 on RHEL 9 (pinned); matches openshift-4.12 rhel-9-golang art-images-base image.
+rhel-9-golang-1.19:
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231941.p2.g805400d.el9
+  mirror: true
+  transform: rhel-9/golang
+  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  upstream_image_mirror:
+    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
+
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
@@ -60,19 +72,6 @@ rhel-8-golang-ci-build-root:
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-{MAJOR}.{MINOR}
-
-etcd_rhel9_golang:
-  aliases:
-    - rhel-9-golang-{GO_EXTRA}
-  image: openshift/golang-builder:v1.19.13-202507041126.g3172d57.el9
-  mirror: false
-  # No transform required as etcd does not yum install
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
-  upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-etcd-golang-1.19
 
 rhel8:
   # the most recent release at present. since we yum update this, it does not need to float.


### PR DESCRIPTION
## Summary

Align etcd golang builders with pinned Go 1.19 on RHEL 9 via stream `rhel-9-golang-1.19`, using the same `registry.redhat.io/openshift/art-images-base` golang builder NVR as `openshift-4.12` `rhel-9-golang`. Remove dedicated `etcd_rhel9_golang` (including its stream aliases on this branch).

## Problem

**Before:** `ose-etcd` used `etcd_rhel9_golang` (`openshift/golang-builder` pullspec); `etcd_rhel9_golang` also exposed aliases that could collide with a future `rhel-9-golang-1.19` stream name.

**After:** Explicit `rhel-9-golang-1.19` stream with art-images-base image and kube-aligned upstream `rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}`; `ose-etcd` builder references that stream. `ci_alignment` still uses `rhel-9-golang-ci-build-root` (Go 1.20 on this branch).

Related: none (no ticket).