### PR TITLE
Disable rhcos-node-image for scan issue

### DIFF
--- a/images/rhcos-node-image.yml
+++ b/images/rhcos-node-image.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Containerfile


### PR DESCRIPTION
ocp4-scan-konflux runs into this error:

```09:45:15  2026-06-04 07:45:15,440 doozerlib.cli.scan_sources_konflux ERROR Failed scanning image rhcos-node-image during builder checks
09:45:15  Traceback (most recent call last):
09:45:15    File "/mnt/jenkins-workspace/d-builds_build_ocp4-scan-konflux@2/art-tools/doozer/doozerlib/cli/scan_sources_konflux.py", line 626, in scan_image
09:45:15      await self.scan_builders_changes(image_meta)
09:45:15    File "/mnt/jenkins-workspace/d-builds_build_ocp4-scan-konflux@2/art-tools/doozer/doozerlib/cli/scan_sources_konflux.py", line 587, in inner
09:45:15      return await coro(self, image_meta, *args, **kwargs)
09:45:15             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
09:45:15    File "/mnt/jenkins-workspace/d-builds_build_ocp4-scan-konflux@2/art-tools/doozer/doozerlib/cli/scan_sources_konflux.py", line 1041, in scan_builders_changes
09:45:15      raise IOError(f'Unable to find nvr for {builder_image_name}')
09:45:15  OSError: Unable to find nvr for registry.ci.openshift.org/coreos/rhel-coreos-base:9.8
```