### PR TITLE
ART-19090: Use :latest tag for rhel9-8-els/rhel-minimal base stream

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -53,7 +53,7 @@ partner-rhel-9-golang-1.25:
 
 rhel9:
   # built on top of rhel9-8-els/rhel-minimal
-  image: registry.redhat.io/rhel9-8-els/rhel-minimal@sha256:80826084cee52711b25acf828e4882f2ed76d9ad222d36002ff1e9343d8a4654
+  image: registry.redhat.io/rhel9-8-els/rhel-minimal:latest
   upstream_image: registry.ci.openshift.org/ocp/builder:ubi9-minimal-openshift-{MAJOR}.{MINOR}.art
   mirror: false
 


### PR DESCRIPTION
## Summary
- Follow-up to #10791: switch from sha-pinned digest to `:latest` tag for the `rhel9-8-els/rhel-minimal` base stream image
- This keeps the base image current without requiring manual pullspec updates

## Related
- Jira: [ART-19090](https://redhat.atlassian.net/browse/ART-19090)
- Previous PR: #10791

🤖 Generated with [Claude Code](https://claude.com/claude-code)