### PR TITLE
Revert "[openshift-4.23] ART-17449 5.0 - Enable opening reconciliation PRs"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -262,7 +262,7 @@ canonical_builders_from_upstream: true
 # builders are not yet set up correctly for the release at branch cut time, and we want to limit
 # the churn.
 reconciliation_prs:
-  enabled: true
+  enabled: false
 
 # To decide whether to build and use signed RPMs, and to decide if a strict bug validation flow is necessary.
 # Possible values are defined here: https://github.com/openshift-eng/art-tools/blob/main/artcommon/artcommonlib/release_util.py#L55-L59


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#10969

4.23 shouldn't have this enabled. Revert