### PR TITLE
fix(agentic-skills): temporarily disable to unblock ec.3

### DIFF
--- a/images/agentic-skills.yml
+++ b/images/agentic-skills.yml
@@ -15,6 +15,8 @@ delivery:
 for_payload: true
 from:
   stream: scratch
+konflux:
+  no_shell: true
 name: openshift/agentic-skills
 payload_name: agentic-skills
 owners:

--- a/images/agentic-skills.yml
+++ b/images/agentic-skills.yml
@@ -1,3 +1,4 @@
+mode: disabled  # Temporarily disabled: Conforma (EC) violation for scratch-based image pending fix
 content:
   source:
     dockerfile: Containerfile
@@ -15,8 +16,6 @@ delivery:
 for_payload: true
 from:
   stream: scratch
-konflux:
-  no_shell: true
 name: openshift/agentic-skills
 payload_name: agentic-skills
 owners:


### PR DESCRIPTION
## Summary
- Set `mode: disabled` on `agentic-skills.yml` to unblock gen-assembly for ec.3
- agentic-skills is a scratch-based image that fails Conforma (EC) verification
- Upstream fix applied today but no successful Konflux build registered yet
- gen-assembly #1210 failed: "No image was found for assembly stream for component agentic-skills"

## Plan
Re-enable once a successful stream build is registered after the upstream Conforma fix propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)