### PR TITLE
Add public_upstreams mapping for ACM 2.16

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -45,6 +45,10 @@ konflux:
 assemblies:
   enabled: true
 
+public_upstreams:
+- private: "https://github.com/openshift-priv"
+  public: "https://github.com/stolostron"
+
 branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 
 urls:


### PR DESCRIPTION
## Summary

- Adds `public_upstreams` config to `group.yml` on the `acm-2.16` branch, mapping `openshift-priv` to `stolostron`
- Without this, `scan-sources-konflux` skips the openshift-priv rebase for all ACM images with warnings like: `image governance-policy-framework-addon does not have a public upstream: skipping openshift-priv rebase`
- The `get_public_upstream()` logic in doozer strips the `stolostron-` org prefix from repo names (e.g. `stolostron-governance-policy-framework-addon` -> `governance-policy-framework-addon`) to correctly resolve the public URL

## Test plan

- [ ] Verify `scan-sources-konflux` no longer emits "does not have a public upstream" warnings for ACM images
- [ ] Verify the public URL resolution is correct (e.g. `openshift-priv/stolostron-governance-policy-framework-addon` -> `stolostron/governance-policy-framework-addon`)

Made with [Cursor](https://cursor.com)