### PR TITLE
fix(images): remove multi from ci-openshift-golang-builder-extra pullspecs

### DIFF
--- a/images/ci-openshift-golang-builder-extra.rhel8.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel8.yml
@@ -13,7 +13,7 @@ content:
         enabled: false
       mirror: true
       mirror_manifest_list: true
-      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-builder-multi-openshift-{MAJOR}.{MINOR}
+      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 from:
   stream: rhel-8-golang-{GO_EXTRA}
 labels:

--- a/images/ci-openshift-golang-builder-extra.rhel9.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel9.yml
@@ -13,7 +13,7 @@ content:
         enabled: false
       mirror: true
       mirror_manifest_list: true
-      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-builder-multi-openshift-{MAJOR}.{MINOR}
+      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 from:
   stream: rhel-9-golang-{GO_EXTRA}
 labels:


### PR DESCRIPTION
## Summary
- Remove `-builder-multi` from `upstream_image` pullspecs in `ci-openshift-golang-builder-extra.rhel8.yml` and `ci-openshift-golang-builder-extra.rhel9.yml`
- These were the only ci-openshift images on 4.19+ still pushing to pullspecs containing "multi"
- Aligns with the pattern already used by golang-builder-latest and all ci-openshift images on 4.20+

## Test plan
- [ ] Verify ci-openshift-golang-builder-extra images build and push to the correct (non-multi) pullspecs

🤖 Generated with [Claude Code](https://claude.com/claude-code)