### PR TITLE
NO-JIRA [openshift-4.15]: Align etcd builder with rhel-9-golang-1.19

### DIFF
--- a/images/ci-openshift-golang-builder-extra.yml
+++ b/images/ci-openshift-golang-builder-extra.yml
@@ -17,7 +17,7 @@ content:
       mirror_manifest_list: true
       upstream_image: registry.ci.openshift.org/ocp-multi/builder:rhel-9-golang-extra-openshift-{MAJOR}.{MINOR}
 from:
-  stream: etcd_rhel9_golang
+  stream: rhel-9-golang-1.19
 labels:
   io.k8s.description: golang builder image for Red Hat CI
 distgit:

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -23,6 +23,7 @@ content:
       web: https://github.com/openshift/etcd
     pkg_managers:
     - gomod
+    # CI build root uses rhel-9-golang-ci-build-root (Go 1.20 on this branch).
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -38,9 +39,8 @@ delivery:
 for_payload: true
 from:
   builder:
-  # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
-  # approval to diverge from what kube apiserver uses for a given release.
-  - stream: etcd_rhel9_golang
+  # Pinned Go 1.19 on RHEL 9 via stream rhel-9-golang-1.19 (same art-images-base as openshift-4.12 rhel-9-golang).
+  - stream: rhel-9-golang-1.19
   member: openshift-enterprise-base-rhel9
 labels:
   License: Apache 2.0

--- a/streams.yml
+++ b/streams.yml
@@ -50,6 +50,18 @@ rhel-9-golang:
   upstream_image_mirror:
     - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
 
+# Go 1.19 on RHEL 9 (pinned); matches openshift-4.12 rhel-9-golang art-images-base image.
+rhel-9-golang-1.19:
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231941.p2.g805400d.el9
+  mirror: true
+  transform: rhel-9/golang
+  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  upstream_image_mirror:
+    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
+
 ibm-rhel-9-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
   image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.20.12-202604101907.p2.g5595e7d.el9
@@ -74,17 +86,6 @@ rhel-9-golang-ci-build-root:
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
   transform: rhel-9/ci-build-root
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-{MAJOR}.{MINOR}
-
-etcd_rhel9_golang:
-  image: openshift/golang-builder:v1.19.13-202507041126.g3172d57.el9
-  mirror: true
-  # No transform required as etcd does not yum install
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
-  upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-etcd-golang-1.19
 
 rhel8:
   # the most recent release at present. since we yum update this, it does not need to float.


### PR DESCRIPTION
## Summary

Align etcd golang builders with pinned Go 1.19 on RHEL 9 via stream `rhel-9-golang-1.19`, using the same `registry.redhat.io/openshift/art-images-base` golang builder NVR as `openshift-4.12` `rhel-9-golang`. Remove dedicated `etcd_rhel9_golang`.

## Problem

**Before:** `ose-etcd` and `ci-openshift-golang-builder-extra` used `etcd_rhel9_golang` (`openshift/golang-builder` pullspec).

**After:** Explicit `rhel-9-golang-1.19` stream with art-images-base image and kube-aligned upstream `rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}`; both images reference that stream. `ci_alignment` still uses `rhel-9-golang-ci-build-root` (Go 1.20 on this branch).

Related: none (no ticket).