### PR TITLE
ART-18962 [openshift-4.18]: fix ose-azure-disk-csi-driver golang builder stream

### DIFF
--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -13,7 +13,7 @@ content:
       streams_prs:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
-          stream: rhel-9-golang-ci-build-root
+          stream: rhel-9-golang-1.23-ci-build-root
         auto_label:
         - approved
         - lgtm
@@ -31,7 +31,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang-extra
+  - stream: rhel-9-golang-1.23
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-azure-disk-csi-driver-rhel9
 payload_name: azure-disk-csi-driver


### PR DESCRIPTION
## Summary
Fix `ose-azure-disk-csi-driver` to use the defined Go 1.23 builder stream instead of the non-existent `rhel-9-golang-extra`.

## Problem
**Before:** Builder stream was `rhel-9-golang-extra`, which is not defined in `streams.yml`. Konflux rebase fails with `Unable to find definition for stream 'rhel-9-golang-extra'`. CI alignment still pointed at the default `rhel-9-golang-ci-build-root` (Go 1.22).

**After:** Builder uses `rhel-9-golang-1.23` (Go 1.23.10) and CI alignment uses `rhel-9-golang-1.23-ci-build-root`, matching other CSI drivers like `ose-powervs-block-csi-driver`.

Related: [ART-18962](https://redhat.atlassian.net/browse/ART-18962)

## Test plan
- [ ] Merge and trigger ocp4-konflux for `ose-azure-disk-csi-driver` on 4.18 stream assembly