### PR TITLE
[openshift-4.22] ART-18749: Use 10.2 GA repos

### DIFF
--- a/repos/rhel-102-appstream.yml
+++ b/repos/rhel-102-appstream.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/AppStream/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/AppStream/aarch64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/AppStream/ppc64le/os/
-      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/AppStream/s390x/os/
+      x86_64:  "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/appstream/os/"
+      aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/aarch64/appstream/os/"
+      ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/ppc64le/appstream/os/"
+      s390x:   "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/s390x/appstream/os/"
     extra_options:
       gpgcheck: '1'
   content_set:

--- a/repos/rhel-102-baseos.yml
+++ b/repos/rhel-102-baseos.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/BaseOS/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/BaseOS/aarch64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/BaseOS/ppc64le/os/
-      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/BaseOS/s390x/os/
+      x86_64:  "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/baseos/os/"
+      aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/aarch64/baseos/os/"
+      ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/ppc64le/baseos/os/"
+      s390x:   "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/s390x/baseos/os/"
     extra_options:
       gpgcheck: '1'
   content_set:

--- a/repos/rhel-102-highavailability.yml
+++ b/repos/rhel-102-highavailability.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/HighAvailability/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/HighAvailability/aarch64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/HighAvailability/ppc64le/os/
-      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/HighAvailability/s390x/os/
+      x86_64:  "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/highavailability/os/"
+      aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/aarch64/highavailability/os/"
+      ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/ppc64le/highavailability/os/"
+      s390x:   "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/s390x/highavailability/os/"
     extra_options:
       gpgcheck: '1'
   content_set:


### PR DESCRIPTION
At the moment, only these repos have complete GA content across all arches:
- appstream
- baseos
- highavailability

Codeready is not available, and nfv is only there for x86 and arm.