### PR TITLE
ART-19382 [openshift-4.15]: fix monitoring-plugin EC builder

### DIFF
--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -32,7 +32,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: nodejs
+  - member: openshift-base-nodejs
   member: openshift-enterprise-base
 name: openshift/ose-monitoring-plugin-rhel8
 payload_name: monitoring-plugin


### PR DESCRIPTION
## Summary
Fix `monitoring-plugin` post-build EC (`its_error`) on openshift-4.15 by using `member: openshift-base-nodejs` instead of `stream: nodejs`.

## Problem
Build succeeds; EC verification fails (~28 consecutive hits). Same root cause as 4.14: `stream: nodejs` resolves parent `nodejs-18-container-1-86` instead of `openshift-base-nodejs-container`.

## Change
- `images/monitoring-plugin.yml`: builder `stream: nodejs` → `member: openshift-base-nodejs`

## Test plan
- [x] Jenkins ocp4-konflux triggered with `IMAGE_LIST=monitoring-plugin`, `ASSEMBLY=test`, PR fork branch
- [ ] EC PLR passes (`openshift-4-15-ec-ose-4-15-monitoring-plugin-*`)
- [ ] Redis ec-failure counter resets for openshift-4.15

## Tickets
- [ART-19382](https://redhat.atlassian.net/browse/ART-19382)
- [ART-18920](https://redhat.atlassian.net/browse/ART-18920)