### PR TITLE
ART-19407 [openshift-4.15]: force base image release for ose-tools and ose-must-gather

### DIFF
--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -22,6 +22,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-must-gather
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: golang

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -23,6 +23,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-tools-rhel8
 for_payload: true
+base_image_release:
+  force: true
 from:
   member: openshift-enterprise-cli
 labels:


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to base image metadata for openshift-4.15, per [ART-19407](https://redhat.atlassian.net/browse/ART-19407) SBOM audit (base images only; excludes openshift-enterprise-base-rhel9 OPD child-build cases).

## Problem
**Before:** Base image definitions had no metadata override to force base-image release behavior.

**After:** Selected base image definitions now set `base_image_release.force: true` so base-image release can be forced when required.

Related: [ART-19407](https://redhat.atlassian.net/browse/ART-19407)