### PR TITLE
Remove ci_build_root extra from golang-1.26 OpenStack images

### DIFF
--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -11,8 +11,6 @@ content:
       web: https://github.com/openshift/cloud-provider-openstack
     ci_alignment:
       streams_prs:
-        ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
         auto_label:
         - approved
         - lgtm

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -7,9 +7,7 @@ content:
       url: git@github.com:openshift-priv/cluster-cloud-controller-manager-operator.git
       web: https://github.com/openshift/cluster-cloud-controller-manager-operator
     ci_alignment:
-      streams_prs:
-        ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
+      streams_prs: {}
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-cloud-controller-manager-operator-container

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -8,8 +8,6 @@ content:
       web: https://github.com/openshift/cloud-provider-openstack
     ci_alignment:
       streams_prs:
-        ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
         auto_label:
         - approved
         - lgtm

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -9,8 +9,6 @@ content:
     ci_alignment:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
-        ci_build_root:
-          member: ci-openshift-build-root-extra.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cloud-controller-manager-container


### PR DESCRIPTION
## Summary
- 4 OpenStack images (`csi-driver-manila`, `ose-cluster-cloud-controller-manager-operator`, `ose-openstack-cinder-csi-driver`, `ose-openstack-cloud-controller-manager`) use `stream: rhel-9-golang-1.26` as their builder but had `ci_build_root` set to `ci-openshift-build-root-extra.rhel9`
- The extra build root resolves via `GO_EXTRA=1.25`, creating a mismatch that causes spurious reconciliation PRs (e.g. [cloud-provider-openstack#404](https://github.com/openshift/cloud-provider-openstack/pull/404)) trying to downgrade `.ci-operator.yaml` from golang-1.26 to golang-1.25
- Removing `ci_build_root` stops ART from managing `.ci-operator.yaml` for these images — the streams PR logic will only align Dockerfile FROM lines going forward

## Test plan
- [ ] Verify `images:streams prs open` no longer opens `.ci-operator.yaml` downgrade PRs for these 4 images
- [ ] Verify existing Dockerfile FROM alignment still works correctly