### PR TITLE
Migrate rhel-9-golang-1.20 to golang mono-branch

### DIFF
--- a/Dockerfiles/1-20.rhel9.Dockerfile
+++ b/Dockerfiles/1-20.rhel9.Dockerfile
@@ -1,0 +1,78 @@
+FROM registry.redhat.io/ubi9:latest
+
+ARG GOPATH
+ENV SUMMARY="RHEL9 based Go builder image for OpenShift ART" \
+    container=oci \
+    GOFLAGS='-mod=vendor' \
+    GOPATH=${GOPATH:-/go} \
+    GOMAXPROCS=8 \
+    VERSION="1.20" \
+    GO_VERSION="${__doozer_version:-$VERSION}"
+
+LABEL summary="$SUMMARY" \
+      description="$SUMMARY" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Go Builder $VERSION" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      version="$VERSION"
+
+RUN dnf update -y && \
+    dnf install -y --nodocs \
+        bc \
+        diffutils \
+        dos2unix \
+        file \
+        findutils \
+        git \
+        goversioninfo \
+        gpgme \
+        gpgme-devel \
+        hostname \
+        libassuan-devel \
+        libtool \
+        lsof \
+        make \
+        openssl \
+        openssl-devel \
+        patch \
+        python3 \
+        rsync \
+        socat \
+        systemd-devel \
+        tar \
+        tree \
+        util-linux \
+        wget \
+        which \
+        xz \
+        zip && \
+    dnf install -y "golang-*$VERSION*" && \
+    mkdir -p /go/src
+# provide a cross-compiler for windows/mac binaries (amd64 only)
+COPY cross.tar.gz .
+RUN [ $(go env GOARCH) != "amd64" ] || (\
+    # only install cross-compiler dependencies on amd64
+    yum install -y --setopt=tsflags=nodocs \
+    # Required packages for mac cross-compilation
+    llvm-toolset cmake3 gcc-c++ libxml2-devel \
+    # Required packages for windows cross-compilation
+    glibc mingw64-gcc && \
+    # compile macos cross-compilers
+    tar zfx cross.tar.gz && \
+    export TP_OSXCROSS_DEV=$(pwd)/cross/deps && \
+    pushd cross/osxcross && \
+    UNATTENDED=yes ./build.sh && \
+    popd && \
+    cp -avr cross/osxcross/target/bin/* /usr/local/bin/ && \
+    cp -avr cross/osxcross/target/lib/* /usr/local/lib64/ && \
+    cp -avr cross/osxcross/target/SDK /usr/local/SDK && \
+    echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
+    /sbin/ldconfig && \
+    rm -rf cross)
+
+# above is conditional; clean up unconditionally
+RUN rm -f cross.tar.gz && yum clean all -y
+
+# FOD wrapper modification
+COPY go_wrapper.sh /tmp/go_wrapper.sh
+RUN GO_BIN_PATH=$(which go) && mv $GO_BIN_PATH $GO_BIN_PATH.real && mv /tmp/go_wrapper.sh $GO_BIN_PATH && chmod +x $GO_BIN_PATH

--- a/Dockerfiles/1-20.rhel9.Dockerfile
+++ b/Dockerfiles/1-20.rhel9.Dockerfile
@@ -48,10 +48,10 @@ RUN dnf update -y && \
         zip && \
     dnf install -y "golang-*$VERSION*" && \
     mkdir -p /go/src
-# provide a cross-compiler for windows/mac binaries (amd64 only)
+# provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .
-RUN [ $(go env GOARCH) != "amd64" ] || (\
-    # only install cross-compiler dependencies on amd64
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+    # only install cross-compiler dependencies on x86_64
     yum install -y --setopt=tsflags=nodocs \
     # Required packages for mac cross-compilation
     llvm-toolset cmake3 gcc-c++ libxml2-devel \
@@ -68,7 +68,8 @@ RUN [ $(go env GOARCH) != "amd64" ] || (\
     cp -avr cross/osxcross/target/SDK /usr/local/SDK && \
     echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
     /sbin/ldconfig && \
-    rm -rf cross)
+    rm -rf cross; \
+fi
 
 # above is conditional; clean up unconditionally
 RUN rm -f cross.tar.gz && yum clean all -y

--- a/group.yml
+++ b/group.yml
@@ -44,6 +44,50 @@ build_profiles:
 
 repos:
   # RHEL 9
+  rhel-90-baseos-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/baseos/os/
+    content_set:
+      default: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_0
+      aarch64: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_0
+      ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_0
+      s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_0
+    reposync:
+      enabled: false
+
+  rhel-90-appstream-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/appstream/os/
+    content_set:
+      default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_0
+      aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_0
+      ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_0
+      s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_0
+    reposync:
+      enabled: false
+
+  rhel-90-codeready-builder-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/codeready-builder/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/codeready-builder/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/codeready-builder/os/
+    content_set:
+      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_0
+      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_0
+      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_0
+      s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_0
+    reposync:
+      enabled: false
 
   rhel-96-baseos-rpms:
     conf:

--- a/images/openshift-golang-builder-1-20.rhel9.yml
+++ b/images/openshift-golang-builder-1-20.rhel9.yml
@@ -1,0 +1,52 @@
+content:
+  set_build_variables: false
+  source:
+    path: images
+    dockerfile: openshift-golang-builder.Dockerfile
+    git:
+      branch:
+        target: golang
+      url: git@github.com:openshift-eng/ocp-build-data.git
+    modifications:
+    - &add_fips_wrapper
+      action: add
+      doozer_source: golang_builder_FIPS_wrapper.sh
+      path: go_wrapper.sh
+      overwriting: true
+enabled_repos:
+- rhel-9-server-ose-build-rpms
+- rhel-9-baseos-rpms
+- rhel-9-golang-rpms
+# for clang
+- rhel-9-appstream-rpms
+
+from:
+  stream: rhel-90
+
+labels:
+  io.k8s.description: golang builder image for Red Hat internal builds
+
+name: openshift/golang-builder
+
+owners:
+- aos-team-art@redhat.com
+
+# Don't add floating tag to FoD builder for now, until we confident CPASS can use it
+additional_tags:
+- 'rhel_9_golang_1.20'
+- 'rhel_9_1.20'
+maintainer:
+  component: Release
+
+konflux:
+  cachi2:
+    artifact_lockfile:
+      resources:
+      - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
+  content:
+    source:
+      modifications:
+        - *add_fips_wrapper
+        - action: replace
+          match: "COPY cross.tar.gz "
+          replacement: "RUN cp /cachi2/output/deps/generic/cross.tar.gz "

--- a/images/openshift-golang-builder-1-20.rhel9.yml
+++ b/images/openshift-golang-builder-1-20.rhel9.yml
@@ -14,11 +14,11 @@ content:
       path: go_wrapper.sh
       overwriting: true
 enabled_repos:
-- rhel-9-server-ose-build-rpms
-- rhel-9-baseos-rpms
+- rhel-90-server-ose-build-rpms
+- rhel-90-baseos-rpms
 - rhel-9-golang-rpms
 # for clang
-- rhel-9-appstream-rpms
+- rhel-90-appstream-rpms
 
 from:
   stream: rhel-90

--- a/images/openshift-golang-builder-1-20.rhel9.yml
+++ b/images/openshift-golang-builder-1-20.rhel9.yml
@@ -14,12 +14,11 @@ content:
       path: go_wrapper.sh
       overwriting: true
 enabled_repos:
-- rhel-90-server-ose-build-rpms
-- rhel-90-baseos-rpms
 - rhel-9-golang-rpms
+- rhel-90-baseos-rpms
 # for clang
 - rhel-90-appstream-rpms
-
+- rhel-90-codeready-builder-rpms
 from:
   stream: rhel-90
 

--- a/images/openshift-golang-builder-1-20.rhel9.yml
+++ b/images/openshift-golang-builder-1-20.rhel9.yml
@@ -1,8 +1,8 @@
 content:
   set_build_variables: false
   source:
-    path: images
-    dockerfile: openshift-golang-builder.Dockerfile
+    path: Dockerfiles
+    dockerfile: 1-20.rhel9.Dockerfile
     git:
       branch:
         target: golang

--- a/streams.yml
+++ b/streams.yml
@@ -11,6 +11,10 @@ rhel10:
   # TODO: update with actual rhel-10 base image digest
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi10:latest
 
+rhel-90:
+# rhel-els-container-9.0.0-974
+  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:c00fe5ad75658431c97b3a225db5625a97c8f3a28253af7ec3aa622db235ff64
+
 rhel-96:
 # ubi9-container-9.6-440.1760321968
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9@sha256:08a8d763ab10280a510d12180363adbe08264a7448bcdfdf92dfaaed4549899c


### PR DESCRIPTION
## Summary
Migrate rhel-9-golang-1.20 variant files to the unified golang mono-branch.

## Changes
This PR adds the rhel9 golang 1-20 variant files to the golang mono-branch:
- `Dockerfiles/1-20.rhel9.Dockerfile`
- `images/openshift-golang-builder-1-20.rhel9.yml`
- Updates to `streams.yml` with [rhel-90](https://redhat.atlassian.net/browse/rhel-90) stream definition

## Naming Convention
Following the pattern established in PR #10624:
- **Dockerfile:** `{go-version}.{rhel-version}.Dockerfile`
- **YAML:** `openshift-golang-builder-{go-version}.{rhel-version}.yml`
- **Stream keys:** Specific RHEL versions (e.g., `rhel-86`, `rhel-94`)

## Migration Context
Part of the effort to consolidate all rhel-{8,9}-golang-1.{19-26} branches into the unified golang mono-branch. This approach allows a single branch to serve all OCP versions through runtime variable injection by doozer.

🤖 Generated by Claude Code