### PR TITLE
enable multicluster-operators-subscription, disable symlink check

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -40,6 +40,7 @@ konflux:
     enabled: true
   network_mode: hermetic
   build_attempts: 1
+  enable_symlink_check: false
 
 assemblies:
   enabled: true

--- a/images/multicluster-operators-subscription.yml
+++ b/images/multicluster-operators-subscription.yml
@@ -1,4 +1,3 @@
-mode: disabled
 cachito:
   enabled: true
   packages:

--- a/images/multicluster-operators-subscription.yml
+++ b/images/multicluster-operators-subscription.yml
@@ -20,6 +20,9 @@ delivery:
   delivery_repo_names:
   - rhacm2/multicluster-operators-subscription-rhel9
 for_payload: false
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
 from:
   builder:
     - stream: rhel-9-golang


### PR DESCRIPTION
## Summary
- Re-enable `multicluster-operators-subscription` image (remove `mode: disabled`)
- Disable symlink check in Konflux group config (`enable_symlink_check: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)