### PR TITLE
[rhel-9-golang-1.19] fix: add codeready-builder repo for consistent mingw sourcing

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -45,7 +45,7 @@ repos:
       extra_options:
         module_hotfixes: 1
         # this repo provides complete RHEL 9 build env; we just want the go-toolset content
-        includepkgs: module-build-macros golang* goversioninfo gpgme-devel libassuan-devel mingw*
+        includepkgs: module-build-macros golang* goversioninfo
       baseurl:
         aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
         ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
@@ -86,5 +86,20 @@ repos:
       aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_0
       ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_0
       s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_0
+    reposync:
+      enabled: false
+
+  rhel-9-codeready-builder-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/codeready-builder/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/codeready-builder/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/codeready-builder/os/
+    content_set:
+      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_0
+      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_0
+      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_0
+      s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_0
     reposync:
       enabled: false

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -18,6 +18,7 @@ enabled_repos:
 - rhel-9-baseos-rpms
 # for clang
 - rhel-9-appstream-rpms
+- rhel-9-codeready-builder-rpms
 
 from:
   stream: rhel9


### PR DESCRIPTION
## Summary
- Add `rhel-9-codeready-builder-rpms` repo definition (EUS 9.0) to `group.yml`
- Add it to `enabled_repos` in image metadata
- Revert `rhel-9-golang-rpms` includepkgs to `module-build-macros golang* goversioninfo` (remove `gpgme-devel libassuan-devel mingw*`)

This makes rhel-9-golang-1.19 consistent with rhel-9-golang-1.22–1.26, where mingw, gpgme-devel, and libassuan-devel are sourced from the codeready-builder repo rather than from the golang-rpms brewroot repo.

Verified that codeready-builder EUS 9.0 contains `mingw64-gcc`, `gpgme-devel`, and `libassuan-devel`.

Sibling PRs for 1.20 and 1.21.

/assign thegreyd