### PR TITLE
Update releases.yml to pin some fbc's operators

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -53,7 +53,17 @@ releases:
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e8ae2267672a6eb2a1486d89cbb08adbf1833b14efa9380412b08bae985f256b
       members:
         rpms: []
-        images: []
+        images:
+          - distgit_key: local-storage-operator-container
+            why: Latest build has missing operands image in quay. Same commit, all operands match.
+            metadata:
+              is:
+                nvr: local-storage-operator-container-v4.16.0-202606091004.p2.g1284973.assembly.stream.el9
+          - distgit_key: ose-aws-efs-csi-driver-operator-container
+            why: Latest build has missing operands image in quay. Same commit, all operands match.
+            metadata:
+              is:
+                nvr: ose-aws-efs-csi-driver-operator-container-v4.16.0-202605291050.p2.gdb01344.assembly.stream.el9
   4.16.63:
     assembly:
       type: standard


### PR DESCRIPTION
Update releases.yml to pin some fbc's operators for which some operands are missing.