### PR TITLE
ART-17449 Bump 1.26 builders and enable rhel-8 extra golang CI builders for 4.23

### DIFF
--- a/images/ci-openshift-build-root-extra.rhel8.yml
+++ b/images/ci-openshift-build-root-extra.rhel8.yml
@@ -1,5 +1,3 @@
-# No 'extra' golang at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-golang-builder-extra.rhel8.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel8.yml
@@ -1,5 +1,3 @@
-# No 'extra' golang at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/streams.yml
+++ b/streams.yml
@@ -36,11 +36,14 @@ rhel-8-golang:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.26:
-  aliases:
-    - rhel-9-golang-{GO_EXTRA}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.2-202605152147.p2.gb1b9903.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.3-202605272015.p2.ged14a27.el9
   mirror: true
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
+rhel-8-golang-1.26:
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.3-202605272015.p2.g8642f2e.el8
+  mirror: true
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.25:
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081607.p2.g2aa6a05.el8


### PR DESCRIPTION
## Summary
- Backport golang 1.26 builder changes from openshift-5.0 (PRs #10826 and #10958)
- Bump rhel-9-golang-1.26 image to v1.26.3
- Add rhel-8-golang-1.26 stream to streams.yml
- Enable rhel-8 extra golang builder and buildroot CI images (remove `mode: disabled`)

## Test plan
- [ ] Verify streams.yml golang entries match openshift-5.0
- [ ] Verify ci-openshift-golang-builder-extra.rhel8 and ci-openshift-build-root-extra.rhel8 are enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)