### PR TITLE
[openshift-4.21] networking-console-plugin: hermetic Konflux alignment (match 4.22)

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -37,6 +37,9 @@ konflux:
     lockfile:
       modules:
       - nginx:1.26
+    artifact_lockfile:
+      resources:
+      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
 okd:
   content:
     source:

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -1,5 +1,3 @@
-envs:
-  CYPRESS_INSTALL_BINARY: "0"
 content:
   source:
     dockerfile: Dockerfile.art
@@ -8,14 +6,8 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/networking-console-plugin.git
       web: https://github.com/openshift/networking-console-plugin
-    modifications:
-    - action: replace
-      match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
-      replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     pkg_managers:
     - npm
-    okd_alignment:
-      dockerfile: Dockerfile
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: networking-console-plugin-container
@@ -39,15 +31,12 @@ owners:
 - mschatzm@redhat.com
 payload_name: networking-console-plugin
 konflux:
-  cachito:
-    mode: removal
+  vm_override:
+    aarch64: linux-d160-c4xlarge/arm64
   cachi2:
     lockfile:
       modules:
       - nginx:1.26
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
 okd:
   content:
     source:


### PR DESCRIPTION
## Summary
- Align `images/networking-console-plugin.yml` on **openshift-4.21** with the newer hermetic layout already used on **4.22+** (same shape as `c60d5f7f6` / follow-up commits on newer streams).
- Removes legacy yarn tarball `content.source` replacement, `konflux.cachito.mode: removal`, `CYPRESS_INSTALL_BINARY`, and the published yarn `artifact_lockfile` entry; adds `konflux.vm_override` for aarch64 and keeps `cachi2.lockfile.modules` at `nginx:1.26`.

## Problem
**Before:** 4.21 used the older band (envs, yarn path `modifications`, cachito removal, yarn artifact lockfile) while 4.22–4.23+ use the streamlined cachi2-only Konflux config.

**After:** 4.21 matches 4.22 for this image so version bands stay consistent and Konflux behavior matches the already-shipped newer streams.

## Test plan
- [ ] Confirm file matches `origin/openshift-4.22:images/networking-console-plugin.yml` aside from any intentional stream-only fields (none expected).
- [ ] Trigger or verify the next Konflux build for networking-console-plugin on 4.21 if applicable.

Related: mirrors hermetic migration pattern from `build(networking-console-plugin): convert to hermetic build for 4.22` (`c60d5f7f6`).