### PR TITLE
HYPBLD-844: MCE 2.11 group.yml and 15 verified Konflux images

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -35,6 +35,8 @@ mr_approvers:
     - ashwindasr
 
 konflux:
+  # The number of times a build should be attempted before giving up.
+  build_attempts: 1
   arches:
   - x86_64
   - aarch64

--- a/images/addon-manager.yml
+++ b/images/addon-manager.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.addon.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-ocm.git
+      web: https://github.com/stolostron/ocm
+distgit:
+  component: mce-addon-manager-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/addon-manager-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/addon-manager-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-addon-manager-container

--- a/images/cluster-api-provider-azure.yml
+++ b/images/cluster-api-provider-azure.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: stolostron/Dockerfile.stolostron
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-api-provider-azure.git
+      web: https://github.com/stolostron/cluster-api-provider-azure
+distgit:
+  component: mce-cluster-api-provider-azure-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/cluster-api-provider-azure-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/cluster-api-provider-azure-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-cluster-api-provider-azure-container

--- a/images/cluster-curator-controller.yml
+++ b/images/cluster-curator-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-curator-controller.git
+      web: https://github.com/stolostron/cluster-curator-controller
+distgit:
+  component: mce-cluster-curator-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/cluster-curator-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/cluster-curator-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-cluster-curator-controller-container

--- a/images/cluster-image-set-controller.yml
+++ b/images/cluster-image-set-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-image-set-controller.git
+      web: https://github.com/stolostron/cluster-image-set-controller
+distgit:
+  component: mce-cluster-image-set-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/cluster-image-set-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/cluster-image-set-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-cluster-image-set-controller-container

--- a/images/cluster-proxy.yml
+++ b/images/cluster-proxy.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: cmd/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-proxy.git
+      web: https://github.com/stolostron/cluster-proxy
+distgit:
+  component: mce-cluster-proxy-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/cluster-proxy-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/cluster-proxy-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-cluster-proxy-container

--- a/images/clusterclaims-controller.yml
+++ b/images/clusterclaims-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-clusterclaims-controller.git
+      web: https://github.com/stolostron/clusterclaims-controller
+distgit:
+  component: mce-clusterclaims-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/clusterclaims-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/clusterclaims-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-clusterclaims-controller-container

--- a/images/clusterlifecycle-state-metrics.yml
+++ b/images/clusterlifecycle-state-metrics.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-clusterlifecycle-state-metrics.git
+      web: https://github.com/stolostron/clusterlifecycle-state-metrics
+distgit:
+  component: mce-clusterlifecycle-state-metrics-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/clusterlifecycle-state-metrics-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/clusterlifecycle-state-metrics-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-clusterlifecycle-state-metrics-container

--- a/images/hypershift-addon-operator.yml
+++ b/images/hypershift-addon-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-hypershift-addon-operator.git
+      web: https://github.com/stolostron/hypershift-addon-operator
+distgit:
+  component: mce-hypershift-addon-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/hypershift-addon-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/hypershift-addon-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-hypershift-addon-operator-container

--- a/images/managedcluster-import-controller-addon.yml
+++ b/images/managedcluster-import-controller-addon.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-managedcluster-import-controller.git
+      web: https://github.com/stolostron/managedcluster-import-controller
+distgit:
+  component: mce-managedcluster-import-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/managedcluster-import-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/managedcluster-import-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-managedcluster-import-controller-container

--- a/images/multicloud-manager.yml
+++ b/images/multicloud-manager.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-multicloud-operators-foundation.git
+      web: https://github.com/stolostron/multicloud-operators-foundation
+distgit:
+  component: mce-multicloud-manager-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/multicloud-manager-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/multicloud-manager-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-multicloud-manager-container

--- a/images/placement.yml
+++ b/images/placement.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.placement.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-ocm.git
+      web: https://github.com/stolostron/ocm
+distgit:
+  component: mce-placement-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/placement-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/placement-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-placement-container

--- a/images/provider-credential-controller.yml
+++ b/images/provider-credential-controller.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-provider-credential-controller.git
+      web: https://github.com/stolostron/provider-credential-controller
+distgit:
+  component: mce-provider-credential-controller-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/provider-credential-controller-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/provider-credential-controller-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-provider-credential-controller-container

--- a/images/registration-operator.yml
+++ b/images/registration-operator.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.registration-operator.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-ocm.git
+      web: https://github.com/stolostron/ocm
+distgit:
+  component: mce-registration-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/registration-operator-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/registration-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-registration-operator-container

--- a/images/registration.yml
+++ b/images/registration.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.registration.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-ocm.git
+      web: https://github.com/stolostron/ocm
+distgit:
+  component: mce-registration-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/registration-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/registration-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-registration-container

--- a/images/work.yml
+++ b/images/work.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.work.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-ocm.git
+      web: https://github.com/stolostron/ocm
+distgit:
+  component: mce-work-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/work-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/work-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-work-container


### PR DESCRIPTION
## Summary

Split from [#10730](https://github.com/openshift-eng/ocp-build-data/pull/10730) per review feedback: land **proven** configs first, then follow up with the remaining images.

This PR adds:
- `group.yml`: `konflux.build_attempts: 1` (aligned with [openshift-5.0/group.yml](https://github.com/openshift-eng/ocp-build-data/blob/openshift-5.0/group.yml#L51)); keeps existing `mce-2.11` settings (`public_upstreams`, `cachi2`, etc.)
- **15** `images/*.yml` files that already have successful Konflux builds on `mce-2.11` / `assembly=test` ([ART build history](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?group=mce-2.11&assembly=test&outcome=success&engine=konflux&dateRange=2026-05-13+to+2026-05-20), batch `202605202346`)

## Images included (15)

1. addon-manager
2. cluster-api-provider-azure
3. clusterclaims-controller
4. cluster-curator-controller
5. cluster-image-set-controller
6. cluster-proxy
7. clusterlifecycle-state-metrics
8. hypershift-addon-operator
9. multicloud-manager
10. placement
11. provider-credential-controller
12. registration
13. registration-operator
14. work
15. managedcluster-import-controller-addon

## Deferred to follow-up PR (#10730 rebase)

9 images not yet green in ART for this window: backplane-operator, azure-service-operator, cluster-api-provider-aws, cluster-api-webhook-config, console-mce, discovery-operator, kube-rbac-proxy, managed-serviceaccount, backplane-must-gather — plus `streams.yml`, `DECISIONS.md`, and any `from:` fixes.

## Test plan

- [ ] openshift-eng member: `/ok-to-test`
- [ ] `lgtm` + `/approve` from fgallott (or delegate)
- [ ] After merge, rebase #10730 onto `mce-2.11`