### PR TITLE
Add version field to supplemental-tools group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -2,6 +2,7 @@ freeze_automation: true
 
 name: supplemental-tools
 product: supplemental-tools
+version: 1.0.0
 
 arches:
 - x86_64


### PR DESCRIPTION
The build_layered_products pipeline requires a version field in group.yml. Without it, the pipeline raises: ValueError: No version found in group config for supplemental-tools

Sets version to 1.0.0.

Ref: [ART-18771](https://redhat.atlassian.net/browse/ART-18771)

Made with [Cursor](https://cursor.com)