### PR TITLE
ART-19305 [openshift-4.19]: force base image release for builder-linked images

### DIFF
--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -27,6 +27,8 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -42,6 +42,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -33,6 +33,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-installer-rhel9
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - member: ose-installer-kube-apiserver-artifacts

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -29,6 +29,8 @@ enabled_repos:
 - rhel-9-fast-datapath-rpms
 - rhel-9-server-ose-rpms-embargoed
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang-{GO_EXTRA}


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to openshift-4.19 image metadata files identified by the builder-member audit so base-image release can be forced for those builder-linked images.

## Problem
**Before:** A subset of openshift-4.19 builder-linked image definitions had no metadata override to force base-image release behavior.

**After:** The selected openshift-4.19 image definitions now set `base_image_release.force: true`.

Related: [ART-19305](https://redhat.atlassian.net/browse/ART-19305)