### PR TITLE
Add cloner stage builder for multiclusterhub-operator

### DIFF
--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -19,6 +19,7 @@ enabled_repos:
 - rhel-9-appstream-rpms
 from:
   builder:
+    - stream: rhel9
     - stream: rhel-9-golang
   stream: rhel9
 name: rhacm2/multiclusterhub-operator-rhel9


### PR DESCRIPTION
## Summary
- The upstream Dockerfile (`build/Dockerfile.rhtap`) on `release-2.16` added a `cloner` stage (`FROM ubi9/ubi-minimal:latest as cloner`) as the first FROM directive
- This resulted in 3 FROM directives total, but the image config only declared 2 parent images
- The rebase fails with: `Build metadata for multiclusterhub-operator expected 2 parent images, but found 3 in Dockerfile`
- Fix: add `- stream: rhel9` as the first builder entry to match the cloner stage

## Test plan
- [x] Verified `streams.yml` has `rhel9` mapping to `ubi9/ubi-minimal`
- [x] Confirmed precedent: `must-gather.yml`, `acm-cli.yml` already use multiple builders
- [ ] Re-run `build-layered-products` with this change to verify rebase+build succeeds


Made with [Cursor](https://cursor.com)