### PR TITLE
ART-17449 Enable canonical builders for 5.0

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -262,7 +262,7 @@ check_golang_versions: "x.y"
 # canonical_builders_from_upstream can be overridden by every single image
 # If set to False, it will use the default art config
 # If set to True, it will honor the image's config
-canonical_builders_from_upstream: false
+canonical_builders_from_upstream: true
 
 # This is a toggle to allow streams prs to not yet be opened. This can be useful when golang
 # builders are not yet set up correctly for the release at branch cut time, and we want to limit

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -10,6 +10,10 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+
+# canonical does not correctly handle multi stage dockerfiles right now
+canonical_builders_from_upstream: false
+
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-operator-framework-tools-container

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -10,10 +10,6 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
-
-# canonical does not correctly handle multi stage dockerfiles right now
-canonical_builders_from_upstream: false
-
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-operator-framework-tools-container


### PR DESCRIPTION
This is to prepare for go1.26 move from 1.25. 

https://github.com/openshift-eng/ocp-build-data/pull/10827

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-scan-konflux/49553/console

We want to soft transition i.e. give upstream time to merge reconciliation PRs, that should be opened when we move to 1.26. In the meantime still build from what's defined upstream

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED