### PR TITLE
ART-18962: Switch ose-azure-disk-csi-driver to Go 1.23 builder [openshift-4.18]

### DIFF
--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -31,7 +31,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-extra
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-azure-disk-csi-driver-rhel9
 payload_name: azure-disk-csi-driver


### PR DESCRIPTION
## Summary

- Switch `ose-azure-disk-csi-driver` builder from `rhel-9-golang` (Go 1.22.12) to `rhel-9-golang-extra` (Go 1.23.10)
- Source code `go.mod` requires `go >= 1.23.0`, causing persistent build failures (67 consecutive) with `GOTOOLCHAIN=local`

## Jira

[ART-18962](https://redhat.atlassian.net/browse/ART-18962)

## Test plan

- [ ] Trigger seed-lockfile test build to verify the image builds with the new Go version

🤖 Generated with [Claude Code](https://claude.com/claude-code)