### PR TITLE
Enable rpm-lockfile-prototype for ose-baremetal-installer in 5.0

### DIFF
--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -42,6 +42,9 @@ payload_name: baremetal-installer
 owners:
 - kni-devel-deployment@redhat.com
 konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype
   vm_override:
     x86_64: linux-d160-c4xlarge/amd64
     aarch64: linux-d160-c4xlarge/arm64


### PR DESCRIPTION
## Summary
- Enable `rpm-lockfile-prototype` backend for ose-baremetal-installer to fix persistent build failures (97 attempts since last success)
- Matches the fix applied in 4.22 via #10889

## Test plan
- [ ] Verify ose-baremetal-installer builds successfully with the new backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)