### PR TITLE
ART-19090: Use rhel9-8-els/rhel-minimal base stream for 4.22

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -52,8 +52,8 @@ partner-rhel-9-golang-1.25:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.25-openshift-{MAJOR}.{MINOR}
 
 rhel9:
-  # built on top of ubi9-minimal
-  image: registry.redhat.io/ubi9/ubi-minimal@sha256:24650313873554b6ba16c1a1b6b9f9142604f6ab735113e1695faf2dd07fdede
+  # built on top of rhel9-8-els/rhel-minimal
+  image: registry.redhat.io/rhel9-8-els/rhel-minimal:latest
   upstream_image: registry.ci.openshift.org/ocp/builder:ubi9-minimal-openshift-{MAJOR}.{MINOR}.art
   mirror: false
 


### PR DESCRIPTION
## Summary
Update rhel9 base image from `ubi9/ubi-minimal` to `rhel9-8-els/rhel-minimal` with `:latest` tag. This keeps the base image current without requiring manual pullspec updates.

## Changes
- Updated `streams.yml` rhel9 image to use `registry.redhat.io/rhel9-8-els/rhel-minimal:latest`
- Updated comment to reflect new base image

## Related
- Jira: [ART-19090](https://redhat.atlassian.net/browse/ART-19090)
- Related to: [ART-18749](https://redhat.atlassian.net/browse/ART-18749) (Use 9.8 GA repositories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)