### PR TITLE
logging-6.6: Update Go builder to 1.26.2

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.2-202605201716.p2.g3947b71.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:


### PR DESCRIPTION
/label tide/merge-method-squash