### PR TITLE
4.23: bump microshift golang to 1.25

### DIFF
--- a/modifications/Dockerfile
+++ b/modifications/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-ci-openshift-golang-builder-latest-rhel9:v4.20
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.23
 USER root
 
 RUN dnf -y install python3 jq gettext python3-pyyaml \


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED