### PR TITLE
[openshift-5.0] Fix invalid repo names in microshift-bootc enabled_repos

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -33,8 +33,8 @@ delivery:
 for_release: false
 for_payload: false
 enabled_repos:
-- rhel-9-baseos
-- rhel-9-appstream
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 - rhel-9-fast-datapath-rpms
 - rhel-9-server-microshift-rpms
 name: openshift/microshift-bootc-rhel9


### PR DESCRIPTION
## Summary

- `rhel-9-baseos` and `rhel-9-appstream` are not valid repo names in `openshift-5.0`
- The correct names (matching files in `repos/`) are `rhel-9-baseos-rpms` and `rhel-9-appstream-rpms`
- This caused build [#330](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc/330/console) of `build-microshift-bootc` to fail during rebase with `ValueError: rhel-9-baseos is not a valid repo name!`