### PR TITLE
ART-19305 [openshift-4.12]: force base image release for builder-linked images

### DIFF
--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -13,6 +13,8 @@ content:
 distgit:
   namespace: containers
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: golang

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -11,6 +11,8 @@ content:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: golang

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -16,6 +16,8 @@ enabled_repos:
 - rhel-8-server-ose-rpms-embargoed
 
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to openshift-4.12 image metadata files identified by the builder-member audit so base-image release can be forced for those builder-linked images.

## Problem
**Before:** A subset of openshift-4.12 builder-linked image definitions had no metadata override to force base-image release behavior.

**After:** The selected openshift-4.12 image definitions now set `base_image_release.force: true`.

Related: [ART-19305](https://redhat.atlassian.net/browse/ART-19305)