### PR TITLE
[rhel-8-golang-1.26] fix: remove unused delve and go-toolset from includepkgs

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -47,7 +47,7 @@ repos:
     conf:
       extra_options:
         module_hotfixes: 1
-        includepkgs: module-build-macros delve golang* go-toolset* goversioninfo
+        includepkgs: module-build-macros golang* goversioninfo
       baseurl:
         aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
         ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/


### PR DESCRIPTION
## Summary
- Remove `delve` and `go-toolset*` from `rhel-8-golang-rpms` includepkgs
- Neither package is installed by the Dockerfile — they are unused pass-through filters
- Cherry-pick to rhel-8-golang-1.22 through 1.25 (identical includepkgs line)

/assign thegreyd