### PR TITLE
Update Go 1.25 builders to 1.25.9 for 5.0

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604081607.p2.g2aa6a05.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.g2aa6a05.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -46,7 +46,7 @@ rhel-8-golang-1.26:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.25:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081607.p2.g2aa6a05.el8
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.9-202604242241.p2.g2aa6a05.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.25-openshift-{MAJOR}.{MINOR}
@@ -54,7 +54,7 @@ partner-rhel-8-golang-1.25:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.25-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-9-golang-1.25:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604150744.p2.gf28329a.el9
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.9-202604271607.p2.ge9dad93.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.25-openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
## Summary
- Bump Go 1.25.8 → 1.25.9 builder images in streams.yml for openshift-5.0
- Updates rhel-9-golang, rhel-8-golang, partner-rhel-8-golang-1.25, and partner-rhel-9-golang-1.25 streams
- Aligns with the latest builder versions already in openshift-4.22

## Test plan
- [ ] Verify builder images resolve correctly
- [ ] Confirm CI builds pass with updated streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)