### PR TITLE
HYPBLD-844: MCE 2.11 — 3 Konflux-verified images

### DIFF
--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -1,0 +1,29 @@
+content:
+  source:
+    dockerfile: build/Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-backplane-operator.git
+      web: https://github.com/stolostron/backplane-operator
+distgit:
+  component: mce-backplane-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/backplane-operator-rhel9
+for_payload: false
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+from:
+  builder:
+    - stream: rhel9
+    - stream: rhel-9-golang
+  stream: rhel9
+name: multicluster-engine/backplane-operator-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-backplane-operator-container

--- a/images/cluster-api-provider-aws.yml
+++ b/images/cluster-api-provider-aws.yml
@@ -1,0 +1,35 @@
+content:
+  source:
+    dockerfile: stolostron/Dockerfile.stolostron
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-cluster-api-provider-aws.git
+      web: https://github.com/stolostron/cluster-api-provider-aws
+    modifications:
+      - action: replace
+        match: "go build -o manager"
+        replacement: "go build -o /tmp/manager"
+      - action: replace
+        match: "/opt/app-root/src/manager"
+        replacement: "/tmp/manager"
+distgit:
+  component: mce-cluster-api-provider-aws-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/cluster-api-provider-aws-rhel9
+for_payload: false
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+from:
+  builder:
+    - stream: rhel-9-golang-1.25
+  stream: rhel9
+name: multicluster-engine/cluster-api-provider-aws-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-cluster-api-provider-aws-container

--- a/images/managed-serviceaccount.yml
+++ b/images/managed-serviceaccount.yml
@@ -1,0 +1,28 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhtap
+    git:
+      branch:
+        target: backplane-2.11
+      url: git@github.com:openshift-priv/stolostron-managed-serviceaccount.git
+      web: https://github.com/stolostron/managed-serviceaccount
+distgit:
+  component: mce-managed-serviceaccount-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - multicluster-engine/managed-serviceaccount-rhel9
+for_payload: false
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+from:
+  builder:
+    - stream: rhel-9-golang-1.25
+  stream: rhel9
+name: multicluster-engine/managed-serviceaccount-rhel9
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: mce-managed-serviceaccount-container


### PR DESCRIPTION
## Summary

- Adds 3 MCE 2.11 image configs verified as building successfully in Konflux:
  - **backplane-operator**
  - **cluster-api-provider-aws** — includes `modifications` to fix WORKDIR mismatch with ART builder
  - **managed-serviceaccount**

- Follows the same pattern as #10771 (15 images) and #10777 (4 images) — splitting verified images into separate PRs for incremental merge.

## Test plan

- [x] All 3 images verified as building successfully in Konflux pipeline runs