### PR TITLE
Bump builder image stream from rhel-9-golang to rhel-9-golang-1.24

### DIFF
--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -25,7 +25,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.24
   member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+


### PR DESCRIPTION
bumping ART builder from 1.23 to 1.24 for 4.19 enterprise builder