### PR TITLE
Use floating base image stream for block-copyfail

### DIFF
--- a/images/block-copyfail.yml
+++ b/images/block-copyfail.yml
@@ -25,7 +25,7 @@ enabled_repos:
 from:
   builder:
   - stream: rhel9-custom
-  member: openshift-enterprise-base-rhel9
+  stream: openshift-enterprise-base-rhel9
 name: openshift4/ose-block-copyfail-rhel9
 owners:
 - aos-team-art@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -5,3 +5,7 @@ rhel9-custom:
 rhel9-minimal-custom:
   image: registry.access.redhat.com/ubi9/ubi-minimal:latest
   mirror: false
+
+openshift-enterprise-base-rhel9:
+  image: registry.redhat.io/openshift/art-images-base:ose-4-21-openshift-enterprise-base-rhel9
+  mirror: false


### PR DESCRIPTION
## Summary

- Adds openshift-enterprise-base-rhel9 stream to streams.yml using the floating tag registry.redhat.io/openshift/art-images-base:ose-4-21-openshift-enterprise-base-rhel9
- Updates block-copyfail.yml to use from.stream instead of from.member for the base image, since the openshift-enterprise-base-rhel9 image metadata does not exist on this branch

## Test plan

- Verify the stream resolves correctly when building block-copyfail
- Confirm the floating tag pulls the correct 4.21 enterprise base image

Ref: [ART-18771](https://redhat.atlassian.net/browse/ART-18771)

Made with [Cursor](https://cursor.com)