### PR TITLE
Add dependents: [multiclusterhub-operator] to all ACM 2.16 operand images

### DIFF
--- a/images/acm-cli.yml
+++ b/images/acm-cli.yml
@@ -26,6 +26,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/acm-cli-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/cert-policy-controller.yml
+++ b/images/cert-policy-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/cert-policy-controller-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-backup-controller.yml
+++ b/images/cluster-backup-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/cluster-backup-controller-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/cluster-permission.yml
+++ b/images/cluster-permission.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/cluster-permission-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/config-policy-controller.yml
+++ b/images/config-policy-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/config-policy-controller-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/console.yml
+++ b/images/console.yml
@@ -20,6 +20,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/console-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-nodejs-20

--- a/images/endpoint-monitoring-operator.yml
+++ b/images/endpoint-monitoring-operator.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/endpoint-monitoring-operator-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/governance-policy-addon-controller.yml
+++ b/images/governance-policy-addon-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/governance-policy-addon-controller-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/governance-policy-framework-addon.yml
+++ b/images/governance-policy-framework-addon.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/governance-policy-framework-addon-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/governance-policy-propagator.yml
+++ b/images/governance-policy-propagator.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/governance-policy-propagator-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/grafana-dashboard-loader.yml
+++ b/images/grafana-dashboard-loader.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/grafana-dashboard-loader-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -20,6 +20,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/grafana-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/insights-client.yml
+++ b/images/insights-client.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/insights-client-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/insights-metrics.yml
+++ b/images/insights-metrics.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/insights-metrics-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/klusterlet-addon-controller.yml
+++ b/images/klusterlet-addon-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/klusterlet-addon-controller-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/kube-rbac-proxy-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/kube-state-metrics-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/memcached-exporter.yml
+++ b/images/memcached-exporter.yml
@@ -19,6 +19,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/memcached-exporter-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/metrics-collector.yml
+++ b/images/metrics-collector.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/metrics-collector-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/mtv-integrations.yml
+++ b/images/mtv-integrations.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/mtv-integrations-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/multicloud-integrations.yml
+++ b/images/multicloud-integrations.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/multicloud-integrations-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/multicluster-observability-addon.yml
+++ b/images/multicluster-observability-addon.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/multicluster-observability-addon-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/multicluster-observability-operator.yml
+++ b/images/multicluster-observability-operator.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/multicluster-observability-operator-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/multicluster-operators-application.yml
+++ b/images/multicluster-operators-application.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/multicluster-operators-application-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/multicluster-operators-channel.yml
+++ b/images/multicluster-operators-channel.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/multicluster-operators-channel-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/multicluster-operators-subscription.yml
+++ b/images/multicluster-operators-subscription.yml
@@ -20,6 +20,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/multicluster-operators-subscription-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/multicluster-role-assignment.yml
+++ b/images/multicluster-role-assignment.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/multicluster-role-assignment-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/must-gather.yml
+++ b/images/must-gather.yml
@@ -22,6 +22,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/must-gather-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/node-exporter.yml
+++ b/images/node-exporter.yml
@@ -19,6 +19,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/node-exporter-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/observatorium-operator.yml
+++ b/images/observatorium-operator.yml
@@ -19,6 +19,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/observatorium-operator-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/observatorium.yml
+++ b/images/observatorium.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/observatorium-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/prometheus-alertmanager.yml
+++ b/images/prometheus-alertmanager.yml
@@ -19,6 +19,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/prometheus-alertmanager-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/prometheus-config-reloader-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/prometheus-operator-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/prometheus.yml
+++ b/images/prometheus.yml
@@ -19,6 +19,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/prometheus-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/rbac-query-proxy.yml
+++ b/images/rbac-query-proxy.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/rbac-query-proxy-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/search-collector.yml
+++ b/images/search-collector.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/search-collector-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/search-indexer.yml
+++ b/images/search-indexer.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/search-indexer-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/search-v2-api.yml
+++ b/images/search-v2-api.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/search-v2-api-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/search-v2-operator.yml
+++ b/images/search-v2-operator.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/search-v2-operator-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/siteconfig.yml
+++ b/images/siteconfig.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/siteconfig-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/submariner-addon.yml
+++ b/images/submariner-addon.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/submariner-addon-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/thanos-receive-controller.yml
+++ b/images/thanos-receive-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/thanos-receive-controller-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -19,6 +19,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/thanos-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/volsync-addon-controller.yml
+++ b/images/volsync-addon-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - rhacm2/volsync-addon-controller-rhel9
 for_payload: false
+dependents:
+- multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang


### PR DESCRIPTION
## Summary
- Adds `dependents: [multiclusterhub-operator]` to all 45 operand image configs in the acm-2.16 group
- Required for doozer's `name_in_bundle_map` to resolve image references during CSV update (update-csv)
- Without this, rebase fails with: `ValueError: Unable to find <image> in image-references data for multiclusterhub-operator`
- Follows the same pattern used in `logging-6.0` (e.g., `vector.yml` has `dependents: [cluster-logging-operator]`)
- Companion to PR #11091 (manifests-dir fix) and upstream stolostron/multiclusterhub-operator#4248

## Note
- `obo-prometheus-rhel9-operator` is listed in upstream `image-references` but has no corresponding image config in this group - needs separate handling

## Test plan
- [ ] Verify multiclusterhub-operator rebase succeeds after both this PR and #11091 are merged
- [ ] Verify bundle build is triggered for multiclusterhub-operator

Made with [Cursor](https://cursor.com)