### PR TITLE
HYPBLD-844: MCE 2.11 — 4 Konflux-verified images and streams

### DIFF
--- a/images/backplane-must-gather.yml
+++ b/images/backplane-must-gather.yml
@@ -1,0 +1,28 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-backplane-must-gather.git
+      web: https://github.com/stolostron/backplane-must-gather
+distgit:
+  component: mce-backplane-must-gather-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/backplane-must-gather-rhel9
+for_payload: false
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+from:
+  builder:
+    - stream: ose-cli-rhel9
+  stream: rhel9
+name: multicluster-engine/backplane-must-gather-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-backplane-must-gather-container

--- a/images/console-mce.yml
+++ b/images/console-mce.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Containerfile.mce.konflux
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-console.git
+      web: https://github.com/stolostron/console
+distgit:
+  component: mce-console-mce-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/console-mce-rhel9
+for_payload: false
+from:
+  builder:
+    - stream: rhel-9-nodejs-24
+  stream: rhel-9-nodejs-24
+name: multicluster-engine/console-mce-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-console-mce-container

--- a/images/discovery-operator.yml
+++ b/images/discovery-operator.yml
@@ -1,0 +1,28 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-discovery.git
+      web: https://github.com/stolostron/discovery
+distgit:
+  component: mce-discovery-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/discovery-operator-rhel9
+for_payload: false
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+from:
+  builder:
+    - stream: rhel-9-golang-1.25
+  stream: rhel9
+name: multicluster-engine/discovery-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-discovery-operator-container

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -1,0 +1,28 @@
+content:
+  source:
+    dockerfile: Containerfile.operator
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-kube-rbac-proxy.git
+      web: https://github.com/stolostron/kube-rbac-proxy
+distgit:
+  component: mce-kube-rbac-proxy-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/kube-rbac-proxy-rhel9
+for_payload: false
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+from:
+  builder:
+    - stream: rhel-9-golang-1.25
+  stream: rhel9
+name: multicluster-engine/kube-rbac-proxy-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-kube-rbac-proxy-container

--- a/streams.yml
+++ b/streams.yml
@@ -1,11 +1,18 @@
 ---
 rhel-9-golang:
-  aliases:
-    - rhel-9-golang-{GO_LATEST}
   image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604211249.p2.g50071d5.el9
+
+rhel-9-golang-1.25:
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9
+
+rhel-9-nodejs-24:
+  image: registry.redhat.io/ubi9/nodejs-24-minimal@sha256:920a22bf794c1e3806b1279a26337ba02d18af7370df18045f5ffd5bf5d54dbc
 
 ose-cli-artifacts:
   image: registry.redhat.io/openshift4/ose-cli-artifacts-rhel9:v4.21
+
+ose-cli-rhel9:
+  image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21
 
 rhel9:
   image: registry.redhat.io/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00


### PR DESCRIPTION
## Summary

Same approach as [#10771](https://github.com/openshift-eng/ocp-build-data/pull/10771): land **Konflux-verified** configs before the larger remaining batch in [#10730](https://github.com/openshift-eng/ocp-build-data/pull/10730).

Adds **4** `images/*.yml` + `streams.yml` updates for components that passed on `mce-2.11` / `assembly=test`.

## Images (4)

1. kube-rbac-proxy — `rhel-9-golang-1.25` builder
2. console-mce — `rhel-9-nodejs-24` builder + final
3. discovery-operator — `rhel-9-golang-1.25` builder
4. backplane-must-gather — `ose-cli-rhel9` builder, `enabled_repos`, 2-stage `from:`

## streams.yml

- Add `rhel-9-golang-1.25` (1.25.9 builder)
- Add `rhel-9-nodejs-24` (matches `Containerfile.mce.konflux`)
- Add `ose-cli-rhel9` (must-gather builder stage)
- Remove `rhel-9-golang` **aliases** (fixes ambiguous `rhel-9-golang-1.25` when `GO_LATEST` = `GO_EXTRA` = `1.25`)

## Deferred to #10730 (rebased)

5 images still in flight: azure-service-operator, backplane-operator, cluster-api-provider-aws, cluster-api-webhook-config, managed-serviceaccount — plus `DECISIONS.md`.

## Test plan

- [ ] `/ok-to-test`
- [ ] `lgtm` + `/approve`
- [ ] Merge before or rebase #10730 onto updated `mce-2.11`


Made with [Cursor](https://cursor.com)