### PR TITLE
Add cachi2 rpm lockfile backend to openshift-enterprise-base-rhel9

### DIFF
--- a/images/openshift-enterprise-base-rhel9.yml
+++ b/images/openshift-enterprise-base-rhel9.yml
@@ -48,6 +48,10 @@ labels:
 name: openshift/openshift-enterprise-base-rhel9
 owners:
 - lmeyer@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype
 okd:
   distgit:
     branch: rhaos-{MAJOR}.{MINOR}-rhel-10


### PR DESCRIPTION
## Summary
- Add `konflux.cachi2.lockfile.backend: rpm-lockfile-prototype` to `openshift-enterprise-base-rhel9`, matching the pattern from #11032

Fixes https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/ose-5-0-openshift-enterprise-base-rhel9-zk6sb/logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)