### PR TITLE
Enable rpm-lockfile-prototype backend for 4.23

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -45,6 +45,8 @@ konflux:
   cachi2:
     enabled: true
     gomod_version_patch: true
+    lockfile:
+      backend: rpm-lockfile-prototype
   network_mode: hermetic
   # The number of times a build should be attempted before giving up.
   # Each failed attempt will result in a failed record in BigQuery


### PR DESCRIPTION
## Summary

Switch lockfile generation to use the new `rpm-lockfile-prototype` backend ([art-tools#2852](https://github.com/openshift-eng/art-tools/pull/2852)) which generates lockfiles dynamically without requiring manually specified RPM lists in image configs.

**Changes:**
- Add `konflux.cachi2.lockfile.backend: rpm-lockfile-prototype` to group.yml

The rpm-lockfile-prototype backend analyzes Dockerfiles at rebase time to automatically determine which packages need to be locked, eliminating the need for manually maintaining RPM lists in image metadata.

## Test plan

YOLO