### PR TITLE
Fix multiclusterhub-operator update-csv manifests-dir for bundle path

### DIFF
--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -25,6 +25,8 @@ from:
 name: rhacm2/multiclusterhub-operator-rhel9
 update-csv:
   name: advanced-cluster-management
+  manifests-dir: bundle
+  bundle-dir: manifests
   registry: image-registry.openshift-image-registry.svc:5000
   registry-target-namespace: open-cluster-management
 owners:


### PR DESCRIPTION
## Summary
- Upstream stolostron/multiclusterhub-operator PR #4248 added OLM bundle artifacts under `bundle/` directory
- Doozer defaults to looking for `image-references` in `manifests/`, causing rebase failures with: `image-references file not found in any location`
- Set `manifests-dir: bundle` and `bundle-dir: manifests` to match the upstream directory structure (`bundle/image-references` and `bundle/manifests/*.clusterserviceversion.yaml`)

## Test plan
- [ ] Trigger a layered-products build and verify multiclusterhub-operator rebase succeeds
- [ ] Verify bundle build is triggered for multiclusterhub-operator

Made with [Cursor](https://cursor.com)