### PR TITLE
[openshift-4.23] openshift-enterprise-console: remove redundant .yarnrc.yml supportedArchitectures injection

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -6,9 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/console.git
       web: https://github.com/openshift/console
-    modifications:
-    - action: command
-      command: ["sh", "-c", "echo '\nsupportedArchitectures:\n  os: [\"linux\"]\n  cpu: [\"x64\", \"arm64\", \"s390x\", \"ppc64\"]' >> frontend/.yarnrc.yml"]
     pkg_managers:
     - yarn
 cachito:


### PR DESCRIPTION
## Summary
- Remove `content.source.modifications` that appended `supportedArchitectures` to `frontend/.yarnrc.yml` for **openshift-enterprise-console** on **openshift-4.23**.
- **Upstream** `openshift/console` `release-4.23` already ships `supportedArchitectures` in `frontend/.yarnrc.yml`; the ART echo duplicated/overrode intent and is redundant.

## Problem
**Before:** Rebase injected a second `supportedArchitectures` block (linux-only os list).

**After:** Rely on the committed `.yarnrc.yml` from `release-4.23`.

## Test plan
- [ ] Author: run targeted **Konflux / rebase** for `openshift-enterprise-console` on 4.23 with this ocp-build-data commit.
- [ ] Confirm Yarn prefetch/build still resolves expected architectures.

Related: cleanup discussed for ART console el8/hermetic analysis (no ticket on branch).