### PR TITLE
[openshift-4.19] networking-console-plugin: hermetic Konflux alignment

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -37,6 +37,9 @@ konflux:
     lockfile:
       modules:
       - nginx:1.24
+    artifact_lockfile:
+      resources:
+      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
 okd:
   content:
     source:

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -1,5 +1,3 @@
-envs:
-  CYPRESS_INSTALL_BINARY: "0"
 content:
   source:
     dockerfile: Dockerfile.art
@@ -8,14 +6,8 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/networking-console-plugin.git
       web: https://github.com/openshift/networking-console-plugin
-    modifications:
-    - action: replace
-      match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
-      replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     pkg_managers:
     - npm
-    okd_alignment:
-      dockerfile: Dockerfile
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: networking-console-plugin-container
@@ -39,12 +31,14 @@ owners:
 - mschatzm@redhat.com
 payload_name: networking-console-plugin
 konflux:
-  cachito:
-    mode: removal
+  vm_override:
+    aarch64: linux-d160-c4xlarge/arm64
   cachi2:
     lockfile:
       modules:
       - nginx:1.24
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
+okd:
+  content:
+    source:
+      dockerfile: Dockerfile
+      modifications: []


### PR DESCRIPTION
## Summary
- Align `images/networking-console-plugin.yml` on **openshift-4.19** with the streamlined Konflux/cachi2 layout used on **4.22+**: remove legacy yarn `content.source` replacement, `konflux.cachito.mode: removal`, `CYPRESS_INSTALL_BINARY`, and the published yarn `artifact_lockfile`; add `konflux.vm_override` for aarch64 and keep **nginx:1.24** in `cachi2.lockfile.modules` for this stream.
- Replace `content.source.okd_alignment` with the same top-level `okd` block pattern as newer branches.

## Test plan
- [ ] Diff structure against `origin/openshift-4.22:images/networking-console-plugin.yml` aside from nginx stream (1.24 here vs 1.26 on 4.22).
- [ ] Confirm Konflux build for this image on 4.19 if/when scheduled.