### PR TITLE
Add mingw packages to includepkgs for hermetic builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -44,7 +44,7 @@ repos:
       extra_options:
         module_hotfixes: 1
         # this repo provides complete RHEL 8 build env; we just want the go-toolset content
-        includepkgs: golang golang-bin golang-docs golang-misc golang-race golang-src golang-tests goversioninfo
+        includepkgs: golang golang-bin golang-docs golang-misc golang-race golang-src golang-tests goversioninfo mingw64-gcc mingw64-cpp mingw64-binutils mingw64-crt mingw64-headers mingw64-filesystem mingw64-winpthreads mingw-binutils-generic mingw-filesystem-base mingw-w64-tools
       # golang-1.21.3-4.el8_9
       # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2770478
       baseurl:


### PR DESCRIPTION
## Summary
- When `rhel-8-server-ose-build-rpms` was removed in 41d6a48 (to fix duplicate content_set collision), the `mingw*` packages it provided were dropped
- These are needed for the windows cross-compilation step in the golang builder Dockerfile (`yum install ... mingw64-gcc`)
- In hermetic (network-isolated) builds, only prefetched RPMs are available, and `mingw64-gcc` + deps must be in the `includepkgs` allowlist to be resolved by the lockfile generator
- Add the specific mingw packages to `rhel-8-golang-rpms` `includepkgs` (same Brew buildroot URL)

## Test plan
- [ ] Trigger a hermetic Konflux build for `rhel-8-golang-1.21` and verify STEP 13 (`yum install ... mingw64-gcc`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)