### PR TITLE
[openshift-2.22] Bump microshift-bootc base image to 9.8 and switch to rpm-lockfile-prototype

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -9,10 +9,10 @@ content:
     modifications:
     - action: replace
       match: "ARG BASE_IMAGE_URL"
-      replacement: "ARG BASE_IMAGE_URL='registry.redhat.io/rhel9-eus/rhel-9.6-bootc'"
+      replacement: "ARG BASE_IMAGE_URL='registry.redhat.io/rhel9/rhel-bootc'"
     - action: replace
       match: "ARG BASE_IMAGE_TAG"
-      replacement: "ARG BASE_IMAGE_TAG='9.6'"
+      replacement: "ARG BASE_IMAGE_TAG='9.8'"
     - action: replace
       match: "RUN dnf install"
       replacement: |

--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -41,3 +41,7 @@ name: openshift/microshift-bootc-rhel9
 canonical_builders_from_upstream: false
 owners:
 - microshift-devel@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype


### PR DESCRIPTION
[Test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc/340/)