### PR TITLE
Add target_release entries for 5.0.0 and 5.0.z

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -10,8 +10,8 @@ bugzilla_config:
   product: "OpenShift Container Platform"
 
 target_release:
-  #  - "{MAJOR}.{MINOR}.0"
-  #  - "{MAJOR}.{MINOR}.z"
+  - "{MAJOR}.{MINOR}.0"
+  - "{MAJOR}.{MINOR}.z"
   - "{MAJOR}.{MINOR}"
 
 version:


### PR DESCRIPTION
## Summary
- Uncomment the `{MAJOR}.{MINOR}.0` and `{MAJOR}.{MINOR}.z` target_release entries in bug.yml
- Ensures bugs with target releases 5.0, 5.0.0, and 5.0.z are all properly tracked

## Test plan
- [ ] Verify bug.yml has all three target_release entries: `{MAJOR}.{MINOR}`, `{MAJOR}.{MINOR}.0`, `{MAJOR}.{MINOR}.z`