### PR TITLE
pin openshift-kubernetes-nmstate-operator in 4.21.19

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -50,7 +50,12 @@ releases:
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:625507510e228c54fe55515b3bf4a16b1ffe08f5a6bb5a59331b655ed86b80dd
       members:
         rpms: []
-        images: []
+        images:
+        - distgit_key: openshift-kubernetes-nmstate-operator
+          why: Latest build has missing nmstate-console-plugin operand image in quay. Same commit, all operands match.
+          metadata:
+            is:
+              nvr: ose-kubernetes-nmstate-operator-container-v4.21.0-202606030321.p2.g0766979.assembly.stream.el9
       permits:
         - code: CONFLICTING_INHERITED_DEPENDENCY
           component: cluster-node-tuning-operator


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED