### PR TITLE
ART-19415 [openshift-5.0]: force base image release for ose-tools and ose-must-gather

### DIFF
--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -24,6 +24,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -25,6 +25,8 @@ enabled_repos:
 dependents:
 - ose-aws-efs-csi-driver-operator
 for_payload: true
+base_image_release:
+  force: true
 from:
   builder:
   - stream: rhel-9-golang


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to base image metadata for openshift-5.0, per [ART-19415](https://redhat.atlassian.net/browse/ART-19415) SBOM audit (base images only).

## Problem
**Before:** Base image definitions had no metadata override to force base-image release behavior.

**After:** Selected base image definitions now set `base_image_release.force: true` so base-image release can be forced when required.

Related: [ART-19415](https://redhat.atlassian.net/browse/ART-19415)