### PR TITLE
Remove wildcard permit

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -215,8 +215,6 @@ releases:
         # ref. https://redhat-internal.slack.com/archives/C01CQA76KMX/p1738863088399379
         - code: INCONSISTENT_RHCOS_RPMS
           component: rhcos
-        - code: MISMATCHED_SIBLINGS
-          component: '*'
         - code: FAILED_CONSISTENCY_REQUIREMENT
           component: '*'
       members:


### PR DESCRIPTION
Removing wildcard permit for `MISMATCHED_SIBLINGS`. Since it affects [installer](https://redhat-internal.slack.com/archives/CB95J6R4N/p1780517405302979)

Lets move to component specific permits from now one so that installer is not included.