### PR TITLE
[openshift-5.0]: point nodejs-rhel9 at registry.redhat.io ubi9/nodejs-22:latest

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -83,7 +83,7 @@ rhel9:
   mirror: false
 
 nodejs-rhel9:
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-3
+  image: registry.redhat.io/ubi9/nodejs-22:latest
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
## Summary
Update `nodejs-rhel9` stream pullspec from registry-proxy OSBS to `registry.redhat.io/ubi9/nodejs-22:latest`.

## Problem
**Before:** `nodejs-rhel9` used `registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-3` (OSBS-only registry).

**After:** `registry.redhat.io/ubi9/nodejs-22:latest` — same Node 22 content, customer-facing registry (aligned with 4.16–4.18 backport PRs #10973–#10975).

No image YAML changes; all console builder consumers already use `openshift-base-nodejs.rhel9`.
