### PR TITLE
Add cachi2 lockfile RPM config for microshift-bootc (4.19)

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -23,6 +23,8 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/microshift.git
       web: https://github.com/openshift/microshift
+    pkg_managers:
+    - gomod
     ci_alignment:
       streams_prs:
         enabled: false
@@ -37,6 +39,13 @@ enabled_repos:
 - rhel-96-appstream
 - rhel-9-fast-datapath-rpms
 - rhel-9-server-microshift-rpms
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - firewalld
+      - microshift
+      - microshift-release-info
 name: openshift/microshift-bootc-rhel9
 owners:
 - microshift-devel@redhat.com


### PR DESCRIPTION
## Summary

- Add `konflux.cachi2.lockfile.rpms` config to `images/microshift-bootc.yml` listing RPMs from the Containerfile: `firewalld`, `microshift`, `microshift-release-info`
- Add `pkg_managers: [gomod]` under `content.source` to match the working 4.20 config
- Fixes `build-microshift-bootc` Konflux build failure at hermeto `prefetch-dependencies` step

## Problem

The group config enables cachi2 with `lockfile.force=true`, but without image-level `lockfile.rpms`, doozer skips RPM lockfile generation:
```
Empty RPM list to install for microshift-bootc; all required RPMs may be inherited? Skipping lockfile generation.
```

Hermeto then fails with:
```
LockfileNotFound: Required files not found: rpms.lock.yaml
```

This was discovered during the 4.19.32 MicroShift bootc release ([ART-19047](https://redhat.atlassian.net/browse/ART-19047)). The `openshift-4.20` branch already has this config and builds successfully.

## Fix

Backport the same `konflux.cachi2.lockfile.rpms` and `pkg_managers` config from `openshift-4.20`.

**Note:** The same fix is needed on `openshift-4.18`, `openshift-4.21`, `openshift-4.22`, and `openshift-4.23` branches — those PRs will follow once this one is validated.

## Test plan

- [ ] Merge this PR
- [ ] Retrigger `build-microshift-bootc` with `BUILD_VERSION=4.19, ASSEMBLY=4.19.32`
- [ ] Verify hermeto prefetch-dependencies step succeeds (rpms.lock.yaml generated)
- [ ] Verify full bootc build completes successfully