### PR TITLE
HYPBLD-844: Add MCE 2.11 images/*.yml

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,59 @@
+# DECISIONS.md — MCE 2.11 ocp-build-data Branch
+
+Product decisions and rationale for the `mce-2.11` branch configuration.
+Created as part of JIRA ticket [HYPBLD-844](https://redhat.atlassian.net/browse/HYPBLD-844).
+
+## Product Identity
+
+- **Decision**: `product: mce`, `name: mce-2.11`, `csv_namespace: multicluster-engine`
+- **Rationale**: Matches ART naming for layered products (parallel to Brian's `acm` / `acm-2.16`). Requires `CPE_PRODUCT_NAME_MAPPING` in art-tools (separate PR).
+
+## OCP Version Alignment
+
+- **Decision**: `MAJOR: 4`, `MINOR: 21` (OCP 4.21 infrastructure)
+- **Rationale**: MCE 2.11 aligns with OCP 4.21; distgit branch `rhaos-4.21-rhel-9`.
+
+## OCP Target Versions
+
+- **Decision**: `OCP_TARGET_VERSIONS: ["4.18", "4.19", "4.20", "4.21", "4.22"]`
+- **Rationale**: From MCE operator catalog channels.
+
+## Git Source URLs
+
+- **Decision**: `git@github.com:openshift-priv/stolostron-{repo}.git` midstream naming (same pattern as ACM PR #10635)
+- **Rationale**: Ashwin verified openshift-priv mirrors exist for stolostron repos.
+
+## Distgit and Delivery Naming
+
+- **Decision**: `mce-{component}-container` distgit; `multicluster-engine/{component}-rhel9` delivery/name
+- **Rationale**: Parallel to ACM's `acm-*` / `rhacm2/*-rhel9`; `multicluster-engine` matches OLM `csv_namespace`.
+
+## Dockerfiles
+
+- **Decision**: Use existing Konflux/RHTAP Dockerfiles per repo (not `Dockerfile.art`)
+- **Rationale**: Per ACM onboarding thread — `Dockerfile.art` does not exist in stolostron repos; paths vary (`Dockerfile.rhtap`, `build/Dockerfile.rhtap`, `cmd/Dockerfile.rhtap`, etc.).
+
+## Branch Target
+
+- **Decision**: `branch.target: backplane-2.11` for all images
+- **Rationale**: MCE 2.11 release branch. Some repos do not have `backplane-2.11` yet; dockerfile paths were discovered on the latest available `backplane-*` branch (documented per image in PR description).
+
+## Components Not Yet in images/
+
+- **Deferred**: `console-mce` (no `stolostron/console-mce` repo), `discovery-operator`, `multicloud-manager`, `cluster-api-provider-agent`, `cluster-api-provider-kubevirt`, `hypershift-operator` (no matching stolostron repo or no `backplane-2.11` branch yet)
+- **Revisit**: Add when repos/branches exist and delivery names are confirmed.
+
+## Bundle Component
+
+- **Decision**: MCE operator bundle excluded from `images/*.yml`
+- **Rationale**: Same as ACM — defer bundle complexity until individual images build.
+
+## Owners
+
+- **Decision**: `acm-cicd@redhat.com` for all images (bootstrap)
+- **Revisit**: MCE team to designate permanent owners.
+
+## Konflux
+
+- **Decision**: `network_mode: hermetic`, `cachi2.enabled: true`, `sast.enabled: true`
+- **Rationale**: Aligned with merged skeleton and ACM PR after Ashwin review.

--- a/group.yml
+++ b/group.yml
@@ -18,21 +18,13 @@ OCP_TARGET_VERSIONS: [
   "4.22",
 ]
 
-OCP_RELEASE_NOTES_VERSION: "4.21"
-
 arches:
 - x86_64
+- aarch64
 - ppc64le
 - s390x
-- aarch64
 
 operator_image_ref_mode: manifest-list
-
-mr_approvers:
-  QE:
-    - ashwindasr
-  DOCS:
-    - ashwindasr
 
 konflux:
   arches:
@@ -42,16 +34,14 @@ konflux:
   - ppc64le
   cachi2:
     enabled: true
-    lockfile:
-      force: true
+  sast:
+    enabled: true
   network_mode: hermetic
 
 assemblies:
   enabled: true
 
-public_upstreams:
-- private: "https://github.com/openshift-priv"
-  public:  "https://github.com/stolostron"
+branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub
@@ -62,10 +52,10 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
         aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
         ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
         s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
     content_set:
       default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6
       aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_6
@@ -77,29 +67,14 @@ repos:
   rhel-9-appstream-rpms:
     conf:
       baseurl:
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
         aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
         ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
         s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
     content_set:
       default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_6
       aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_6
       ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_6
       s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
-    reposync:
-      enabled: false
-
-  rhel-9-codeready-builder-rpms:
-    conf:
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/codeready-builder/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/codeready-builder/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/codeready-builder/os/
-    content_set:
-      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_6
-      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_6
-      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_6
-      s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_6
     reposync:
       enabled: false

--- a/images/addon-manager.yml
+++ b/images/addon-manager.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-proxy-addon.git
+      web: https://github.com/stolostron/cluster-proxy-addon
+distgit:
+  component: mce-addon-manager-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/addon-manager-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/addon-manager-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-addon-manager-container

--- a/images/backplane-must-gather.yml
+++ b/images/backplane-must-gather.yml
@@ -1,0 +1,23 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-backplane-must-gather.git
+      web: https://github.com/stolostron/backplane-must-gather
+distgit:
+  component: mce-backplane-must-gather-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/backplane-must-gather-rhel9
+for_payload: false
+from:
+  stream: rhel9
+name: multicluster-engine/backplane-must-gather-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-backplane-must-gather-container

--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-backplane-operator.git
+      web: https://github.com/stolostron/backplane-operator
+distgit:
+  component: mce-backplane-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/backplane-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/backplane-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-backplane-operator-container

--- a/images/cluster-curator-controller.yml
+++ b/images/cluster-curator-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-curator-controller.git
+      web: https://github.com/stolostron/cluster-curator-controller
+distgit:
+  component: mce-cluster-curator-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/cluster-curator-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/cluster-curator-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-cluster-curator-controller-container

--- a/images/cluster-image-set-controller.yml
+++ b/images/cluster-image-set-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-image-set-controller.git
+      web: https://github.com/stolostron/cluster-image-set-controller
+distgit:
+  component: mce-cluster-image-set-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/cluster-image-set-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/cluster-image-set-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-cluster-image-set-controller-container

--- a/images/cluster-proxy-addon.yml
+++ b/images/cluster-proxy-addon.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-proxy-addon.git
+      web: https://github.com/stolostron/cluster-proxy-addon
+distgit:
+  component: mce-cluster-proxy-addon-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/cluster-proxy-addon-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/cluster-proxy-addon-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-cluster-proxy-addon-container

--- a/images/cluster-proxy.yml
+++ b/images/cluster-proxy.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: cmd/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-proxy.git
+      web: https://github.com/stolostron/cluster-proxy
+distgit:
+  component: mce-cluster-proxy-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/cluster-proxy-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/cluster-proxy-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-cluster-proxy-container

--- a/images/clusterclaims-controller.yml
+++ b/images/clusterclaims-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-clusterclaims-controller.git
+      web: https://github.com/stolostron/clusterclaims-controller
+distgit:
+  component: mce-clusterclaims-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/clusterclaims-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/clusterclaims-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-clusterclaims-controller-container

--- a/images/clusterlifecycle-state-metrics.yml
+++ b/images/clusterlifecycle-state-metrics.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-clusterlifecycle-state-metrics.git
+      web: https://github.com/stolostron/clusterlifecycle-state-metrics
+distgit:
+  component: mce-clusterlifecycle-state-metrics-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/clusterlifecycle-state-metrics-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/clusterlifecycle-state-metrics-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-clusterlifecycle-state-metrics-container

--- a/images/hypershift-addon-operator.yml
+++ b/images/hypershift-addon-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-hypershift-addon-operator.git
+      web: https://github.com/stolostron/hypershift-addon-operator
+distgit:
+  component: mce-hypershift-addon-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/hypershift-addon-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/hypershift-addon-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-hypershift-addon-operator-container

--- a/images/kube-rbac-proxy-mce.yml
+++ b/images/kube-rbac-proxy-mce.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.prow
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-kube-rbac-proxy.git
+      web: https://github.com/stolostron/kube-rbac-proxy
+distgit:
+  component: mce-kube-rbac-proxy-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/kube-rbac-proxy-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/kube-rbac-proxy-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-kube-rbac-proxy-container

--- a/images/managed-serviceaccount.yml
+++ b/images/managed-serviceaccount.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-managed-serviceaccount.git
+      web: https://github.com/stolostron/managed-serviceaccount
+distgit:
+  component: mce-managed-serviceaccount-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/managed-serviceaccount-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/managed-serviceaccount-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-managed-serviceaccount-container

--- a/images/managedcluster-import-controller-addon.yml
+++ b/images/managedcluster-import-controller-addon.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-managedcluster-import-controller.git
+      web: https://github.com/stolostron/managedcluster-import-controller
+distgit:
+  component: mce-managedcluster-import-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/managedcluster-import-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/managedcluster-import-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-managedcluster-import-controller-container

--- a/images/placement.yml
+++ b/images/placement.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-placement.git
+      web: https://github.com/stolostron/placement
+distgit:
+  component: mce-placement-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/placement-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/placement-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-placement-container

--- a/images/provider-credential-controller.yml
+++ b/images/provider-credential-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-provider-credential-controller.git
+      web: https://github.com/stolostron/provider-credential-controller
+distgit:
+  component: mce-provider-credential-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/provider-credential-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/provider-credential-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-provider-credential-controller-container

--- a/images/registration-operator.yml
+++ b/images/registration-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-registration-operator.git
+      web: https://github.com/stolostron/registration-operator
+distgit:
+  component: mce-registration-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/registration-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/registration-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-registration-operator-container

--- a/images/registration.yml
+++ b/images/registration.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.addon.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-ocm.git
+      web: https://github.com/stolostron/ocm
+distgit:
+  component: mce-registration-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/registration-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/registration-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-registration-container

--- a/images/work.yml
+++ b/images/work.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-work.git
+      web: https://github.com/stolostron/work
+distgit:
+  component: mce-work-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/work-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/work-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-work-container


### PR DESCRIPTION
## Summary

Adds per-component `images/*.yml` configs for MCE 2.11 (17 components), following [ACM PR #10635](https://github.com/openshift-eng/ocp-build-data/pull/10635).

- **Pattern**: `openshift-priv/stolostron-{repo}`, `backplane-2.11`, `multicluster-engine/{name}-rhel9`, `mce-{name}-container`
- **Dockerfiles**: Actual RHTAP/Konflux paths per repo (not `Dockerfile.art`)
- **group.yml**: Aligned with ACM (`branch: rhaos-{MAJOR}.{MINOR}-rhel-9`, simplified konflux block)
- **DECISIONS.md**: Rationale and deferred components

**Deferred** (no repo/branch yet): console-mce, discovery-operator, multicloud-manager, cluster-api-provider-agent/kubevirt, hypershift-operator

Jira: [HYPBLD-844](https://redhat.atlassian.net/browse/HYPBLD-844)