### PR TITLE
Add RHEL 10 base image definitions

### DIFF
--- a/ci_images/rhel-10/ci-openshift-base/Dockerfile
+++ b/ci_images/rhel-10/ci-openshift-base/Dockerfile
@@ -1,0 +1,27 @@
+FROM replaced_by_doozer
+
+# Used by builds scripts to detect whether they are running in the context
+# of OpenShift CI or elsewhere (e.g. brew).
+ENV OPENSHIFT_CI="true"
+
+# Ensure that repo files can be written by non-root users at runtime so that repos
+# can be resolved on build farms and written into yum.repos.d.
+RUN chmod 777 /etc/yum.repos.d/
+
+# Install the dnf/yum wrapper that will work for CI workloads.
+ENV DNF_WRAPPER_DIR=/bin/dnf_wrapper
+
+# Directories relevant to dnf_wrapper.sh
+ENV ART_REPOS_DIR_CI="/etc/yum.repos.art/ci"
+ENV ART_REPOS_DIR_LOCALDEV="/etc/yum.repos.art/localdev"
+
+ADD ci_images/dnf_wrapper.sh /tmp
+ADD ci_images/install_dnf_wrapper.sh /tmp
+RUN chmod +x /tmp/*.sh && \
+    /tmp/install_dnf_wrapper.sh
+# Ensure dnf wrapper scripts appear before anything else in the $PATH
+ENV PATH=$DNF_WRAPPER_DIR:$PATH
+# Add the doozer repos so that someone connected to the VPN can use those
+# repositories. The dnf_wrapper will enable these repos if it detects
+# it is not running on a build farm.
+ADD .oit/art-unsigned.repo $DNF_WRAPPER_DIR/unsigned.repo

--- a/images/ci-openshift-base.rhel10.yml
+++ b/images/ci-openshift-base.rhel10.yml
@@ -1,0 +1,68 @@
+content:
+  # set_build_variables is necessary in order to set CI_RPM_SVC (see .envs below) in the Dockerfile.
+  set_build_variables: true
+  source:
+    dockerfile: ci_images/rhel-10/ci-openshift-base/Dockerfile
+    git:
+      branch:
+        target: openshift-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: true
+      mirror_manifest_list: true
+      upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:base-rhel10
+
+    okd_alignment:
+      # The tag name in the okd stream to which this image should be promoted
+      tag_name: base-stream10
+      inject_rpm_repositories:
+      - id: rhel-10-server-ose
+        baseurl: http://base-{MAJOR}-{MINOR}-rhel10.ocp.svc/rhel-10-server-ose
+
+from:
+  member: openshift-enterprise-base-rhel10
+labels:
+  io.k8s.description: openshift-enterprise-base-rhel10 for Red Hat CI
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-10
+  component: ci-openshift-base-rhel10-container
+
+# Repos enabled in the builder image will be ultimately be injected as repos
+# in the builder image. This means that engineers who download the image and
+# run it connected to the VPN will be able to access the content. This is
+# desirable since it allows Dockerfile builds requiring RPMs to work as long
+# as the host is connected to the VPN.
+enabled_repos:
+- rhel-102-baseos
+- rhel-102-appstream
+- rhel-10-server-ose-rpms
+- rhel-102-fast-datapath
+
+name: openshift/ci-openshift-base-rhel10
+for_payload: false
+for_release: false
+owners:
+- aos-team-art@redhat.com
+maintainer:
+  component: Release
+
+envs:
+  # These services run on the build farms and serve RPMs to CI workloads.
+  # This environment variable is used by dnf_wrapper.sh to know which service
+  # to acquire repo information from.
+  CI_RPM_SVC: "base-{MAJOR}-{MINOR}-rhel10.ocp.svc"
+
+# The from: stanza is exactly what we want to use. So ignore anything in
+# the Dockerfile.
+canonical_builders_from_upstream: false
+
+scan_sources:
+  exempt_rpms:
+  - '*'
+konflux:
+  network_mode: open
+okd:
+  mode: disabled

--- a/images/openshift-base-rhel10.yml
+++ b/images/openshift-base-rhel10.yml
@@ -1,0 +1,32 @@
+base_only: true
+content:
+  source:
+    git:
+      branch:
+        target: openshift-base-rhel10
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: false
+      upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:base-rhel10
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-10
+  component: openshift-base-rhel10-container
+enabled_repos:
+- rhel-102-baseos
+- rhel-102-appstream
+  # sometimes we ship RHEL content ahead of RHEL (usually for RHCOS).
+  # update with that content too so we avoid out-of-date assembly issues:
+- rhel-10-server-ose-rpms-embargoed
+for_payload: false
+for_release: false
+from:
+  stream: rhel10
+name: openshift/base-rhel10
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false
+okd:
+  mode: disabled

--- a/images/openshift-enterprise-base-rhel10.yml
+++ b/images/openshift-enterprise-base-rhel10.yml
@@ -1,0 +1,52 @@
+base_only: true
+content:
+  source:
+    # TODO: Change to Dockerfile.rhel10 once it exists in openshift/images
+    dockerfile: Dockerfile.rhel9
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/images.git
+      web: https://github.com/openshift/images
+    path: base
+    ci_alignment:
+      streams_prs:
+        # Try to have this PR merge as quickly as possible by pre-approving it.
+        auto_label:
+        - approved
+        - lgtm
+        merge_first: true
+      # The actual image used by CI for the enterprise base image is
+      # built and pushed from ci-openshift-base.rhel10. Setting upstream_image
+      # here ensures that reconciliation PRs for components referencing
+      # this image as their base image will use the image created by
+      # ci-openshift-base.rhel10 and be able to resolve RPMs.
+      mirror: false
+      upstream_image: registry.ci.openshift.org/ocp/{MAJOR}.{MINOR}:base-rhel10
+    okd_alignment:
+      # The tag name in the okd stream to which this image should be promoted
+      tag_name: base-stream10
+      inject_rpm_repositories:
+      - id: rhel-10-server-ose
+        baseurl: http://base-{MAJOR}-{MINOR}-rhel10.ocp.svc/rhel-10-server-ose
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-10
+  component: openshift-enterprise-base-rhel10-container
+enabled_repos:
+- rhel-102-baseos
+- rhel-102-appstream
+for_payload: false
+for_release: false
+from:
+  member: openshift-base-rhel10
+labels:
+  License: GPLv2+
+  io.k8s.description: This is the base image from which all OpenShift Container Platform images inherit.
+  io.k8s.display-name: OpenShift Container Platform RHEL 10 Base
+  io.openshift.tags: openshift,base
+name: openshift/openshift-enterprise-base-rhel10
+owners:
+- lmeyer@redhat.com
+okd:
+  distgit:
+    branch: rhaos-{MAJOR}.{MINOR}-rhel-10

--- a/streams.yml
+++ b/streams.yml
@@ -66,6 +66,11 @@ rhel9:
   upstream_image: registry.ci.openshift.org/ocp/builder:ubi9-minimal-openshift-{MAJOR}.{MINOR}.art
   mirror: false
 
+rhel10:
+  image: registry.redhat.io/ubi10/ubi-minimal:10.2
+  upstream_image: registry.ci.openshift.org/ocp/builder:ubi10-minimal-openshift-{MAJOR}.{MINOR}.art
+  mirror: false
+
 nodejs-rhel9:
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-3
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-base-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
## Summary
- Add `rhel10` stream to `streams.yml` based on `ubi10/ubi-minimal:10.2`
- Add base image configs (`openshift-base-rhel10`, `openshift-enterprise-base-rhel10`, `ci-openshift-base.rhel10`) following the RHEL 9 patterns
- Add CI Dockerfile at `ci_images/rhel-10/ci-openshift-base/Dockerfile`
- Enterprise base temporarily uses `Dockerfile.rhel9` until `Dockerfile.rhel10` is created in `openshift/images`

## Test plan
- [ ] Trigger ocp4-konflux build in test assembly pointing to this branch
- [ ] Verify base image builds successfully
- [ ] Create `Dockerfile.rhel10` in openshift/images before merging