### PR TITLE
ART-19305 [openshift-4.15]: force base image release for builder-linked images

### DIFF
--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -20,6 +20,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-cli
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: golang

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -19,6 +19,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-installer
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - member: ose-installer-terraform-providers

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -33,6 +33,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-ovn-kubernetes-rhel9
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to openshift-4.15 image metadata files identified by the builder-member audit so base-image release can be forced for those builder-linked images.

## Problem
**Before:** A subset of openshift-4.15 builder-linked image definitions had no metadata override to force base-image release behavior.

**After:** The selected openshift-4.15 image definitions now set `base_image_release.force: true`.

Related: [ART-19305](https://redhat.atlassian.net/browse/ART-19305)