### PR TITLE
ART-18717 [openshift-4.17]: Node 22 builder for networking-console-plugin

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -30,7 +30,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - member: openshift-base-nodejs.rhel9
+  - member: openshift-base-nodejs-22.rhel9
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-networking-console-plugin-rhel9
 owners:

--- a/images/openshift-base-nodejs-22.rhel9.yml
+++ b/images/openshift-base-nodejs-22.rhel9.yml
@@ -1,0 +1,41 @@
+base_only: true
+content:
+  source:
+    git:
+      branch:
+        target: openshift-base-nodejs-rhel9
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: true
+      transform: rhel-9/base-repos
+      upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-22-openshift-{MAJOR}.{MINOR}.art
+      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-22-openshift-{MAJOR}.{MINOR}
+    okd_alignment:
+      resolve_as:
+        image: registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-22-openshift-{MAJOR}.{MINOR}
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-base-nodejs-22-container
+# the console build cares not, but just to keep us/ds same as possible, end with same USER:
+final_stage_user: 1001
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+scan_sources:
+  # Packages exempted from update:
+  # https://github.com/openshift-eng/ocp-build-data/blob/0fb79a4bfdfad72416f37f6a10e672d05b52ba9e/Dockerfile#L17
+  exempt_rpms:
+  - nodejs*
+  - npm
+for_payload: false
+for_release: false
+from:
+  stream: nodejs-22-rhel9
+labels:
+  io.k8s.description: This image is only used in building images that require Node.js 22 and is not shipped.
+name: openshift/base-nodejs-rhel9-22
+owners:
+- aos-team-art@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -146,7 +146,7 @@ nodejs-rhel9:
   mirror: true
 
 nodejs-22-rhel9:
-  image: registry.redhat.io/ubi9/nodejs-22:1
+  image: registry.redhat.io/ubi9/nodejs-22:latest
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-22-base-{MAJOR}.{MINOR}.art
   mirror: true
 

--- a/streams.yml
+++ b/streams.yml
@@ -146,7 +146,7 @@ nodejs-rhel9:
   mirror: true
 
 nodejs-22-rhel9:
-  image: registry.redhat.io/ubi9/nodejs-22:1-1741637231
+  image: registry.redhat.io/ubi9/nodejs-22:1
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-22-base-{MAJOR}.{MINOR}.art
   mirror: true
 

--- a/streams.yml
+++ b/streams.yml
@@ -146,7 +146,7 @@ nodejs-rhel9:
   mirror: true
 
 nodejs-22-rhel9:
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-3
+  image: registry.redhat.io/ubi9/nodejs-22:1-1741637231
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-22-base-{MAJOR}.{MINOR}.art
   mirror: true
 

--- a/streams.yml
+++ b/streams.yml
@@ -145,6 +145,11 @@ nodejs-rhel9:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true
 
+nodejs-22-rhel9:
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-3
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-22-base-{MAJOR}.{MINOR}.art
+  mirror: true
+
 centos_stream8:
   # Mirror the centos images so that okd_alignment can reference them in app.ci
   image: quay.io/centos/centos:stream8


### PR DESCRIPTION
## Summary

Add a parallel Node 22 builder stream and base image for networking-console-plugin on openshift-4.17. Other console images keep nodejs-rhel9 (Node 18).

## Problem

**Before:** networking-console-plugin used openshift-base-nodejs.rhel9 (Node 18) while upstream needs Node 22 for the npm build.

**After:** networking-console-plugin uses openshift-base-nodejs-22.rhel9; nodejs-22-rhel9 stream added.

Related: [ART-18717](https://redhat.atlassian.net/browse/ART-18717)

## Jenkins validation (test assembly)

| Step | Job | Result |
|------|-----|--------|
| seed-lockfile `openshift-base-nodejs-22.rhel9` | [build/seed-lockfile #447](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fseed-lockfile/447/) | SUCCESS |
| ocp4-konflux `networking-console-plugin` | [build/ocp4-konflux #36543](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/36543/) | SUCCESS |

Seed NVR: `openshift-base-nodejs-22-container-v4.17.0-202606031400.p2.g8374249.assembly.test.el9`

## Test plan

- [x] seed-lockfile for `openshift-base-nodejs-22.rhel9` (test assembly)
- [x] ocp4-konflux build `networking-console-plugin` on test assembly