### PR TITLE
HYPBLD-844: Add cachito configs for MCE 2.11 hermetic builds

### DIFF
--- a/images/azure-service-operator.yml
+++ b/images/azure-service-operator.yml
@@ -1,3 +1,8 @@
+cachito:
+  enabled: true
+  packages:
+    gomod:
+    - path: v2
 content:
   source:
     dockerfile: stolostron/Dockerfile.stolostron

--- a/images/azure-service-operator.yml
+++ b/images/azure-service-operator.yml
@@ -5,6 +5,8 @@ cachito:
     - path: v2
 content:
   source:
+    pkg_managers:
+    - gomod
     dockerfile: stolostron/Dockerfile.stolostron
     git:
       branch:

--- a/images/console-mce.yml
+++ b/images/console-mce.yml
@@ -1,3 +1,10 @@
+cachito:
+  enabled: true
+  packages:
+    npm:
+    - path: .
+    - path: backend
+    - path: frontend
 content:
   source:
     dockerfile: Containerfile.mce.konflux


### PR DESCRIPTION
## Summary

Adds missing `cachito` configurations so that hermetic (network-isolated) builds can prefetch dependencies via cachi2.

Both images were building successfully in open-network mode but fail in hermetic mode because `go mod download` / `npm ci` cannot reach the internet.

## Images fixed

### azure-service-operator
- **Problem**: `go mod download` fails with `network is unreachable` — no gomod dependencies prefetched
- **Fix**: Add `cachito.packages.gomod` with `path: v2` (since `go.mod` lives in the `v2/` subdirectory)

### console-mce
- **Problem**: `npm ci` in `backend/` fails — npm dependencies not prefetched for all subdirectories
- **Fix**: Add `cachito.packages.npm` with paths `.`, `backend`, and `frontend` (the Dockerfile runs `npm ci` in all three locations)

## Test plan

- [ ] Verify both images build successfully in hermetic Konflux builds
- [ ] `lgtm`, `/approve`


Made with [Cursor](https://cursor.com)