### PR TITLE
fix(golang-builder): use uname -m for arch conditional

### DIFF
--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -49,10 +49,10 @@ RUN dnf update -y && \
         zip && \
     dnf install -y "golang-*$VERSION*" && \
     mkdir -p /go/src
-# provide a cross-compiler for windows/mac binaries (amd64 only)
+# provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .
-RUN [ $(go env GOARCH) != "amd64" ] || (\
-    # only install cross-compiler dependencies on amd64
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+    # only install cross-compiler dependencies on x86_64
     yum install -y --setopt=tsflags=nodocs \
     # Required packages for mac cross-compilation
     llvm-toolset-17* cmake3 gcc-c++ libxml2-devel \
@@ -69,7 +69,8 @@ RUN [ $(go env GOARCH) != "amd64" ] || (\
     cp -avr cross/osxcross/target/SDK /usr/local/SDK && \
     echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
     /sbin/ldconfig && \
-    rm -rf cross)
+    rm -rf cross; \
+fi
 
 # above is conditional; clean up unconditionally
 RUN rm -f cross.tar.gz && yum clean all -y


### PR DESCRIPTION
## Summary
- Rewrites the arch-conditional block in `openshift-golang-builder.Dockerfile` from `[ $(go env GOARCH) != "amd64" ] || (...)` to `if [ "$(uname -m)" = "x86_64" ]; then ... fi`
- The lockfile parser doesn't recognize `$(go env GOARCH)` or the `[ != ] || ()` short-circuit pattern, causing `mingw64-gcc` and other x86_64-only cross-compilation packages to be treated as common (all-arch) packages
- This makes rpm-lockfile-prototype resolution fail on non-x86_64 arches, and the retry logic silently drops these packages from the lockfile entirely — including on x86_64 where they're actually needed

## Test plan
- [ ] Verify lockfile parser correctly identifies packages as x86_64-only with the new syntax
- [ ] Run `doozer ... beta:images:konflux:rebase` and confirm `mingw64-gcc` appears in the generated `rpms.lock.yaml` for x86_64
- [ ] Confirm no "retrying without unavailable packages: ['mingw64-gcc']" warning in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)