### PR TITLE
fix(agentic-skills): add no_shell flag for scratch-based image

### DIFF
--- a/images/agentic-skills.yml
+++ b/images/agentic-skills.yml
@@ -15,6 +15,8 @@ delivery:
 for_payload: true
 from:
   stream: scratch
+konflux:
+  no_shell: true
 name: openshift/agentic-skills
 payload_name: agentic-skills
 owners:


### PR DESCRIPTION
## Summary
- Add `konflux: no_shell: true` to `agentic-skills.yml`
- agentic-skills uses `FROM scratch` (no RPMs installed)
- Without this flag, doozer's `update_konflux_db` fails extracting RPMs from SBOM → builds marked UNSTABLE despite successful Konflux PipelineRun

## Context
- ocp4-konflux #37446 (ASSEMBLY=test) — UNSTABLE
- ocp4-konflux #37448 (ASSEMBLY=stream) — UNSTABLE
- Both had successful Konflux PipelineRuns (25/25 pods Succeeded)
- Failure: `Could not get rpms from SBOM for arch x86_64`
- Jira: [ART-19755](https://redhat.atlassian.net/browse/ART-19755)

## Pattern
Same approach as `okd-only-upi-installer.yml` which also uses `no_shell: true` for images without `/bin/sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)