### PR TITLE
Migrate rhel-8-golang-1.21 to golang mono-branch

### DIFF
--- a/Dockerfiles/1-21.rhel8.Dockerfile
+++ b/Dockerfiles/1-21.rhel8.Dockerfile
@@ -1,0 +1,80 @@
+FROM registry.redhat.io/ubi8:latest
+
+ARG GOPATH
+ENV SUMMARY="RHEL8 based Go builder image for OpenShift ART" \
+    container=oci \
+    GOFLAGS='-mod=vendor' \
+    GOPATH=${GOPATH:-/go} \
+    GOMAXPROCS=8 \
+    VERSION="1.21" \
+    GO_VERSION="${__doozer_version:-$VERSION}" \
+    GODEBUG="disablethp=1"
+
+LABEL summary="$SUMMARY" \
+      description="$SUMMARY" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Go Builder $VERSION" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      version="$VERSION"
+
+RUN dnf update -y && \
+    dnf install -y --nodocs \
+        bc \
+        diffutils \
+        dos2unix \
+        file \
+        findutils \
+        git \
+        goversioninfo \
+        gpgme \
+        gpgme-devel \
+        hostname \
+        libassuan-devel \
+        libtool \
+        lsof \
+        make \
+        openssl \
+        openssl-devel \
+        patch \
+        python3 \
+        rsync \
+        socat \
+        systemd-devel \
+        tar \
+        tree \
+        util-linux \
+        wget \
+        which \
+        xz \
+        zip && \
+    dnf install -y "golang-*$VERSION*" && \
+    mkdir -p /go/src
+# provide a cross-compiler for windows/mac binaries (x86_64 only)
+COPY cross.tar.gz .
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+    # only install cross-compiler dependencies on x86_64
+    yum install -y --setopt=tsflags=nodocs \
+    # Required packages for mac cross-compilation
+    llvm-toolset cmake3 gcc-c++ libxml2-devel \
+    # Required packages for windows cross-compilation
+    glibc mingw64-gcc && \
+    # compile macos cross-compilers
+    tar zfx cross.tar.gz && \
+    export TP_OSXCROSS_DEV=$(pwd)/cross/deps && \
+    pushd cross/osxcross && \
+    UNATTENDED=yes ./build.sh && \
+    popd && \
+    cp -avr cross/osxcross/target/bin/* /usr/local/bin/ && \
+    cp -avr cross/osxcross/target/lib/* /usr/local/lib64/ && \
+    cp -avr cross/osxcross/target/SDK /usr/local/SDK && \
+    echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
+    /sbin/ldconfig && \
+    rm -rf cross; \
+fi
+
+# above is conditional; clean up unconditionally
+RUN rm -f cross.tar.gz && yum clean all -y
+
+# FOD wrapper modification
+COPY go_wrapper.sh /tmp/go_wrapper.sh
+RUN GO_BIN_PATH=$(which go) && mv $GO_BIN_PATH $GO_BIN_PATH.real && mv /tmp/go_wrapper.sh $GO_BIN_PATH && chmod +x $GO_BIN_PATH

--- a/group.yml
+++ b/group.yml
@@ -61,51 +61,6 @@ repos:
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
       optional: true
 
-  rhel-810-baseos-rpms:
-    conf:
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/baseos/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/baseos/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/
-    content_set:
-      default: rhel-8-for-x86_64-baseos-rpms
-      aarch64: rhel-8-for-aarch64-baseos-rpms
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms
-      s390x: rhel-8-for-s390x-baseos-rpms
-    reposync:
-      enabled: false
-
-  rhel-810-appstream-rpms:
-    conf:
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/appstream/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/appstream/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/
-    content_set:
-      default: rhel-8-for-x86_64-appstream-rpms
-      aarch64: rhel-8-for-aarch64-appstream-rpms
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms
-      s390x: rhel-8-for-s390x-appstream-rpms
-    reposync:
-      enabled: false
-
-  rhel-810-codeready-builder-rpms:
-    conf:
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/codeready-builder/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/codeready-builder/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/codeready-builder/os/
-    content_set:
-      default: codeready-builder-for-rhel-8-x86_64-rpms
-      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
-      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
-      s390x:   codeready-builder-for-rhel-8-s390x-rpms
-    reposync:
-      enabled: false
-
   rhel-86-baseos-rpms:
     conf:
       baseurl:
@@ -151,6 +106,51 @@ repos:
     reposync:
       enabled: false
 
+  rhel-810-baseos-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/baseos/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/baseos/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/
+    content_set:
+      default: rhel-8-for-x86_64-baseos-rpms
+      aarch64: rhel-8-for-aarch64-baseos-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms
+      s390x: rhel-8-for-s390x-baseos-rpms
+    reposync:
+      enabled: false
+
+  rhel-810-appstream-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/appstream/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/appstream/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/
+    content_set:
+      default: rhel-8-for-x86_64-appstream-rpms
+      aarch64: rhel-8-for-aarch64-appstream-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms
+      s390x: rhel-8-for-s390x-appstream-rpms
+    reposync:
+      enabled: false
+
+  rhel-810-codeready-builder-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/codeready-builder/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/codeready-builder/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/codeready-builder/os/
+    content_set:
+      default: codeready-builder-for-rhel-8-x86_64-rpms
+      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
+      s390x:   codeready-builder-for-rhel-8-s390x-rpms
+    reposync:
+      enabled: false
+
   # RHEL 9
   rhel-9-golang-rpms:
     conf:
@@ -168,7 +168,7 @@ repos:
       ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
       optional: true
-      
+
   rhel-90-baseos-rpms:
     conf:
       baseurl:

--- a/group.yml
+++ b/group.yml
@@ -43,7 +43,132 @@ build_profiles:
         - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
 
 repos:
+  # RHEL 8
+  rhel-8-golang-rpms:
+    conf:
+      extra_options:
+        module_hotfixes: 1
+        includepkgs: module-build-macros golang* goversioninfo
+      baseurl:
+        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
+        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/
+        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/s390x/
+        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/x86_64/
+    content_set:
+      default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms
+      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-8-aarch64-rpms
+      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
+      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
+      optional: true
+
+  rhel-810-baseos-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/baseos/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/baseos/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/
+    content_set:
+      default: rhel-8-for-x86_64-baseos-rpms
+      aarch64: rhel-8-for-aarch64-baseos-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms
+      s390x: rhel-8-for-s390x-baseos-rpms
+    reposync:
+      enabled: false
+
+  rhel-810-appstream-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/appstream/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/appstream/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/
+    content_set:
+      default: rhel-8-for-x86_64-appstream-rpms
+      aarch64: rhel-8-for-aarch64-appstream-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms
+      s390x: rhel-8-for-s390x-appstream-rpms
+    reposync:
+      enabled: false
+
+  rhel-810-codeready-builder-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/codeready-builder/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/codeready-builder/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/codeready-builder/os/
+    content_set:
+      default: codeready-builder-for-rhel-8-x86_64-rpms
+      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
+      s390x:   codeready-builder-for-rhel-8-s390x-rpms
+    reposync:
+      enabled: false
+
+  rhel-86-baseos-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/baseos/os/
+    content_set:
+      default: rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
+      aarch64: rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_6
+      ppc64le: rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_6
+      s390x: rhel-8-for-s390x-baseos-eus-rpms__8_DOT_6
+    reposync:
+      enabled: false
+
+  rhel-86-appstream-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/appstream/os/
+    content_set:
+      default: rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
+      aarch64: rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
+      ppc64le: rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
+      s390x: rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
+    reposync:
+      enabled: false
+
+  rhel-86-codeready-builder-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/codeready-builder/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/codeready-builder/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/codeready-builder/os/
+    content_set:
+      default: codeready-builder-for-rhel-8-x86_64-eus-rpms__8_DOT_6
+      aarch64: codeready-builder-for-rhel-8-aarch64-eus-rpms__8_DOT_6
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-eus-rpms__8_DOT_6
+      s390x: codeready-builder-for-rhel-8-s390x-eus-rpms__8_DOT_6
+    reposync:
+      enabled: false
+
   # RHEL 9
+  rhel-9-golang-rpms:
+    conf:
+      extra_options:
+        module_hotfixes: 1
+        includepkgs: module-build-macros golang* goversioninfo
+      baseurl:
+        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
+        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
+        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
+        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
+    content_set:
+      default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
+      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
+      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
+      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
+      optional: true
+      
   rhel-90-baseos-rpms:
     conf:
       baseurl:
@@ -135,22 +260,6 @@ repos:
       s390x: codeready-builder-for-rhel-9-s390x-rpms__9_DOT_6
     reposync:
       enabled: false
-  rhel-9-golang-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1
-        includepkgs: module-build-macros golang* goversioninfo
-      baseurl:
-        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
-        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
-        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
-        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
-    content_set:
-      default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
-      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
-      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
-      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
-      optional: true
 
   rhel-94-baseos-rpms:
     conf:
@@ -197,68 +306,6 @@ repos:
     reposync:
       enabled: false
 
-  # RHEL 8
-  rhel-8-golang-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1
-        includepkgs: module-build-macros golang* goversioninfo
-      baseurl:
-        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
-        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/
-        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/s390x/
-        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/x86_64/
-    content_set:
-      default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms
-      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-8-aarch64-rpms
-      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
-      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
-      optional: true
-
-  rhel-810-baseos-rpms:
-    conf:
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/baseos/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/baseos/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/
-    content_set:
-      default: rhel-8-for-x86_64-baseos-rpms
-      aarch64: rhel-8-for-aarch64-baseos-rpms
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms
-      s390x: rhel-8-for-s390x-baseos-rpms
-    reposync:
-      enabled: false
-
-  rhel-810-appstream-rpms:
-    conf:
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/appstream/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/appstream/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/
-    content_set:
-      default: rhel-8-for-x86_64-appstream-rpms
-      aarch64: rhel-8-for-aarch64-appstream-rpms
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms
-      s390x: rhel-8-for-s390x-appstream-rpms
-    reposync:
-      enabled: false
-
-  rhel-810-codeready-builder-rpms:
-    conf:
-      baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/codeready-builder/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/codeready-builder/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/codeready-builder/os/
-    content_set:
-      default: codeready-builder-for-rhel-8-x86_64-rpms
-      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
-      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
-      s390x:   codeready-builder-for-rhel-8-s390x-rpms
-    reposync:
-      enabled: false
 
   # RHEL 10
   rhel-10-golang-rpms:

--- a/images/openshift-golang-builder-1-21.rhel8.yml
+++ b/images/openshift-golang-builder-1-21.rhel8.yml
@@ -1,0 +1,55 @@
+content:
+  set_build_variables: false
+  source:
+    path: images
+    dockerfile: openshift-golang-builder.Dockerfile
+    git:
+      branch:
+        target: golang
+      url: git@github.com:openshift-eng/ocp-build-data.git
+    modifications:
+    - &add_fips_wrapper
+      action: add
+      doozer_source: golang_builder_FIPS_wrapper.sh
+      path: go_wrapper.sh
+      overwriting: true
+enabled_repos:
+- rhel-8-golang-rpms
+- rhel-8-baseos-rpms
+# for clang
+- rhel-8-appstream-rpms
+- rhel-8-codeready-builder-rpms
+
+from:
+  stream: rhel-86
+
+labels:
+  io.k8s.description: golang builder image for Red Hat internal builds
+
+name: openshift/golang-builder
+
+owners:
+- aos-team-art@redhat.com
+
+additional_tags:
+- 'rhel_8_golang_1.21'
+- 'rhel_8_1.21'
+maintainer:
+  component: Release
+
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype
+      rpms:
+      - golang
+    artifact_lockfile:
+      resources:
+      - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
+  content:
+    source:
+      modifications:
+        - *add_fips_wrapper
+        - action: replace
+          match: "COPY cross.tar.gz "
+          replacement: "RUN cp /cachi2/output/deps/generic/cross.tar.gz "

--- a/images/openshift-golang-builder-1-21.rhel8.yml
+++ b/images/openshift-golang-builder-1-21.rhel8.yml
@@ -1,8 +1,8 @@
 content:
   set_build_variables: false
   source:
-    path: images
-    dockerfile: openshift-golang-builder.Dockerfile
+    path: Dockerfiles
+    dockerfile: 1-21.rhel8.Dockerfile
     git:
       branch:
         target: golang
@@ -15,10 +15,10 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-8-baseos-rpms
+- rhel-86-baseos-rpms
 # for clang
-- rhel-8-appstream-rpms
-- rhel-8-codeready-builder-rpms
+- rhel-86-appstream-rpms
+- rhel-86-codeready-builder-rpms
 
 from:
   stream: rhel-86

--- a/streams.yml
+++ b/streams.yml
@@ -7,6 +7,9 @@ rhel-810:
   # ubi8-container-8.10-901.1717584420
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8@sha256:143123d85045df426c5bbafc6863659880ebe276eb02c77ee868b88d08dbd05d
 
+rhel-86:
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.6-754
+
 rhel10:
   # TODO: update with actual rhel-10 base image digest
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi10:latest


### PR DESCRIPTION
## Summary
Migrate rhel-8-golang-1.21 variant files to the unified golang mono-branch.

## Changes
This PR adds the rhel8 golang 1-21 variant files to the golang mono-branch:
- `Dockerfiles/1-21.rhel8.Dockerfile`
- `images/openshift-golang-builder-1-21.rhel8.yml`
- Updates to `streams.yml` with [rhel-86](https://redhat.atlassian.net/browse/rhel-86) stream definition

## Naming Convention
Following the pattern established in PR #10624:
- **Dockerfile:** `{go-version}.{rhel-version}.Dockerfile`
- **YAML:** `openshift-golang-builder-{go-version}.{rhel-version}.yml`
- **Stream keys:** Specific RHEL versions (e.g., `rhel-86`, `rhel-94`)

## Migration Context
Part of the effort to consolidate all rhel-{8,9}-golang-1.{19-26} branches into the unified golang mono-branch. This approach allows a single branch to serve all OCP versions through runtime variable injection by doozer.

🤖 Generated by Claude Code