### PR TITLE
Pin dpu-operator for rc.5

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -83,7 +83,11 @@ releases:
           component: rhcos
       members:
         rpms: []
-        images: []
+        images:
+          - distgit_key: dpu-operator
+            metadata:
+              is:
+                nvr: dpu-operator-container-v4.22.0-202605270858.p2.gb2a79d5.assembly.stream.el9
   rc.4:
     assembly:
       type: candidate

--- a/releases.yml
+++ b/releases.yml
@@ -85,6 +85,7 @@ releases:
         rpms: []
         images:
           - distgit_key: dpu-operator
+            why: "Pin to build where previously failing member builds now succeed"
             metadata:
               is:
                 nvr: dpu-operator-container-v4.22.0-202605270858.p2.gb2a79d5.assembly.stream.el9


### PR DESCRIPTION
## Summary
- Pin `dpu-operator` image for assembly `rc.5`
- NVR: `dpu-operator-container-v4.22.0-202605270858.p2.gb2a79d5.assembly.stream.el9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)