### PR TITLE
Enable Go 1.26 builder and switch OpenStack images to it; fix ci_build_root mismatches (4.23)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -24,7 +24,7 @@ vars:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
   GO_LATEST: "1.25"
-  #GO_EXTRA: "1.25"  # ovn-kubernetes or other components require Go 1.25
+  GO_EXTRA: "1.26"
 
 compliance:
   rpm_shim:

--- a/images/ci-openshift-build-root-extra.rhel9.yml
+++ b/images/ci-openshift-build-root-extra.rhel9.yml
@@ -1,5 +1,3 @@
-# No 'extra' golang at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-golang-builder-extra.rhel9.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel9.yml
@@ -1,5 +1,3 @@
-# No 'extra' golang at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -12,7 +12,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
         auto_label:
         - approved
         - lgtm
@@ -27,7 +27,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.26
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-csi-driver-manila-rhel9
 payload_name: csi-driver-manila

--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
     okd_alignment:
       dockerfile: Dockerfile.okd
 distgit:

--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: operator-lifecycle-manager-container

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: operator-registry-container

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-cloud-controller-manager-operator-container
@@ -21,7 +21,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.26
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-cloud-controller-manager-rhel9-operator
 payload_name: cluster-cloud-controller-manager-operator

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-olm-operator-container

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -12,7 +12,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-catalogd-container

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -12,7 +12,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
     pkg_managers:
     - gomod
 distgit:

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
         auto_label:
         - approved
         - lgtm
@@ -27,7 +27,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.26
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-openstack-cinder-csi-driver-rhel9
 payload_name: openstack-cinder-csi-driver

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -10,7 +10,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cloud-controller-manager-container
@@ -22,7 +22,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.26
   member: openshift-enterprise-base-rhel9
 labels:
   License: ASL 2.0

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+          member: ci-openshift-build-root-latest.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-operator-framework-tools-container

--- a/streams.yml
+++ b/streams.yml
@@ -35,6 +35,13 @@ rhel-8-golang:
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
 
+rhel-9-golang-1.26:
+  aliases:
+    - rhel-9-golang-{GO_EXTRA}
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.2-202605152147.p2.gb1b9903.el9
+  mirror: true
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
 partner-rhel-8-golang-1.25:
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081607.p2.g2aa6a05.el8
   mirror: true


### PR DESCRIPTION
## Summary

cloud-provider-openstack (commit gf8bb599) and cluster-cloud-controller-manager-operator
(commit g7f6aa93) bumped `go.mod`/`go.work` to require `go >= 1.26.0`. The current builder
stream `rhel-9-golang` provides Go 1.25.8, causing build failures.

This PR enables the Go 1.26 builder infrastructure on 4.23 (previously disabled) and
switches the 4 affected OpenStack images to use it.

Also fixes 7 images that incorrectly referenced `ci-openshift-build-root-extra.rhel9`
in their `ci_build_root` despite using the standard `rhel-9-golang` builder.

**Failing builds:** [ART-18932](https://redhat.atlassian.net/browse/ART-18932), [ART-18931](https://redhat.atlassian.net/browse/ART-18931), [ART-18930](https://redhat.atlassian.net/browse/ART-18930), [ART-18928](https://redhat.atlassian.net/browse/ART-18928)

## Changes

**group.yml:**
- Set `GO_EXTRA: "1.26"` (was commented out)

**streams.yml:**
- Add `rhel-9-golang-1.26` stream pointing to Go 1.26.2 builder image

**CI builder images** (remove `mode: disabled`):
- `ci-openshift-golang-builder-extra.rhel9`
- `ci-openshift-build-root-extra.rhel9`

**OpenStack images** (builder `rhel-9-golang` -> `rhel-9-golang-1.26`, ci_build_root `latest` -> `extra`):
- `csi-driver-manila` ([ART-18931](https://redhat.atlassian.net/browse/ART-18931))
- `ose-openstack-cinder-csi-driver` ([ART-18930](https://redhat.atlassian.net/browse/ART-18930))
- `ose-openstack-cloud-controller-manager` ([ART-18932](https://redhat.atlassian.net/browse/ART-18932))
- `ose-cluster-cloud-controller-manager-operator` ([ART-18928](https://redhat.atlassian.net/browse/ART-18928))

**ci_build_root fix** (`ci-openshift-build-root-extra.rhel9` -> `ci-openshift-build-root-latest.rhel9`):
- `marketplace-operator`
- `operator-lifecycle-manager`
- `operator-registry`
- `ose-cluster-olm-operator`
- `ose-olm-catalogd`
- `ose-olm-operator-controller`
- `ose-operator-framework-tools`

These 7 images use the standard `rhel-9-golang` builder but incorrectly referenced the
`extra` CI build root. This mismatch means upstream CI would use a different Go version
than the production build.

Generated with [Claude Code](https://claude.com/claude-code)