### PR TITLE
logging-6.4: Update RHEL 9 repos from 9.7 to 9.8

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -85,10 +85,10 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/baseos/os/
     content_set:
       default: rhel-9-for-x86_64-baseos-rpms
       aarch64: rhel-9-for-aarch64-baseos-rpms
@@ -100,10 +100,10 @@ repos:
   rhel-9-baseos-source:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/source/SRPMS
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/source/SRPMS
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/source/SRPMS
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/source/SRPMS
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/baseos/source/SRPMS
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/baseos/source/SRPMS
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/baseos/source/SRPMS
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/baseos/source/SRPMS
       extra_options:
         gpgcheck: "1"
     content_set:
@@ -117,10 +117,10 @@ repos:
   rhel-9-appstream-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/appstream/os/
     content_set:
       default: rhel-9-for-x86_64-appstream-rpms
       aarch64: rhel-9-for-aarch64-appstream-rpms
@@ -132,10 +132,10 @@ repos:
   rhel-9-appstream-source:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/source/SRPMS
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/source/SRPMS
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/source/SRPMS
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/source/SRPMS
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/appstream/source/SRPMS
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/appstream/source/SRPMS
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/appstream/source/SRPMS
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/appstream/source/SRPMS
       extra_options:
         gpgcheck: "1"
     content_set:
@@ -149,10 +149,10 @@ repos:
   rhel-9-appstream-debug:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/debug/
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/debug/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/debug/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/debug/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/appstream/debug/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/appstream/debug/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/appstream/debug/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/appstream/debug/
       extra_options:
         gpgcheck: "1"
     content_set:
@@ -166,10 +166,10 @@ repos:
   rhel-9-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/codeready-builder/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/codeready-builder/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/codeready-builder/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/codeready-builder/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/codeready-builder/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/codeready-builder/os/
     content_set:
       default: codeready-builder-for-rhel-9-x86_64-rpms
       aarch64: codeready-builder-for-rhel-9-aarch64-rpms


### PR DESCRIPTION
## Summary
- Update all RHEL 9 repo URLs in group.yml from 9.7 to 9.8
- Base image now ships RHEL 9.8 packages (e.g. `crypto-policies` el9_8) which conflict with 9.7 RPMs during hermetic builds, causing depsolve failures for `gcc-c++`, `llvm-toolset`, `rust-toolset`, and `git`
- Affects all 6 repo sections (baseos, baseos-source, appstream, appstream-source, appstream-debug, codeready-builder) across all 4 arches