### PR TITLE
Remove microshift_bootc_shipment URL from releases.yml

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -9,8 +9,6 @@ releases:
         release_jira: ART-14438
         release_date: 2026-Jun-09
         upgrades: 4.21.6,4.21.7,4.21.8,4.21.9,4.21.10,4.21.11,4.21.12,4.21.13,4.21.14,4.21.15,4.21.16,4.21.17,4.21.18,4.21.19,4.22.0-ec.0,4.22.0-ec.1,4.22.0-ec.2,4.22.0-ec.3,4.22.0-ec.4,4.22.0-ec.5,4.22.0-rc.0,4.22.0-rc.1,4.22.0-rc.2,4.22.0-rc.3,4.22.0-rc.4,4.22.0-rc.5
-        microshift_bootc_shipment:
-          url: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/554
         operator_index_mode: ga
         dependencies:
           rpms:


### PR DESCRIPTION
It was the rc.5 one