### PR TITLE
ART-14750: Switch golang-builder to plashet + signed RPMs (rhel-8-golang-1.24)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -10,6 +10,8 @@ vars:
   MAJOR: 4
   MINOR: 21
 
+sign_golang_rpm: true
+
 konflux:
   network_mode: hermetic
   build_attempts: 1
@@ -44,14 +46,14 @@ repos:
       extra_options:
         module_hotfixes: 1
         # this repo provides complete RHEL 8 build env; we just want the go-toolset content
-        includepkgs: module-build-macros golang* goversioninfo
+        includepkgs: golang* goversioninfo
       # golang-1.21.3-4.el8_9
       # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2770478
       baseurl:
-        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
-        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/
-        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/s390x/
-        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/x86_64/
+        aarch64: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el8/latest/aarch64/os/
+        ppc64le: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el8/latest/ppc64le/os/
+        s390x: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el8/latest/s390x/os/
+        x86_64: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el8/latest/x86_64/os/
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms
@@ -68,10 +70,10 @@ repos:
         s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
         x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
     content_set:
-      default: rhel-8-for-x86_64-baseos-rpms__8
-      aarch64: rhel-8-for-aarch64-baseos-rpms__8
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms__8
-      s390x: rhel-8-for-s390x-baseos-rpms__8
+      default: rhel-8-for-x86_64-baseos-rpms
+      aarch64: rhel-8-for-aarch64-baseos-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms
+      s390x: rhel-8-for-s390x-baseos-rpms
     reposync:
       enabled: false
 
@@ -83,10 +85,10 @@ repos:
         s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
         x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
     content_set:
-      default: rhel-8-for-x86_64-appstream-rpms__8
-      aarch64: rhel-8-for-aarch64-appstream-rpms__8
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms__8
-      s390x: rhel-8-for-s390x-appstream-rpms__8
+      default: rhel-8-for-x86_64-appstream-rpms
+      aarch64: rhel-8-for-aarch64-appstream-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms
+      s390x: rhel-8-for-s390x-appstream-rpms
     reposync:
       enabled: false
 
@@ -98,9 +100,9 @@ repos:
         s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/codeready-builder/os/
         x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os/
     content_set:
-      default: codeready-builder-for-rhel-8-x86_64-rpms__8
-      aarch64: codeready-builder-for-rhel-8-aarch64-rpms__8
-      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms__8
-      s390x:   codeready-builder-for-rhel-8-s390x-rpms__8
+      default: codeready-builder-for-rhel-8-x86_64-rpms
+      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
+      s390x:   codeready-builder-for-rhel-8-s390x-rpms
     reposync:
       enabled: false


### PR DESCRIPTION
## Summary
- Switch `rhel-8-golang-rpms` repo from brewroot URLs to plashet URLs (signed RPMs)
- Remove `module-build-macros`, `delve`, `go-toolset*` from `includepkgs`
- Add `sign_golang_rpm: true` (sustaining golang — auto-signed via brew tags)
- Fix content set names to match EC policy's `known_rpm_repositories.yml` (remove `__8` suffix from RHEL 8 content sets)

Part of [ART-14750](https://redhat.atlassian.net/browse/ART-14750): Use only signed RPMs in golang builder images