### PR TITLE
Re-enable console and grafana with prefetch fixes

### DIFF
--- a/images/console.yml
+++ b/images/console.yml
@@ -1,4 +1,10 @@
-mode: disabled
+cachito:
+  enabled: true
+  packages:
+    npm:
+    - path: .
+    - path: ./frontend
+    - path: ./backend
 content:
   source:
     dockerfile: Containerfile.acm.konflux

--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -1,4 +1,8 @@
-mode: disabled
+cachito:
+  enabled: true
+  packages:
+    gomod:
+    - path: .
 content:
   source:
     dockerfile: Containerfile.operator

--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -5,6 +5,8 @@ cachito:
     - path: .
 content:
   source:
+    pkg_managers:
+    - gomod
     dockerfile: Containerfile.operator
     git:
       branch:

--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -12,7 +12,6 @@ content:
       branch:
         target: release-2.16
       url: git@github.com:openshift-priv/stolostron-grafana.git
-      url_pull: https://github.com/dhaiducek/grafana.git
       web: https://github.com/stolostron/grafana
 distgit:
   component: acm-grafana-container

--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -12,6 +12,7 @@ content:
       branch:
         target: release-2.16
       url: git@github.com:openshift-priv/stolostron-grafana.git
+      url_pull: https://github.com/dhaiducek/grafana.git
       web: https://github.com/stolostron/grafana
 distgit:
   component: acm-grafana-container


### PR DESCRIPTION
- console: Add explicit cachito npm paths (., ./frontend, ./backend) to match the upstream .tekton prefetch-input config
- grafana: Add explicit cachito gomod path to prevent yarn.lock auto-detection which fails on unsupported Git dependencies

multicluster-operators-subscription remains disabled pending art-tools support for enable-symlink-check parameter.