### PR TITLE
ART-19305 [openshift-4.17]: force base image release for builder-linked images

### DIFF
--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -27,6 +27,8 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -39,6 +39,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-etcd-rhel9
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -23,6 +23,8 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-server-ose-rpms-embargoed
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - member: ose-installer-terraform-providers

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -39,6 +39,8 @@ scan_sources:
   exempt_rpms:
   - libreswan*
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to openshift-4.17 image metadata files identified by the builder-member audit so base-image release can be forced for those builder-linked images.

## Problem
**Before:** A subset of openshift-4.17 builder-linked image definitions had no metadata override to force base-image release behavior.

**After:** The selected openshift-4.17 image definitions now set `base_image_release.force: true`.

Related: [ART-19305](https://redhat.atlassian.net/browse/ART-19305)