### PR TITLE
logging-6.4: Update UBI9 baseimage

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -10,4 +10,4 @@ ose-cli-artifacts:
 
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
-  image: registry.redhat.io/ubi9/ubi-minimal@sha256:24650313873554b6ba16c1a1b6b9f9142604f6ab735113e1695faf2dd07fdede
+  image: registry.redhat.io/ubi9-minimal@sha256:5b74fce9d6e629942a0c6dc0f546c193e70d7f974d999a48c948c53dd3d36362


### PR DESCRIPTION
Apparently the naming scheme for the ubi9-minimal images changed ... (image is not available in the old repository)

/label tide/merge-method-squash