### PR TITLE
mta-8.2: mta-ops use rpm-lockfile-prototype

### DIFF
--- a/images/mta-ops.yml
+++ b/images/mta-ops.yml
@@ -29,3 +29,7 @@ from:
 name: mta/mta-ops-rhel9
 owners:
 - mta-devs@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED