### PR TITLE
Fix release_jira for 4.21.17

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -10,7 +10,7 @@ releases:
         advisories:
           rpm: 167608
           rhcos: 167609
-        release_jira: ART-0
+        release_jira: ART-19045
         shipment:
           advisories:
             - kind: image


### PR DESCRIPTION
Restores `release_jira: ART-19045` for assembly 4.21.17, which was overwritten back to `ART-0` when PR #10769 was merged on top of PR #10768.

PR #10768 (from prepare-release-konflux build #951) correctly set `release_jira: ART-19045`, but PR #10769 was branched before that merge and overwrote it.