### PR TITLE
Add builder stage to base-rhel9 metadata for multi-stage Dockerfile

### DIFF
--- a/images/openshift-enterprise-base-rhel9.yml
+++ b/images/openshift-enterprise-base-rhel9.yml
@@ -37,6 +37,8 @@ enabled_repos:
 for_payload: false
 for_release: false
 from:
+  builder:
+  - member: openshift-base-rhel9
   member: openshift-base-rhel9
 labels:
   License: GPLv2+


### PR DESCRIPTION
## Summary
- Upstream https://github.com/openshift/images/pull/230 added a builder stage to `base/Dockerfile.rhel9` for post-quantum crypto-policies configuration
- The Dockerfile now has 2 FROMs (builder + final), but ART metadata only declared 1 (`from.member`), causing a cardinality mismatch
- This mismatch results in the reconciliation PR ([openshift/images#236](https://github.com/openshift/images/pull/236)) getting an `URGENT!` warning comment instead of proper FROM rewriting, which blocks all ~223 downstream image PRs
- Fix: add `from.builder: - member: openshift-base-rhel9` to match the builder stage (which uses the same base image)

## Test plan
- [ ] Re-run `sync-ci-images` for 5.0 and verify the base image reconciliation PR no longer has the URGENT comment
- [ ] Verify downstream image PRs are no longer blocked by the cardinality mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)