### PR TITLE
[openshift-4.20] networking-console-plugin: hermetic Konflux alignment

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -37,6 +37,9 @@ konflux:
     lockfile:
       modules:
       - nginx:1.26
+    artifact_lockfile:
+      resources:
+      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
 okd:
   content:
     source:

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -1,5 +1,3 @@
-envs:
-  CYPRESS_INSTALL_BINARY: "0"
 content:
   source:
     dockerfile: Dockerfile.art
@@ -8,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/networking-console-plugin.git
       web: https://github.com/openshift/networking-console-plugin
-    modifications:
-    - action: replace
-      match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
-      replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     pkg_managers:
     - npm
 distgit:
@@ -37,17 +31,12 @@ owners:
 - mschatzm@redhat.com
 payload_name: networking-console-plugin
 konflux:
-  cachito:
-    mode: removal
+  vm_override:
+    aarch64: linux-d160-c4xlarge/arm64
   cachi2:
     lockfile:
       modules:
       - nginx:1.26
-      rpms:
-      - nginx
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
 okd:
   content:
     source:


### PR DESCRIPTION
## Summary
- Align `images/networking-console-plugin.yml` on **openshift-4.20** with the streamlined Konflux/cachi2 layout used on **4.22+**: remove legacy yarn `content.source` replacement, `konflux.cachito.mode: removal`, `CYPRESS_INSTALL_BINARY`, the published yarn `artifact_lockfile`, and the `lockfile.rpms: [nginx]` stanza; add `konflux.vm_override` for aarch64 and keep **nginx:1.26** in `cachi2.lockfile.modules`.

## Test plan
- [ ] Confirm file matches `origin/openshift-4.22:images/networking-console-plugin.yml` for Konflux-related keys (delivery and OKD blocks unchanged for this stream).
- [ ] Confirm Konflux build for this image on 4.20 if/when scheduled.