### PR TITLE
fix: remove duplicate content_set repo causing hermetic build failure

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -44,8 +44,8 @@ repos:
     conf:
       extra_options:
         module_hotfixes: 1
-        # this repo provides complete RHEL 8 build env; we just want the go-toolset content
-        includepkgs: module-build-macros golang*
+        # this repo provides complete RHEL 9 build env; we just want the go-toolset content
+        includepkgs: module-build-macros golang* goversioninfo gpgme-devel libassuan-devel mingw*
       baseurl:
         # golang-1.21.3-5.el9
         # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2770477
@@ -53,29 +53,6 @@ repos:
         ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
         s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
         x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
-    # These content sets are not used, so just putting something here
-    content_set:
-      default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
-      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
-      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
-      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
-      optional: true
-
-  rhel-9-server-ose-build-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1
-        # this repo is for our own buildroot, which also inherits a complete RHEL 8 build env;
-        # restrict to specific necessary content, because RHEL 8 build dev content may include
-        # pending unreleased content that can cause conflicts for later CI installs lacking access
-        # to that content.
-        includepkgs: goversioninfo gpgme-devel libassuan-devel mingw* golang*
-      baseurl:
-        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
-        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
-        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
-        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
-
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -14,9 +14,8 @@ content:
       path: go_wrapper.sh
       overwriting: true
 enabled_repos:
-- rhel-9-server-ose-build-rpms
-- rhel-9-baseos-rpms
 - rhel-9-golang-rpms
+- rhel-9-baseos-rpms
 # for clang
 - rhel-9-appstream-rpms
 


### PR DESCRIPTION
## Summary
- Remove `rhel-9-server-ose-build-rpms` repo which has identical `content_set` values as `rhel-9-golang-rpms`
- Merge its `includepkgs` (`goversioninfo`, `gpgme-devel`, `libassuan-devel`, `mingw*`) into `rhel-9-golang-rpms`
- In Konflux, repos with the same `content_set` collapse into one repo ID, causing DNF to fail with `Repository rhocp-4.16-for-rhel-9-aarch64-rpms is listed more than once in the configuration`
- Same fix was already applied to rhel-8-golang branches

Also affects `rhel-9-golang-1.19` and `rhel-9-golang-1.20` (separate PRs needed).

## Test plan
- [ ] Verify hermetic build no longer fails with duplicate repo error
- [ ] Verify lockfile includes mingw packages for x86_64
- [ ] Verify goversioninfo, gpgme-devel, libassuan-devel are still resolvable

🤖 Generated with [Claude Code](https://claude.com/claude-code)