### PR TITLE
ART-19406 [openshift-4.20]: force base image release for ose-must-gather and ose-tools

### DIFF
--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -24,6 +24,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -25,6 +25,8 @@ enabled_repos:
 dependents:
 - ose-aws-efs-csi-driver-operator
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to `ose-must-gather` and `ose-tools` image metadata for openshift-4.20, completing the builder-linked image set from the base-image release audit.

## Problem
**Before:** `ose-must-gather` and `ose-tools` had no metadata override to force base-image release behavior, unlike other builder-linked images already updated on 4.20.

**After:** Both image definitions now set `base_image_release.force: true` so base-image release can be forced when required.

Related: [ART-19406](https://redhat.atlassian.net/browse/ART-19406)