### PR TITLE
[openshift-4.12] ART-17441: Build ose-machine-os-images hermetically

### DIFF
--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -24,7 +24,15 @@ konflux:
     # ref thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1743022042311039
     # can be removed after whilelist is in
     x86_64: linux/amd64
-  network_mode: open
+  cachi2:
+    artifact_lockfile:
+      # RHCOS ISO URLs sourced from openshift/installer repo:
+      # data/data/coreos/rhcos.json
+      # These are the same URLs that openshift-install coreos print-stream-json outputs.
+      # Whenever it changes, update these URLs to match .architectures.{arch}.artifacts.metal.formats.iso.disk.location
+      resources:
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202402272018-0/x86_64/rhcos-412.86.202402272018-0-live.x86_64.iso
+        filename: coreos-x86_64.iso
 delivery:
   delivery_repo_names:
   - openshift4/ose-machine-os-images-rhel8


### PR DESCRIPTION
## Summary

`ose-machine-os-images` can't be built hermetically by default because `fetch_image.sh` downloads RHCOS ISO images at build time from an internal mirror.

This adds support for Cachi2 generic artifact prefetching. When the Cachi2 prefetch directory (`/cachi2/output/deps/generic/`) exists, `fetch_image.sh` copies ISOs from there instead of downloading them.

### Changes

- Switch RPM lockfile backend to `rpm-lockfile-prototype`
- Add `artifact_lockfile.resources` with RHCOS ISO URLs matching the installer image
- Remove `network_mode: open`