### PR TITLE
Change agentic-skills to use scratch stream (ART-18530)

### DIFF
--- a/images/agentic-skills.yml
+++ b/images/agentic-skills.yml
@@ -15,7 +15,7 @@ delivery:
   - openshift5/agentic-skills
 for_payload: true
 from:
-  member: openshift-enterprise-base-rhel9
+  stream: scratch
 name: openshift/agentic-skills
 payload_name: agentic-skills
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -111,3 +111,6 @@ centos_stream10:
 rhel_coreos:
   image: registry.ci.openshift.org/coreos/rhel-coreos-base:9.8
   skip_nvr_check: true
+
+scratch:
+  image: scratch


### PR DESCRIPTION
## Summary
- Change `agentic-skills` image to build `from: stream: scratch` instead of `from: member: openshift-enterprise-base-rhel9`
- Add `scratch` stream definition to `streams.yml` pointing to `image: scratch`

## Test Plan
- [ ] Verify ART pipeline picks up the new `scratch` stream correctly
- [ ] Confirm `agentic-skills` image builds successfully from scratch base