### PR TITLE
ART-19305 [openshift-4.18]: force base image release for builder-linked images

### DIFF
--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -27,6 +27,8 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -42,6 +42,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang-1.23

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -23,6 +23,8 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-server-ose-rpms-embargoed
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - member: ose-installer-terraform-providers

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -38,6 +38,8 @@ scan_sources:
   exempt_rpms:
   - libreswan*
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang-1.24


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to openshift-4.18 image metadata files identified by the builder-member audit so base-image release can be forced for those builder-linked images.

## Problem
**Before:** A subset of openshift-4.18 builder-linked image definitions had no metadata override to force base-image release behavior.

**After:** The selected openshift-4.18 image definitions now set `base_image_release.force: true`.

Related: [ART-19305](https://redhat.atlassian.net/browse/ART-19305)