### PR TITLE
ART-14750: Switch golang-builder to plashet + signed RPMs (rhel-8-golang-1.21)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -44,14 +44,12 @@ repos:
       extra_options:
         module_hotfixes: 1
         # this repo provides complete RHEL 8 build env; we just want the go-toolset content
-        includepkgs: golang golang-bin golang-docs golang-misc golang-race golang-src golang-tests goversioninfo
-      # golang-1.21.3-4.el8_9
-      # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2770478
+        includepkgs: golang* goversioninfo
       baseurl:
-        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
-        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/
-        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/s390x/
-        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/x86_64/
+        aarch64: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el8/latest/aarch64/os/
+        ppc64le: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el8/latest/ppc64le/os/
+        s390x: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el8/latest/s390x/os/
+        x86_64: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el8/latest/x86_64/os/
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms


### PR DESCRIPTION
## Summary
- Switch `rhel-8-golang-rpms` repo from brewroot URLs to plashet URLs (signed RPMs)
- Replace `rhel-8-server-ose-build-rpms` with `rhel-8-codeready-builder-rpms` (8.6/eus)
- Update `enabled_repos` in `images/openshift-golang-builder.yml`
- Remove `module-build-macros`, `delve`, `go-toolset*` from `includepkgs`, add `goversioninfo`

Part of [ART-14750](https://redhat.atlassian.net/browse/ART-14750): Use only signed RPMs in golang builder images