### PR TITLE
fix(acm-cli): remove sync-build-package modification

### DIFF
--- a/images/acm-cli.yml
+++ b/images/acm-cli.yml
@@ -15,10 +15,6 @@ content:
         target: release-2.16
       url: git@github.com:openshift-priv/stolostron-acm-cli.git
       web: https://github.com/stolostron/acm-cli
-    modifications:
-      - action: replace
-        match: "make sync-build-package"
-        replacement: "make build-and-package"
 distgit:
   component: acm-cli-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9


### PR DESCRIPTION
The modification was originally added because the submodule directories did not exist at build time. Now that cachi2 prefetch populates them, git submodule update --init can reset the tree to a clean state, fixing the dirty-tree check failure in policy-cli and policy-generator-plugin.