### PR TITLE
Switch OpenStack images to Go 1.26 builder; fix ci_build_root mismatches (5.0)

### DIFF
--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -12,7 +12,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
         auto_label:
         - approved
         - lgtm
@@ -27,7 +27,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.26
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-csi-driver-manila-rhel9
 payload_name: csi-driver-manila

--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
     okd_alignment:
       dockerfile: Dockerfile.okd
 distgit:

--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: operator-lifecycle-manager-container

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: operator-registry-container

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-cloud-controller-manager-operator-container
@@ -21,7 +21,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.26
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-cloud-controller-manager-rhel9-operator
 payload_name: cluster-cloud-controller-manager-operator

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-olm-operator-container

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -12,7 +12,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-catalogd-container

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -12,7 +12,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
     pkg_managers:
     - gomod
 distgit:

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
         auto_label:
         - approved
         - lgtm
@@ -27,7 +27,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.26
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-openstack-cinder-csi-driver-rhel9
 payload_name: openstack-cinder-csi-driver

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -10,7 +10,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cloud-controller-manager-container
@@ -22,7 +22,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.26
   member: openshift-enterprise-base-rhel9
 labels:
   License: ASL 2.0

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-operator-framework-tools-container

--- a/streams.yml
+++ b/streams.yml
@@ -35,7 +35,7 @@ rhel-8-golang:
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang-extra:
+rhel-9-golang-1.26:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.2-202605152147.p2.gb1b9903.el9


### PR DESCRIPTION
## Summary

cloud-provider-openstack (commit gf8bb599) and cluster-cloud-controller-manager-operator
(commit g7f6aa93) bumped `go.mod`/`go.work` to require `go >= 1.26.0`. The current builder
stream `rhel-9-golang` provides Go 1.25.8, causing build failures.

Also fixes 7 images that incorrectly referenced `ci-openshift-build-root-extra.rhel9`
in their `ci_build_root` despite using the standard `rhel-9-golang` builder.

**Failing builds:** [ART-18929](https://redhat.atlassian.net/browse/ART-18929), [ART-18924](https://redhat.atlassian.net/browse/ART-18924), [ART-18922](https://redhat.atlassian.net/browse/ART-18922), [ART-18923](https://redhat.atlassian.net/browse/ART-18923)

## Changes

**streams.yml:**
- Rename `rhel-9-golang-extra` to `rhel-9-golang-1.26`

**OpenStack images** (builder `rhel-9-golang` -> `rhel-9-golang-1.26`, ci_build_root `latest` -> `extra`):
- `csi-driver-manila` ([ART-18922](https://redhat.atlassian.net/browse/ART-18922))
- `ose-openstack-cinder-csi-driver` ([ART-18929](https://redhat.atlassian.net/browse/ART-18929))
- `ose-openstack-cloud-controller-manager` ([ART-18924](https://redhat.atlassian.net/browse/ART-18924))
- `ose-cluster-cloud-controller-manager-operator` ([ART-18923](https://redhat.atlassian.net/browse/ART-18923))

**ci_build_root fix** (`ci-openshift-build-root-extra.rhel9` -> `ci-openshift-build-root-latest.rhel9`):
- `marketplace-operator`
- `operator-lifecycle-manager`
- `operator-registry`
- `ose-cluster-olm-operator`
- `ose-olm-catalogd`
- `ose-olm-operator-controller`
- `ose-operator-framework-tools`

These 7 images use the standard `rhel-9-golang` builder but incorrectly referenced the
`extra` CI build root. This mismatch means upstream CI would use a different Go version
than the production build.

Generated with [Claude Code](https://claude.com/claude-code)