### PR TITLE
ART-14453: Add rhcos-node-image container definition

### DIFF
--- a/images/rhcos-node-image.yml
+++ b/images/rhcos-node-image.yml
@@ -1,0 +1,59 @@
+content:
+  source:
+    dockerfile: Containerfile
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/os.git
+      web: https://github.com/openshift/os
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: false
+    modifications:
+    - action: replace
+      match: "ARG OPENSHIFT_VERSION=overridden"
+      replacement: "ARG OPENSHIFT_VERSION=4.23"
+    - action: replace
+      match: "ARG IMAGE_NAME"
+      replacement: "ARG IMAGE_NAME=openshift/rhcos-node-image-rhel9"
+    - action: replace
+      match: "ARG IMAGE_CPE"
+      replacement: "ARG IMAGE_CPE=cpe:/a:redhat:openshift:4.23::el9"
+    - action: replace
+      match: "ARG TARGETARCH"
+      replacement: "ARG TARGETARCH=amd64"
+    - action: replace
+      match: "LABEL name=${IMAGE_NAME}"
+      replacement: ""
+    - action: replace
+      match: "LABEL architecture=${TARGETARCH}"
+      replacement: ""
+    - action: replace
+      match: 'RUN --mount=type=bind,target=/run/src --mount=type=secret,id=yumrepos,target=/run/src/secret.repo /run/src/build-node-image.sh'
+      replacement: |
+        RUN --mount=type=bind,target=/run/src --mount=type=secret,id=yumrepos,target=/run/src/secret.repo \
+            sed -e 's/dnf --repo="${YUM_REPO_NAMES}"/dnf/' \
+                -e '/cat \/run\/src\/\*\.repo >> \/etc\/yum\.repos\.d\/git\.repo/a sed -i "s/enabled=1/enabled=0/g" /etc/yum.repos.d/git.repo' \
+                /run/src/build-node-image.sh | bash
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: rhcos-node-image-container
+enabled_repos:
+- rhel-9-fast-datapath-rpms
+- rhel-9-server-ose-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+for_payload: false
+for_release: false
+from:
+  builder:
+    - stream: rhel_coreos
+name: openshift/rhcos-node-image-rhel9
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false
+konflux:
+  network_mode: open
+okd:
+  mode: disabled

--- a/streams.yml
+++ b/streams.yml
@@ -89,3 +89,6 @@ centos_stream10:
   upstream_image: registry.ci.openshift.org/ocp/builder:stream10
   mirror: true
   mirror_manifest_list: true
+
+rhel_coreos:
+  image: registry.ci.openshift.org/coreos/rhel-coreos-base:9.8


### PR DESCRIPTION
Test  build at [rhcos-node-image-container-v4.23.0-202605281643.p2.g176d885.assembly.stream.el9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=rhcos-node-image-container-v4.23.0-202605281643.p2.g176d885.assembly.stream.el9&record_id=dc53fbb3-01b0-d874-22bf-fd0b4388a742&group=openshift-4.23&outcome=success&type=image)