### PR TITLE
Enable the rhel-102-baseos repo so that we can get 10.2 kernels

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -32,6 +32,7 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
 - rhel-9-rt-rpms
+- rhel-102-baseos
 for_payload: true
 from:
   member: openshift-enterprise-base-rhel9


### PR DESCRIPTION
The DTK toolchain itself can be major version agnostic, however we do need to have the repos enabled for all major OSes so we can install the kernel deps

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED