### PR TITLE
ART-17449 Enable rhel-8 Go 1.26 (extra) CI builder and buildroot images

### DIFF
--- a/images/ci-openshift-build-root-extra.rhel8.yml
+++ b/images/ci-openshift-build-root-extra.rhel8.yml
@@ -1,5 +1,3 @@
-# No extra golang at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-golang-builder-extra.rhel8.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel8.yml
@@ -1,5 +1,3 @@
-# No extra golang at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they


### PR DESCRIPTION
rhel8 extra is currently pointing at 1.26 https://github.com/openshift-eng/ocp-build-data/pull/10826 
Note: In future, this will be moved to go_latest (not part of current change)

## Summary
- Enable `ci-openshift-golang-builder-extra.rhel8` and `ci-openshift-build-root-extra.rhel8` by removing `mode: disabled`
- These images mirror to `registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-5.0` and `registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.26-openshift-5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)