### PR TITLE
ART-19410 [openshift-4.18]: force base image release for openshift-enterprise-cli, ose-must-gather, and ose-tools

### DIFF
--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -20,6 +20,8 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-cli-rhel9
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -22,6 +22,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -25,6 +25,8 @@ enabled_repos:
 dependents:
 - ose-aws-efs-csi-driver-operator
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to base image metadata for openshift-4.18, per [ART-19410](https://redhat.atlassian.net/browse/ART-19410) SBOM audit (base images only; excludes openshift-enterprise-base-rhel9 OPD child-build cases).

## Problem
**Before:** Base image definitions had no metadata override to force base-image release behavior.

**After:** Selected base image definitions now set `base_image_release.force: true` so base-image release can be forced when required.

Related: [ART-19410](https://redhat.atlassian.net/browse/ART-19410)