### PR TITLE
Update rhel9 base image to UBI 9.8 minimal

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -53,7 +53,7 @@ partner-rhel-9-golang-1.25:
 
 rhel9:
   # built on top of ubi9-minimal
-  image: registry.redhat.io/ubi9/ubi-minimal@sha256:34880b64c07f28f64d95737f82f891516de9a3b43583f39970f7bf8e4cfa48b7
+  image: registry.redhat.io/ubi9/ubi-minimal@sha256:24650313873554b6ba16c1a1b6b9f9142604f6ab735113e1695faf2dd07fdede
   upstream_image: registry.ci.openshift.org/ocp/builder:ubi9-minimal-openshift-{MAJOR}.{MINOR}.art
   mirror: false
 


### PR DESCRIPTION
## Summary
- Update `streams.yml` rhel9 stream digest from UBI 9.6 to UBI 9.8 minimal
- Fixes depsolve failure in `openshift-base-rhel9` Konflux builds: `crypto-policies` from 9.8 repos conflicts with `gnutls-3.8.3` from the 9.6 base image (requires `gnutls >= 3.8.10`)
- Root cause: `group.yml` `rhel_version` is 9.8 and repos point to `e4s-rpms__9_DOT_8`, but the base image was still pinned to a 9.6 digest

## Failing builds
- [build/ocp4-konflux #35088](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/35088/) (4.22 - UNSTABLE)

## Test plan
- [ ] Verify `openshift-base-rhel9` Konflux build passes with the new digest
- [ ] Verify downstream images that depend on `openshift-base-rhel9` build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)