### PR TITLE
[rhel-8-golang-1.22] fix: remove unused delve and go-toolset from includepkgs

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -44,7 +44,7 @@ repos:
       extra_options:
         module_hotfixes: 1
         # this repo provides complete RHEL 8 build env; we just want the go-toolset content
-        includepkgs: module-build-macros delve golang* go-toolset* goversioninfo
+        includepkgs: module-build-macros golang* goversioninfo
       # golang-1.21.3-4.el8_9
       # https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2770478
       baseurl:


### PR DESCRIPTION
## Summary
- Remove `delve` and `go-toolset*` from `rhel-8-golang-rpms` includepkgs
- Neither package is installed by the Dockerfile

Cherry-pick of #11155.

/assign thegreyd