### PR TITLE
ART-19408 [openshift-4.16]: force base image release for openshift-enterprise-cli, ose-must-gather, and ose-tools

### DIFF
--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -20,6 +20,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-cli-rhel9
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -22,6 +22,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-must-gather-rhel9
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -23,6 +23,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-tools-rhel9
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to base image metadata for openshift-4.16, per [ART-19408](https://redhat.atlassian.net/browse/ART-19408) SBOM audit (base images only; excludes openshift-enterprise-base-rhel9 OPD child-build cases).

## Problem
**Before:** Base image definitions had no metadata override to force base-image release behavior.

**After:** Selected base image definitions now set `base_image_release.force: true` so base-image release can be forced when required.

Related: [ART-19408](https://redhat.atlassian.net/browse/ART-19408)