### PR TITLE
[rhel-8-golang-1.21] fix: remove redundant mingw from golang-rpms includepkgs

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -44,7 +44,7 @@ repos:
       extra_options:
         module_hotfixes: 1
         # this repo provides complete RHEL 8 build env; we just want the go-toolset content
-        includepkgs: golang golang-bin golang-docs golang-misc golang-race golang-src golang-tests goversioninfo mingw64-gcc mingw64-cpp mingw64-binutils mingw64-crt mingw64-headers mingw64-filesystem mingw64-winpthreads mingw-binutils-generic mingw-filesystem-base mingw-w64-tools
+        includepkgs: golang golang-bin golang-docs golang-misc golang-race golang-src golang-tests goversioninfo
       # golang-1.21.3-4.el8_9
       # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2770478
       baseurl:


### PR DESCRIPTION
## Summary
- Remove explicit mingw packages from `rhel-8-golang-rpms` includepkgs
- These are already provided by the `rhel-8-codeready-builder-rpms` repo (no includepkgs filter)
- Aligns with rhel-8-golang-1.19/1.20 which never had mingw in their includepkgs

/assign thegreyd