### PR TITLE
ART-18521 [openshift-4.18]: Node 22 builder for networking-console-plugin

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -30,7 +30,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - member: openshift-base-nodejs.rhel9
+  - member: openshift-base-nodejs-22.rhel9
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-networking-console-plugin-rhel9
 owners:

--- a/images/openshift-base-nodejs-22.rhel9.yml
+++ b/images/openshift-base-nodejs-22.rhel9.yml
@@ -1,0 +1,41 @@
+base_only: true
+content:
+  source:
+    git:
+      branch:
+        target: openshift-base-nodejs-rhel9
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: true
+      transform: rhel-9/base-repos
+      upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-22-openshift-{MAJOR}.{MINOR}.art
+      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-22-openshift-{MAJOR}.{MINOR}
+    okd_alignment:
+      resolve_as:
+        image: registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-22-openshift-{MAJOR}.{MINOR}
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-base-nodejs-22-container
+# the console build cares not, but just to keep us/ds same as possible, end with same USER:
+final_stage_user: 1001
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+scan_sources:
+  # Packages exempted from update:
+  # https://github.com/openshift-eng/ocp-build-data/blob/0fb79a4bfdfad72416f37f6a10e672d05b52ba9e/Dockerfile#L17
+  exempt_rpms:
+  - nodejs*
+  - npm
+for_payload: false
+for_release: false
+from:
+  stream: nodejs-22-rhel9
+labels:
+  io.k8s.description: This image is only used in building images that require Node.js 22 and is not shipped.
+name: openshift/base-nodejs-rhel9-22
+owners:
+- aos-team-art@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -157,7 +157,7 @@ nodejs-rhel9:
   mirror: true
 
 nodejs-22-rhel9:
-  image: registry.redhat.io/ubi9/nodejs-22:1-1741637231
+  image: registry.redhat.io/ubi9/nodejs-22:1
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-22-base-{MAJOR}.{MINOR}.art
   mirror: true
 

--- a/streams.yml
+++ b/streams.yml
@@ -157,7 +157,7 @@ nodejs-rhel9:
   mirror: true
 
 nodejs-22-rhel9:
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-3
+  image: registry.redhat.io/ubi9/nodejs-22:1-1741637231
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-22-base-{MAJOR}.{MINOR}.art
   mirror: true
 

--- a/streams.yml
+++ b/streams.yml
@@ -156,6 +156,11 @@ nodejs-rhel9:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true
 
+nodejs-22-rhel9:
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-3
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-22-base-{MAJOR}.{MINOR}.art
+  mirror: true
+
 centos_stream8:
   # Mirror the centos images so that okd_alignment can reference them in app.ci
   image: quay.io/centos/centos:stream8


### PR DESCRIPTION
## Summary

Add a parallel Node 22 builder path for `networking-console-plugin` on 4.18 while leaving other console images on the existing Node 18 `nodejs-rhel9` stream.

## Problem

**Before:** `networking-console-plugin` builds with `openshift-base-nodejs.rhel9` → `nodejs-rhel9` (ubi9-nodejs-18). Upstream console SDK deps need Node 22.

**After:** New `nodejs-22-rhel9` stream and `openshift-base-nodejs-22.rhel9` base image; only `networking-console-plugin` uses the Node 22 builder. Monitoring/console plugin images unchanged.

Related: [ART-18521](https://redhat.atlassian.net/browse/ART-18521)

## Jenkins validation (test assembly)

| Step | Job | Result |
|------|-----|--------|
| seed-lockfile `openshift-base-nodejs-22.rhel9` | [build/seed-lockfile #442](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/442/) | SUCCESS |
| ocp4-konflux `networking-console-plugin` | [build/ocp4-konflux #36517](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/36517/) | SUCCESS |

Seed NVR: `openshift-base-nodejs-22-container-v4.18.0-202606031212.p2.g8374249.assembly.test.el9`

## Test plan

- [x] seed-lockfile for `openshift-base-nodejs-22.rhel9` (test assembly)
- [x] ocp4-konflux build `networking-console-plugin` on test assembly
- [ ] Merge; backport to 4.16 ([ART-18760](https://redhat.atlassian.net/browse/ART-18760)) and 4.17 ([ART-18717](https://redhat.atlassian.net/browse/ART-18717)) — PRs open