### PR TITLE
Migrate rhel-8-golang-1.19 to golang mono-branch

### DIFF
--- a/Dockerfiles/1-19.rhel8.Dockerfile
+++ b/Dockerfiles/1-19.rhel8.Dockerfile
@@ -1,0 +1,79 @@
+FROM registry.redhat.io/ubi8:latest
+
+ARG GOPATH
+ENV SUMMARY="RHEL8 based Go builder image for OpenShift ART" \
+    container=oci \
+    GOFLAGS='-mod=vendor' \
+    GOPATH=${GOPATH:-/go} \
+    GOMAXPROCS=8 \
+    VERSION="1.19" \ 
+    GO_VERSION="${__doozer_version:-$VERSION}"
+
+LABEL summary="$SUMMARY" \
+      description="$SUMMARY" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Go Builder $VERSION" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      version="$VERSION"
+
+RUN dnf update -y && \
+    dnf install -y --nodocs \
+        bc \
+        diffutils \
+        dos2unix \
+        file \
+        findutils \
+        git \
+        goversioninfo \
+        gpgme \
+        gpgme-devel \
+        hostname \
+        libassuan-devel \
+        libtool \
+        lsof \
+        make \
+        openssl \
+        openssl-devel \
+        patch \
+        python3 \
+        rsync \
+        socat \
+        systemd-devel \
+        tar \
+        tree \
+        util-linux \
+        wget \
+        which \
+        xz \
+        zip && \
+    dnf install -y "golang-*$VERSION*" && \
+    mkdir -p /go/src
+# provide a cross-compiler for windows/mac binaries (x86_64 only)
+COPY cross.tar.gz .
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+    # only install cross-compiler dependencies on x86_64
+    yum install -y --setopt=tsflags=nodocs \
+    # Required packages for mac cross-compilation
+    llvm-toolset cmake3 gcc-c++ libxml2-devel \
+    # Required packages for windows cross-compilation
+    glibc mingw64-gcc && \
+    # compile macos cross-compilers
+    tar zfx cross.tar.gz && \
+    export TP_OSXCROSS_DEV=$(pwd)/cross/deps && \
+    pushd cross/osxcross && \
+    UNATTENDED=yes ./build.sh && \
+    popd && \
+    cp -avr cross/osxcross/target/bin/* /usr/local/bin/ && \
+    cp -avr cross/osxcross/target/lib/* /usr/local/lib64/ && \
+    cp -avr cross/osxcross/target/SDK /usr/local/SDK && \
+    echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
+    /sbin/ldconfig && \
+    rm -rf cross; \
+fi
+
+# above is conditional; clean up unconditionally
+RUN rm -f cross.tar.gz && yum clean all -y
+
+# FOD wrapper modification
+COPY go_wrapper.sh /tmp/go_wrapper.sh
+RUN GO_BIN_PATH=$(which go) && mv $GO_BIN_PATH $GO_BIN_PATH.real && mv /tmp/go_wrapper.sh $GO_BIN_PATH && chmod +x $GO_BIN_PATH

--- a/Dockerfiles/1-19.rhel8.Dockerfile
+++ b/Dockerfiles/1-19.rhel8.Dockerfile
@@ -6,7 +6,7 @@ ENV SUMMARY="RHEL8 based Go builder image for OpenShift ART" \
     GOFLAGS='-mod=vendor' \
     GOPATH=${GOPATH:-/go} \
     GOMAXPROCS=8 \
-    VERSION="1.19" \ 
+    VERSION="1.19" \
     GO_VERSION="${__doozer_version:-$VERSION}"
 
 LABEL summary="$SUMMARY" \

--- a/images/openshift-golang-builder-1-19.rhel8.yml
+++ b/images/openshift-golang-builder-1-19.rhel8.yml
@@ -1,0 +1,55 @@
+content:
+  set_build_variables: false
+  source:
+    path: images
+    dockerfile: openshift-golang-builder.Dockerfile
+    git:
+      branch:
+        target: golang
+      url: git@github.com:openshift-eng/ocp-build-data.git
+    modifications:
+    - &add_fips_wrapper
+      action: add
+      doozer_source: golang_builder_FIPS_wrapper.sh
+      path: go_wrapper.sh
+      overwriting: true
+enabled_repos:
+- rhel-8-golang-rpms
+- rhel-8-baseos-rpms
+# for clang
+- rhel-8-appstream-rpms
+- rhel-8-codeready-builder-rpms
+
+from:
+  stream: rhel-86
+
+labels:
+  io.k8s.description: golang builder image for Red Hat internal builds
+
+name: openshift/golang-builder
+
+owners:
+- aos-team-art@redhat.com
+
+additional_tags:
+- 'rhel_8_golang_1.19'
+- 'rhel_8_1.19'
+maintainer:
+  component: Release
+
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype
+      rpms:
+      - golang
+    artifact_lockfile:
+      resources:
+      - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
+  content:
+    source:
+      modifications:
+        - *add_fips_wrapper
+        - action: replace
+          match: "COPY cross.tar.gz "
+          replacement: "RUN cp /cachi2/output/deps/generic/cross.tar.gz "

--- a/images/openshift-golang-builder-1-19.rhel8.yml
+++ b/images/openshift-golang-builder-1-19.rhel8.yml
@@ -1,8 +1,8 @@
 content:
   set_build_variables: false
   source:
-    path: images
-    dockerfile: openshift-golang-builder.Dockerfile
+    path: Dockerfiles
+    dockerfile: 1-19.rhel8.Dockerfile
     git:
       branch:
         target: golang
@@ -15,10 +15,10 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-8-baseos-rpms
+- rhel-86-baseos-rpms
 # for clang
-- rhel-8-appstream-rpms
-- rhel-8-codeready-builder-rpms
+- rhel-86-appstream-rpms
+- rhel-86-codeready-builder-rpms
 
 from:
   stream: rhel-86

--- a/streams.yml
+++ b/streams.yml
@@ -1,23 +1,23 @@
 ---
-rhel-94:
-# rhel-els-container-9.4-943.1726661131
-  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7
+rhel-86:
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.6-754
 
 rhel-810:
   # ubi8-container-8.10-901.1717584420
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8@sha256:143123d85045df426c5bbafc6863659880ebe276eb02c77ee868b88d08dbd05d
 
-rhel-86:
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.6-754
-
-rhel10:
-  # TODO: update with actual rhel-10 base image digest
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi10:latest
-
 rhel-90:
 # rhel-els-container-9.0.0-974
   image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:c00fe5ad75658431c97b3a225db5625a97c8f3a28253af7ec3aa622db235ff64
 
+rhel-94:
+# rhel-els-container-9.4-943.1726661131
+  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7
+
 rhel-96:
 # ubi9-container-9.6-440.1760321968
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9@sha256:08a8d763ab10280a510d12180363adbe08264a7448bcdfdf92dfaaed4549899c
+
+rhel10:
+  # TODO: update with actual rhel-10 base image digest
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi10:latest


### PR DESCRIPTION
## Summary
Migrate rhel-8-golang-1.19 variant files to the unified golang mono-branch.

## Changes
This PR adds the RHEL 8 golang 1.19 variant files to the golang mono-branch:
- `Dockerfiles/1-19.rhel8.Dockerfile`
- `images/openshift-golang-builder-1-19.rhel8.yml`
- Updates to `streams.yml` with [rhel-86](https://redhat.atlassian.net/browse/rhel-86) stream definition

## Naming Convention
Following the pattern established in PR #10624:
- **Dockerfile:** `{go-version}.{rhel-version}.Dockerfile`
- **YAML:** `openshift-golang-builder-{go-version}.{rhel-version}.yml`
- **Stream keys:** Specific RHEL versions (e.g., `rhel-86`)

## Migration Context
Part of the effort to consolidate all rhel-{8,9}-golang-1.{19-26} branches into the unified golang mono-branch. This approach allows a single branch to serve all OCP versions through runtime variable injection by doozer.

## Files Added
```
Dockerfiles/1-19.rhel8.Dockerfile
images/openshift-golang-builder-1-19.rhel8.yml
```

## streams.yml Changes
Added [rhel-86](https://redhat.atlassian.net/browse/rhel-86) stream definition for RHEL 8.6 base image.

🤖 Generated by Claude Code