### PR TITLE
ART-19228: Disable reposync for RHEL 10.2 GA repos (openshift-4.23)

### DIFF
--- a/repos/rhel-102-baseos.yml
+++ b/repos/rhel-102-baseos.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-102-baseos
   reposync:
-    enabled: true
+    enabled: false  # RHEL 10.2 is GA; use E4S content directly
   type: external

--- a/repos/rhel-102-highavailability.yml
+++ b/repos/rhel-102-highavailability.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-102-highavailability
   reposync:
-    enabled: true
+    enabled: false  # RHEL 10.2 is GA; use E4S content directly
   type: external

--- a/repos/rhel-102-nfv.yml
+++ b/repos/rhel-102-nfv.yml
@@ -1,14 +1,14 @@
 - conf:
     baseurl:
-      x86_64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/NFV/x86_64/os/
-      aarch64: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/NFV/x86_64/os/
-      ppc64le: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/NFV/x86_64/os/
-      s390x: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.2/compose/NFV/x86_64/os/
+      x86_64:  "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/nfv/os/"
+      aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/aarch64/nfv/os/"
+      ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/ppc64le/nfv/os/"
+      s390x:   "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/s390x/nfv/os/"
     extra_options:
       gpgcheck: '1'
   content_set:
     optional: true
   name: rhel-102-nfv
   reposync:
-    enabled: true
+    enabled: false  # RHEL 10.2 is GA; use E4S content directly
   type: external


### PR DESCRIPTION
## Summary

RHEL 10.2 has gone GA and is available via E4S. This PR disables reposync for RHEL 10.2 repos to use E4S content directly instead of syncing to S3 mirrors.

## Changes

Disabled `reposync` for the following repos:
- `rhel-102-baseos`
- `rhel-102-highavailability`
- `rhel-102-nfv` (also updated baseurl from nightly composes to E4S)

**Note**: openshift-4.23 does not have `rhel-102-appstream` repo.

## Unchanged

- `rhel-102-fast-datapath`: Not available in E4S
- `rhel-102-early-kernel`: Uses plashet source, not E4S

## Benefits

- No sync lag - direct access to GA content
- Cost savings - no S3 storage/bandwidth for RHEL 10.2 content
- Eliminates version mismatches (e.g., openssl-3.5.5-1 vs 3.5.5-2)

## Related PRs

- openshift/release PR to update repo files to use E4S URLs directly
- Similar changes for openshift-5.0 and openshift-4.22 branches

## Issue

Resolves package version mismatches where reposync was syncing newer package versions while CI jobs were looking for older versions that no longer exist in the GA repo.

Related Slack thread: https://redhat-internal.slack.com/archives/CBN38N3MW/p1779418280741809