### PR TITLE
Set MTA 8.0 software lifecycle phase to eol

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -106,3 +106,6 @@ repos:
       aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_6
     reposync:
       enabled: false
+
+software_lifecycle:
+  phase: eol


### PR DESCRIPTION
## Summary
- Marks MTA 8.0 as end-of-life by adding `software_lifecycle.phase: eol` to group.yml
- Follows the same pattern used in `logging-6.3`
- This is not the official EOL by product but only from an ART tooling

## Effect
- Bug checks will be skipped for this group
- TRT nightly delay alerts will not fire
- Forum notifications will be disabled
- Signed repos and GPG checks remain enabled