### PR TITLE
[openshift-4.21] ART-17441: Build ose-machine-os-images hermetically

### DIFF
--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -38,18 +38,18 @@ konflux:
     x86_64: linux/amd64
   cachi2:
     lockfile:
-      rpms:
-      - jq
-      - coreos-installer
-      - cryptsetup-libs
-      - device-mapper
-      - device-mapper-libs
-      - kbd
-      - kbd-legacy
-      - kbd-misc
-      - kmod
-      - kpartx
-      - oniguruma
-      - s390utils-core
-      - systemd-udev
-  network_mode: open  # fetch_image.sh script requires network access to download images in hermetic env - ART-14122
+      backend: rpm-lockfile-prototype
+    artifact_lockfile:
+      # RHCOS ISO URLs sourced from openshift/installer repo:
+      # data/data/coreos/rhcos.json
+      # These are the same URLs that openshift-install coreos print-stream-json outputs.
+      # Whenever it changes, update these URLs to match .architectures.{arch}.artifacts.metal.formats.iso.disk.location
+      resources:
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/x86_64/rhcos-9.6.20260520-0-live-iso.x86_64.iso
+        filename: coreos-x86_64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/aarch64/rhcos-9.6.20260520-0-live-iso.aarch64.iso
+        filename: coreos-aarch64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/ppc64le/rhcos-9.6.20260520-0-live-iso.ppc64le.iso
+        filename: coreos-ppc64le.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260520-0/s390x/rhcos-9.6.20260520-0-live-iso.s390x.iso
+        filename: coreos-s390x.iso


### PR DESCRIPTION
## Summary

`ose-machine-os-images` can't be built hermetically by default because `fetch_image.sh` downloads RHCOS ISO images at build time from an internal mirror.

This adds support for Cachi2 generic artifact prefetching. When the Cachi2 prefetch directory (`/cachi2/output/deps/generic/`) exists, `fetch_image.sh` copies ISOs from there instead of downloading them.

### Changes

- Switch RPM lockfile backend to `rpm-lockfile-prototype`
- Add `artifact_lockfile.resources` with RHCOS ISO URLs matching the installer image
- Remove `network_mode: open`