### PR TITLE
Migrate rhel-9-golang-1.26 to golang mono-branch

### DIFF
--- a/images/openshift-golang-builder-1-26.rhel9.yml
+++ b/images/openshift-golang-builder-1-26.rhel9.yml
@@ -28,7 +28,7 @@ enabled_repos:
 - rhel-9-codeready-builder-rpms
 
 from:
-  stream: rhel9
+  stream: rhel-94
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/streams.yml
+++ b/streams.yml
@@ -1,3 +1,4 @@
+---
 rhel9:
 # rhel-els-container-9.4-943.1726661131
   image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7

--- a/streams.yml
+++ b/streams.yml
@@ -1,5 +1,5 @@
 ---
-rhel9:
+rhel-94:
 # rhel-els-container-9.4-943.1726661131
   image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7
 
@@ -10,7 +10,3 @@ rhel8:
 rhel10:
   # TODO: update with actual rhel-10 base image digest
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi10:latest
-
-rhel-94:
-# rhel-els-container-9.4-943.1726661131
-  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7

--- a/streams.yml
+++ b/streams.yml
@@ -10,3 +10,9 @@ rhel8:
 rhel10:
   # TODO: update with actual rhel-10 base image digest
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi10:latest
+
+# From rhel-9-golang-1.26:
+---
+rhel-94:
+# rhel-els-container-9.4-943.1726661131
+  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7

--- a/streams.yml
+++ b/streams.yml
@@ -1,4 +1,3 @@
----
 rhel9:
 # rhel-els-container-9.4-943.1726661131
   image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7
@@ -11,8 +10,6 @@ rhel10:
   # TODO: update with actual rhel-10 base image digest
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi10:latest
 
-# From rhel-9-golang-1.26:
----
 rhel-94:
 # rhel-els-container-9.4-943.1726661131
   image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7


### PR DESCRIPTION
## Summary
Migrate rhel-9-golang-1.26 variant files to the unified golang mono-branch.

## Changes
This PR adds the rhel9 golang 1-26 variant files to the golang mono-branch:
- `Dockerfiles/1-26.rhel9.Dockerfile`
- `images/openshift-golang-builder-1-26.rhel9.yml`
- Updates to `streams.yml` with [rhel-94](https://redhat.atlassian.net/browse/rhel-94) stream definition

## Naming Convention
Following the pattern established in PR #10624:
- **Dockerfile:** `{go-version}.{rhel-version}.Dockerfile`
- **YAML:** `openshift-golang-builder-{go-version}.{rhel-version}.yml`
- **Stream keys:** Specific RHEL versions (e.g., `rhel-86`, `rhel-94`)

## Migration Context
Part of the effort to consolidate all rhel-{8,9}-golang-1.{19-26} branches into the unified golang mono-branch. This approach allows a single branch to serve all OCP versions through runtime variable injection by doozer.

🤖 Generated by Claude Code