### PR TITLE
Migrate rhel-9-golang-1.19 to golang mono-branch

### DIFF
--- a/Dockerfiles/1-19.rhel9.Dockerfile
+++ b/Dockerfiles/1-19.rhel9.Dockerfile
@@ -1,0 +1,79 @@
+FROM registry.redhat.io/ubi9:latest
+
+ARG GOPATH
+ENV SUMMARY="RHEL9 based Go builder image for OpenShift ART" \
+    container=oci \
+    GOFLAGS='-mod=vendor' \
+    GOPATH=${GOPATH:-/go} \
+    GOMAXPROCS=8 \
+    VERSION="1.19" \
+    GO_VERSION="${__doozer_version:-$VERSION}"
+
+LABEL summary="$SUMMARY" \
+      description="$SUMMARY" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Go Builder $VERSION" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      version="$VERSION"
+
+RUN dnf update -y && \
+    dnf install -y --nodocs \
+        bc \
+        diffutils \
+        dos2unix \
+        file \
+        findutils \
+        git \
+        goversioninfo \
+        gpgme \
+        gpgme-devel \
+        hostname \
+        libassuan-devel \
+        libtool \
+        lsof \
+        make \
+        openssl \
+        openssl-devel \
+        patch \
+        python3 \
+        rsync \
+        socat \
+        systemd-devel \
+        tar \
+        tree \
+        util-linux \
+        wget \
+        which \
+        xz \
+        zip && \
+    dnf install -y "golang-*$VERSION*" && \
+    mkdir -p /go/src
+# provide a cross-compiler for windows/mac binaries (x86_64 only)
+COPY cross.tar.gz .
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+    # only install cross-compiler dependencies on x86_64
+    yum install -y --setopt=tsflags=nodocs \
+    # Required packages for mac cross-compilation
+    llvm-toolset cmake3 gcc-c++ libxml2-devel \
+    # Required packages for windows cross-compilation
+    glibc mingw64-gcc && \
+    # compile macos cross-compilers
+    tar zfx cross.tar.gz && \
+    export TP_OSXCROSS_DEV=$(pwd)/cross/deps && \
+    pushd cross/osxcross && \
+    UNATTENDED=yes ./build.sh && \
+    popd && \
+    cp -avr cross/osxcross/target/bin/* /usr/local/bin/ && \
+    cp -avr cross/osxcross/target/lib/* /usr/local/lib64/ && \
+    cp -avr cross/osxcross/target/SDK /usr/local/SDK && \
+    echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
+    /sbin/ldconfig && \
+    rm -rf cross; \
+fi
+
+# above is conditional; clean up unconditionally
+RUN rm -f cross.tar.gz && yum clean all -y
+
+# FOD wrapper modification
+COPY go_wrapper.sh /tmp/go_wrapper.sh
+RUN GO_BIN_PATH=$(which go) && mv $GO_BIN_PATH $GO_BIN_PATH.real && mv /tmp/go_wrapper.sh $GO_BIN_PATH && chmod +x $GO_BIN_PATH

--- a/images/openshift-golang-builder-1-19.rhel9.yml
+++ b/images/openshift-golang-builder-1-19.rhel9.yml
@@ -1,8 +1,8 @@
 content:
   set_build_variables: false
   source:
-    path: images
-    dockerfile: openshift-golang-builder.Dockerfile
+    path: Dockerfiles
+    dockerfile: 1-19.rhel19.Dockerfile
     git:
       branch:
         target: golang
@@ -15,10 +15,10 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-9-golang-rpms
-- rhel-90-server-ose-build-rpms
 - rhel-90-baseos-rpms
 # for clang
 - rhel-90-appstream-rpms
+- rhel-90-codeready-builder-rpms
 
 from:
   stream: rhel-90

--- a/images/openshift-golang-builder-1-19.rhel9.yml
+++ b/images/openshift-golang-builder-1-19.rhel9.yml
@@ -1,0 +1,56 @@
+content:
+  set_build_variables: false
+  source:
+    path: images
+    dockerfile: openshift-golang-builder.Dockerfile
+    git:
+      branch:
+        target: golang
+      url: git@github.com:openshift-eng/ocp-build-data.git
+    modifications:
+    - &add_fips_wrapper
+      action: add
+      doozer_source: golang_builder_FIPS_wrapper.sh
+      path: go_wrapper.sh
+      overwriting: true
+enabled_repos:
+- rhel-9-golang-rpms
+- rhel-90-server-ose-build-rpms
+- rhel-90-baseos-rpms
+# for clang
+- rhel-90-appstream-rpms
+
+from:
+  stream: rhel-90
+
+image_build_method: osbs2
+
+labels:
+  io.k8s.description: golang builder image for Red Hat internal builds
+
+name: openshift/golang-builder
+
+owners:
+- aos-team-art@redhat.com
+
+additional_tags:
+- 'rhel_9_golang_1.19'
+- 'rhel_9_1.19'
+maintainer:
+  component: Release
+
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - golang
+    artifact_lockfile:
+      resources:
+      - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
+  content:
+    source:
+      modifications:
+        - *add_fips_wrapper
+        - action: replace
+          match: "COPY cross.tar.gz "
+          replacement: "RUN cp /cachi2/output/deps/generic/cross.tar.gz "


### PR DESCRIPTION
## Summary
Migrate rhel-9-golang-1.19 variant files to the unified golang mono-branch.

## Changes
This PR adds the rhel9 golang 1-19 variant files to the golang mono-branch:
- `Dockerfiles/1-19.rhel9.Dockerfile`
- `images/openshift-golang-builder-1-19.rhel9.yml`
- Updates to `streams.yml` with [rhel-90](https://redhat.atlassian.net/browse/rhel-90) stream definition

## Naming Convention
Following the pattern established in PR #10624:
- **Dockerfile:** `{go-version}.{rhel-version}.Dockerfile`
- **YAML:** `openshift-golang-builder-{go-version}.{rhel-version}.yml`
- **Stream keys:** Specific RHEL versions (e.g., `rhel-86`, `rhel-94`)

## Migration Context
Part of the effort to consolidate all rhel-{8,9}-golang-1.{19-26} branches into the unified golang mono-branch. This approach allows a single branch to serve all OCP versions through runtime variable injection by doozer.

🤖 Generated by Claude Code