### PR TITLE
ART-19421 [mta-8.0]: force base image release for mta-jdtls-server-base and mta-analyzer-lsp

### DIFF
--- a/images/mta-analyzer-lsp.yml
+++ b/images/mta-analyzer-lsp.yml
@@ -21,6 +21,8 @@ delivery:
   delivery_repo_names:
   - mta/mta-analyzer-lsp-rhel9
 for_payload: false
+base_image_release:
+  force: true
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -16,6 +16,8 @@ delivery:
   delivery_repo_names:
   - mta/mta-jdtls-server-base-rhel9
 for_payload: false
+base_image_release:
+  force: true
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms


### PR DESCRIPTION
## Summary
Add `base_image_release.force: true` to MTA base image metadata for mta-8.0, per [ART-19421](https://redhat.atlassian.net/browse/ART-19421) SBOM audit (base images only).

## Problem
**Before:** Base MTA image definitions had no metadata override to force base-image release behavior for internal quay.io bases.

**After:** Selected base image definitions now set `base_image_release.force: true` so base-image release can be forced when required.

Related: [ART-19421](https://redhat.atlassian.net/browse/ART-19421)