### PR TITLE
Pin dpu-operator operands for rc.5

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -89,6 +89,41 @@ releases:
             metadata:
               is:
                 nvr: dpu-operator-container-v4.22.0-202605270858.p2.gb2a79d5.assembly.stream.el9
+          - distgit_key: dpu-daemon
+            why: "Operand referenced by dpu-operator-bundle not in release"
+            metadata:
+              is:
+                nvr: dpu-daemon-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9
+          - distgit_key: dpu-intel-ipu-p4sdk
+            why: "Operand referenced by dpu-operator-bundle not in release"
+            metadata:
+              is:
+                nvr: dpu-intel-ipu-p4sdk-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9
+          - distgit_key: dpu-intel-ipu-vsp
+            why: "Operand referenced by dpu-operator-bundle not in release"
+            metadata:
+              is:
+                nvr: dpu-intel-ipu-vsp-container-v4.22.0-202605270858.p2.gb2a79d5.assembly.stream.el9
+          - distgit_key: dpu-intel-netsec-vsp
+            why: "Operand referenced by dpu-operator-bundle not in release"
+            metadata:
+              is:
+                nvr: dpu-intel-netsec-vsp-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9
+          - distgit_key: dpu-marvell-cp-agent
+            why: "Operand referenced by dpu-operator-bundle not in release"
+            metadata:
+              is:
+                nvr: dpu-marvell-cp-agent-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9
+          - distgit_key: dpu-marvell-vsp
+            why: "Operand referenced by dpu-operator-bundle not in release"
+            metadata:
+              is:
+                nvr: dpu-marvell-vsp-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9
+          - distgit_key: dpu-network-resources-injector
+            why: "Operand referenced by dpu-operator-bundle not in release"
+            metadata:
+              is:
+                nvr: dpu-network-resources-injector-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9
   rc.4:
     assembly:
       type: candidate


### PR DESCRIPTION
## Summary
- Pin dpu-operator operands for assembly `rc.5` to match the bundle `dpu-operator-bundle-container-v4.22.0.202605270858.p2.gb2a79d5.assembly.stream.el9-1`
- Operands pinned:
  - `dpu-daemon-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9`
  - `dpu-intel-ipu-p4sdk-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9`
  - `dpu-intel-ipu-vsp-container-v4.22.0-202605270858.p2.gb2a79d5.assembly.stream.el9`
  - `dpu-intel-netsec-vsp-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9`
  - `dpu-marvell-cp-agent-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9`
  - `dpu-marvell-vsp-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9`
  - `dpu-network-resources-injector-container-v4.22.0-202605260814.p2.gb2a79d5.assembly.stream.el9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)