### PR TITLE
CNTRLPLANE-3380: Add commit prefix to HyperShift component images

### DIFF
--- a/images/aws-kms-encryption-provider.yml
+++ b/images/aws-kms-encryption-provider.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/aws-encryption-provider
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/aws-node-termination-handler.yml
+++ b/images/aws-node-termination-handler.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/aws-node-termination-handler
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/azure-kms-encryption-provider.yml
+++ b/images/azure-kms-encryption-provider.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/azure-kubernetes-kms
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:

--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/apiserver-network-proxy
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:


### PR DESCRIPTION
## Summary
- Adds `commit_prefix: "UPSTREAM: <carry>: "` to 4 HyperShift-owned image configs
- Fixes `ci/prow/verify-commits` failures on open ART CI alignment PRs:
  - [openshift/apiserver-network-proxy#112](https://github.com/openshift/apiserver-network-proxy/pull/112)
  - [openshift/aws-encryption-provider#51](https://github.com/openshift/aws-encryption-provider/pull/51)
  - [openshift/aws-node-termination-handler#11](https://github.com/openshift/aws-node-termination-handler/pull/11)
  - [openshift/azure-kubernetes-kms#43](https://github.com/openshift/azure-kubernetes-kms/pull/43)

## Files changed
- `images/ose-apiserver-network-proxy.yml`
- `images/aws-kms-encryption-provider.yml`
- `images/aws-node-termination-handler.yml`
- `images/azure-kms-encryption-provider.yml`

Follows the same pattern as https://github.com/openshift-eng/ocp-build-data/pull/7140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)