### PR TITLE
ART-17449 Bump 1.26 builders

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -36,11 +36,14 @@ rhel-8-golang:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.26:
-  aliases:
-    - rhel-9-golang-{GO_EXTRA}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.2-202605152147.p2.gb1b9903.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.3-202605272015.p2.ged14a27.el9
   mirror: true
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
+rhel-8-golang-1.26:
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.3-202605272015.p2.g8642f2e.el8
+  mirror: true
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.25:
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081607.p2.g2aa6a05.el8


### PR DESCRIPTION
Taken from: https://github.com/openshift-eng/ocp-build-data/pull/10825/changes

Part 1 of 2 PRs
2nd PR will move 1.26 to be the default golang stream

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED