### PR TITLE
Clear inherited microshift_bootc_shipment for 4.22.0

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -26,6 +26,7 @@ releases:
             - kind: fbc
           env: prod
           url: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/562
+        microshift_bootc_shipment!: {}
         advisories!:
           rpm: 164955
           rhcos: 164956


### PR DESCRIPTION
4.22.0 inherits from rc.5 which has a closed microshift_bootc_shipment MR, causing build-microshift-bootc to fail with `MR state closed is not opened`.