### PR TITLE
ART-19414 [openshift-4.14]: force base image release for ose-tools and ose-must-gather

### DIFF
--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -14,6 +14,8 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: golang

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -16,6 +16,8 @@ enabled_repos:
 - rhel-8-appstream-rpms
 - rhel-8-baseos-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   member: openshift-enterprise-cli
 labels:


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to base image metadata for openshift-4.14, per [ART-19414](https://redhat.atlassian.net/browse/ART-19414) SBOM audit (base images only).

## Problem
**Before:** Base image definitions had no metadata override to force base-image release behavior.

**After:** Selected base image definitions now set `base_image_release.force: true` so base-image release can be forced when required.

Related: [ART-19414](https://redhat.atlassian.net/browse/ART-19414)