### PR TITLE
[openshift-4.22] ART-17441: Build ose-machine-os-images hermetically

### DIFF
--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -38,18 +38,28 @@ konflux:
     x86_64: linux/amd64
   cachi2:
     lockfile:
-      rpms:
-      - jq
-      - coreos-installer
-      - cryptsetup-libs
-      - device-mapper
-      - device-mapper-libs
-      - kbd
-      - kbd-legacy
-      - kbd-misc
-      - kmod
-      - kpartx
-      - oniguruma
-      - s390utils-core
-      - systemd-udev
-  network_mode: open  # fetch_image.sh script requires network access to download images in hermetic env - ART-14122
+      backend: rpm-lockfile-prototype
+    artifact_lockfile:
+      # RHCOS ISO URLs sourced from openshift/installer repo:
+      # data/data/coreos/coreos-rhel-9.json and data/data/coreos/coreos-rhel-10.json
+      # These are the same URLs that openshift-install coreos print-stream-json outputs.
+      # Whenever it changes, update these URLs to match .architectures.{arch}.artifacts.metal.formats.iso.disk.location
+      resources:
+      # RHEL 9 ISOs
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-live-iso.x86_64.iso
+        filename: coreos-x86_64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-live-iso.aarch64.iso
+        filename: coreos-aarch64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-live-iso.ppc64le.iso
+        filename: coreos-ppc64le.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-live-iso.s390x.iso
+        filename: coreos-s390x.iso
+      # RHEL 10 ISOs
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-live-iso.x86_64.iso
+        filename: coreos10-x86_64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-live-iso.aarch64.iso
+        filename: coreos10-aarch64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-live-iso.ppc64le.iso
+        filename: coreos10-ppc64le.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-live-iso.s390x.iso
+        filename: coreos10-s390x.iso


### PR DESCRIPTION
## Summary

`ose-machine-os-images` can't be built hermetically by default because `fetch_image.sh` downloads RHCOS ISO images at build time from an internal mirror.

This adds support for Cachi2 generic artifact prefetching. When the Cachi2 prefetch directory (`/cachi2/output/deps/generic/`) exists, `fetch_image.sh` copies ISOs from there instead of downloading them.

### Changes

- Switch RPM lockfile backend to `rpm-lockfile-prototype`
- Add `artifact_lockfile.resources` with RHCOS ISO URLs matching the installer image
- Remove `network_mode: open`