### PR TITLE
ART-19384 [openshift-4.14]: fix monitoring-plugin EC builder

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -27,7 +27,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: nodejs
+  - member: openshift-base-nodejs
   member: openshift-enterprise-base
 name: openshift/ose-monitoring-plugin-rhel8
 payload_name: monitoring-plugin


### PR DESCRIPTION
## Summary
Fix `monitoring-plugin` post-build EC (`its_error`) on openshift-4.14 by using `member: openshift-base-nodejs` instead of `stream: nodejs`.

## Problem
Build succeeds; EC verification fails (~32 consecutive hits). The image was the only 4.14 console plugin still on `stream: nodejs`, which resolves parent `nodejs-18-container-1-86` instead of `openshift-base-nodejs-container`. Working plugins (`nmstate-console-plugin`, `openshift-enterprise-console`) already use `member: openshift-base-nodejs`.

## Change
- `images/monitoring-plugin.yml`: builder `stream: nodejs` → `member: openshift-base-nodejs`

## Test plan
- [x] Jenkins ocp4-konflux triggered with `IMAGE_LIST=monitoring-plugin`, `ASSEMBLY=test`, PR fork branch
- [ ] EC PLR passes (`openshift-4-14-ec-ose-4-14-monitoring-plugin-*`)
- [ ] Redis ec-failure counter resets for openshift-4.14

## Tickets
- [ART-19384](https://redhat.atlassian.net/browse/ART-19384)
- [ART-18898](https://redhat.atlassian.net/browse/ART-18898)