### PR TITLE
logging-6.0: Update UBI9 baseimage and repositories

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -86,10 +86,10 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/baseos/os/
     content_set:
       default: rhel-9-for-x86_64-baseos-rpms
       aarch64: rhel-9-for-aarch64-baseos-rpms
@@ -101,10 +101,10 @@ repos:
   rhel-9-baseos-source:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/source/SRPMS
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/source/SRPMS
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/source/SRPMS
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/source/SRPMS
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/baseos/source/SRPMS
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/baseos/source/SRPMS
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/baseos/source/SRPMS
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/baseos/source/SRPMS
       extra_options:
         gpgcheck: "1"
     content_set:
@@ -118,10 +118,10 @@ repos:
   rhel-9-appstream-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/appstream/os/
     content_set:
       default: rhel-9-for-x86_64-appstream-rpms
       aarch64: rhel-9-for-aarch64-appstream-rpms
@@ -133,10 +133,10 @@ repos:
   rhel-9-appstream-source:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/source/SRPMS
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/source/SRPMS
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/source/SRPMS
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/source/SRPMS
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/appstream/source/SRPMS
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/appstream/source/SRPMS
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/appstream/source/SRPMS
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/appstream/source/SRPMS
       extra_options:
         gpgcheck: "1"
     content_set:
@@ -150,10 +150,10 @@ repos:
   rhel-9-appstream-debug:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/debug/
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/debug/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/debug/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/debug/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/appstream/debug/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/appstream/debug/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/appstream/debug/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/appstream/debug/
       extra_options:
         gpgcheck: "1"
     content_set:
@@ -167,10 +167,10 @@ repos:
   rhel-9-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/codeready-builder/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/codeready-builder/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/codeready-builder/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/ppc64le/codeready-builder/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/s390x/codeready-builder/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.8/x86_64/codeready-builder/os/
     content_set:
       default: codeready-builder-for-rhel-9-x86_64-rpms
       aarch64: codeready-builder-for-rhel-9-aarch64-rpms

--- a/streams.yml
+++ b/streams.yml
@@ -10,4 +10,4 @@ ose-cli-artifacts:
 
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
-  image: registry.redhat.io/ubi9/ubi-minimal@sha256:24650313873554b6ba16c1a1b6b9f9142604f6ab735113e1695faf2dd07fdede
+  image: registry.redhat.io/ubi9-minimal@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc


### PR DESCRIPTION
/label tide/merge-method-squash
