### PR TITLE
[openshift-4.20] openshift-enterprise-console: remove redundant .yarnrc.yml supportedArchitectures injection

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -6,13 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/console.git
       web: https://github.com/openshift/console
-    modifications:
-    - action: command
-      command:
-      - sh
-      - -c
-      - "echo '\nsupportedArchitectures:\n  os: [\"linux\"]\n  cpu: [\"x64\", \"arm64\"\
-        , \"s390x\", \"ppc64\"]' >> frontend/.yarnrc.yml"
     pkg_managers:
     - yarn
 cachito:


### PR DESCRIPTION
## Summary
- Remove `content.source.modifications` that appended `supportedArchitectures` to `frontend/.yarnrc.yml` for **openshift-enterprise-console** (same rationale as openshift-4.23 draft).
- **Upstream** `openshift/console` `release-{MAJOR}.{MINOR}` already ships `supportedArchitectures` in `frontend/.yarnrc.yml`.

## Test plan
- [ ] Run targeted Konflux / rebase for `openshift-enterprise-console` on this stream with this ocp-build-data commit.

Related: chore/remove-console-yarnrc-mod series.