### PR TITLE
ART-18749: Use 10.2 GA repos

### DIFF
--- a/repos/rhel-102-baseos.yml
+++ b/repos/rhel-102-baseos.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/BaseOS/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/BaseOS/aarch64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/BaseOS/ppc64le/os/
-      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/BaseOS/s390x/os/
+      x86_64:  "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/baseos/os/"
+      aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/aarch64/baseos/os/"
+      ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/ppc64le/baseos/os/"
+      s390x:   "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/s390x/baseos/os/"
     extra_options:
       gpgcheck: '1'
   content_set:

--- a/repos/rhel-102-highavailability.yml
+++ b/repos/rhel-102-highavailability.yml
@@ -1,9 +1,9 @@
 - conf:
     baseurl:
-      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/HighAvailability/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/HighAvailability/aarch64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/HighAvailability/ppc64le/os/
-      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/HighAvailability/s390x/os/
+      x86_64:  "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/highavailability/os/"
+      aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/aarch64/highavailability/os/"
+      ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/ppc64le/highavailability/os/"
+      s390x:   "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/s390x/highavailability/os/"
     extra_options:
       gpgcheck: '1'
   content_set:


### PR DESCRIPTION
Equivalent to PR #10720 but for openshift-4.23 branch.

Original PR: https://github.com/openshift-eng/ocp-build-data/pull/10720

## Summary
- Updates RHEL 10.2 repos to use GA repos instead of nightly repos
- Updates `rhel-102-baseos.yml` and `rhel-102-highavailability.yml`

## Notes
At the moment, only these repos have complete GA content across all arches:
- baseos
- highavailability

Note: The `appstream` file doesn't exist in the openshift-4.23 branch, so only baseos and highavailability are updated.