### PR TITLE
fix(golang-builder): use uname -m in rhel96 Dockerfile arch conditional

### DIFF
--- a/images/openshift-golang-builder-rhel96.Dockerfile
+++ b/images/openshift-golang-builder-rhel96.Dockerfile
@@ -51,10 +51,10 @@ RUN dnf update -y && \
         zip && \
     dnf install -y "golang-*$VERSION*" && \
     mkdir -p /go/src
-# provide a cross-compiler for windows/mac binaries (amd64 only)
+# provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .
-RUN [ $(go env GOARCH) != "amd64" ] || (\
-    # only install cross-compiler dependencies on amd64
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+    # only install cross-compiler dependencies on x86_64
     yum install -y --setopt=tsflags=nodocs \
     # Required packages for mac cross-compilation
     llvm-toolset cmake3 gcc-c++ libxml2-devel \
@@ -71,7 +71,8 @@ RUN [ $(go env GOARCH) != "amd64" ] || (\
     cp -avr cross/osxcross/target/SDK /usr/local/SDK && \
     echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
     /sbin/ldconfig && \
-    rm -rf cross)
+    rm -rf cross; \
+fi
 
 # above is conditional; clean up unconditionally
 RUN rm -f cross.tar.gz && yum clean all -y


### PR DESCRIPTION
same as https://github.com/openshift-eng/ocp-build-data/pull/10822

## Summary
- Switch `openshift-golang-builder-rhel96.Dockerfile` from `[ $(go env GOARCH) != "amd64" ] || (...)` to `if [ "$(uname -m)" = "x86_64" ]; then ... fi`
- The lockfile parser doesn't recognize `$(go env GOARCH)`, causing mingw64-gcc and other x86_64-only cross-compilation packages to be missing from the lockfile
- This was already fixed in the `-94` Dockerfile on this branch and all other golang builder branches, but missed in the rhel96 Dockerfile

## Test plan
- [ ] Verify lockfile generation includes mingw packages for x86_64
- [ ] Verify hermetic build succeeds with cross-compilation packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)