### PR TITLE
[openshift-4.22] ART-18749: Use 9.8 GA repos

### DIFF
--- a/repos/rhel-9-appstream-rpms.yml
+++ b/repos/rhel-9-appstream-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/aarch64/appstream/os/
-      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/ppc64le/appstream/os/
-      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/s390x/appstream/os/
-      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/appstream/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/aarch64/appstream/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/ppc64le/appstream/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/s390x/appstream/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/appstream/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -18,5 +18,5 @@
     s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_8
   name: rhel-9-appstream-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/baseos/os/
-      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os/
-      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/ppc64le/baseos/os/
-      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/s390x/baseos/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/baseos/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/ppc64le/baseos/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/s390x/baseos/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -18,5 +18,5 @@
     s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_8
   name: rhel-9-baseos-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-codeready-builder-rpms.yml
+++ b/repos/rhel-9-codeready-builder-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
-      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
-      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
-      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.8/aarch64/codeready-builder/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.8/ppc64le/codeready-builder/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.8/s390x/codeready-builder/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.8/x86_64/codeready-builder/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -16,5 +16,5 @@
     s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_8
   name: rhel-9-codeready-builder-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-fast-datapath-rpms.yml
+++ b/repos/rhel-9-fast-datapath-rpms.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
-      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
-      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
-      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
     ci_alignment:
       localdev:
         enabled: true
@@ -17,5 +17,5 @@
     s390x: fast-datapath-for-rhel-9-s390x-rpms
   name: rhel-9-fast-datapath-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-highavailability.yml
+++ b/repos/rhel-9-highavailability.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/aarch64/highavailability/os/
-      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/ppc64le/highavailability/os/
-      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/s390x/highavailability/os/
-      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/highavailability/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/aarch64/highavailability/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/ppc64le/highavailability/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/s390x/highavailability/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/highavailability/os/
     extra_options:
       gpgcheck: '1'
   content_set:
@@ -13,5 +13,5 @@
     s390x: rhel-9-for-s390x-highavailability-e4s-rpms__9_DOT_8
   name: rhel-9-highavailability
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-nfv.yml
+++ b/repos/rhel-9-nfv.yml
@@ -1,15 +1,15 @@
 - conf:
     baseurl:
       # We only have x86_64 repo for nfv
-      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
-      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
-      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
-      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/nfv/os/
     extra_options:
       gpgcheck: '1'
   content_set:
     default: rhel-9-for-x86_64-nfv-e4s-rpms__9_DOT_8
   name: rhel-9-nfv
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-rt-rpms.yml
+++ b/repos/rhel-9-rt-rpms.yml
@@ -1,13 +1,15 @@
 - conf:
     baseurl:
-      aarch64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
-      ppc64le: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
-      s390x: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
-      x86_64: https://rhsm-pulp.corp.stage.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
+      aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
+      ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
+      s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
+      x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/rt/os/
     extra_options:
       module_hotfixes: 1
   content_set:
     default: rhel-9-for-x86_64-rt-e4s-rpms__9_DOT_8
     optional: true
   name: rhel-9-rt-rpms
+  reposync:
+    enabled: false
   type: external


### PR DESCRIPTION
## Test
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/35065/

Failed images:
- [cluster-node-tuning-operator](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-cluster-node-tuning-operator-gm4fm) with `No package matches 'tuned'`
- [openshift-enterprise-tests](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-openshift-enterprise-tests-qm4pz) for x86 only with `nothing provides libcpupower.so.1()(64bit) needed by realtime-tests-2.9-1.el9.x86_64 from rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_8`
- [kube-proxy](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-22/pipelineruns/ose-4-22-kube-proxy-ld7pc) with `error: No package matches 'nftables'`