### PR TITLE
[rhel-9-golang-1.19] fix: remove duplicate content_set repo causing hermetic build failure

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -44,34 +44,13 @@ repos:
     conf:
       extra_options:
         module_hotfixes: 1
+        # this repo provides complete RHEL 9 build env; we just want the go-toolset content
+        includepkgs: module-build-macros golang* goversioninfo gpgme-devel libassuan-devel mingw*
       baseurl:
         aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
         ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
         s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
         x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
-    # These content sets are not used, so just putting something here
-    content_set:
-      default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
-      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
-      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
-      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
-      optional: true
-
-  rhel-9-server-ose-build-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1
-        # this repo is for our own buildroot, which also inherits a complete RHEL 8 build env;
-        # restrict to specific necessary content, because RHEL 8 build dev content may include
-        # pending unreleased content that can cause conflicts for later CI installs lacking access
-        # to that content.
-        includepkgs: goversioninfo gpgme-devel libassuan-devel mingw* golang*
-      baseurl:
-        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
-        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
-        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
-        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
-
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -15,7 +15,6 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-9-golang-rpms
-- rhel-9-server-ose-build-rpms
 - rhel-9-baseos-rpms
 # for clang
 - rhel-9-appstream-rpms


### PR DESCRIPTION
## Summary
- Remove `rhel-9-server-ose-build-rpms` repo which duplicates the same `content_set` values as `rhel-9-golang-rpms`, causing `Repository is listed more than once` DNF errors in Konflux hermetic builds
- Merge its `includepkgs` (`goversioninfo gpgme-devel libassuan-devel mingw*`) into `rhel-9-golang-rpms` (which previously had no `includepkgs` filter)
- Add `module-build-macros golang*` to the includepkgs for consistency with other branches
- Remove `rhel-9-server-ose-build-rpms` from `enabled_repos` in image metadata

Cherry-pick of #11147 (rhel-9-golang-1.21) and sibling of #11148 (rhel-9-golang-1.20).

/assign thegreyd