### PR TITLE
Disable base image release until verified

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -18,6 +18,10 @@ konflux:
     lockfile:
       backend: rpm-lockfile-prototype
 
+# revert after manually verifying base-image-release works for the desired golang builder nvr
+base_image_release:
+  enabled: false
+
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub
   brew_image_host: registry-proxy.engineering.redhat.com


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C07RAB68T5G/p1779907374910579

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED