### PR TITLE
ART-19227: microshift: add rhel-10 build target

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -18,12 +18,12 @@ content:
       env:
         RELEASE_NAME: "{release_name}"
 name: microshift
-distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+- rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
 owners:
 - microshift-devel@redhat.com
 # This is used by microshift_sync job
 rhel_targets:
 - 9
+- 10


### PR DESCRIPTION
- https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift/3940/
- [microshift-5.0.0~0.nightly_2026_05_25_211852-202605270658.p0.g7424765.assembly.microshift.el10](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=4025945)
- [microshift-5.0.0~0.nightly_2026_05_25_211852-202605270658.p0.g7424765.assembly.microshift.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=4025944)