### PR TITLE
ART-19529: Add RHEL10 support for rhcos-node-image

### DIFF
--- a/images/rhcos-node-image-rhel10.yml
+++ b/images/rhcos-node-image-rhel10.yml
@@ -1,0 +1,60 @@
+content:
+  source:
+    dockerfile: Containerfile
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/os.git
+      web: https://github.com/openshift/os
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: false
+    modifications:
+    - action: replace
+      match: "ARG OPENSHIFT_VERSION=overridden"
+      replacement: "ARG OPENSHIFT_VERSION=4.23"
+    - action: replace
+      match: "ARG IMAGE_NAME"
+      replacement: "ARG IMAGE_NAME=openshift/rhcos-node-image-rhel10"
+    - action: replace
+      match: "ARG IMAGE_CPE"
+      replacement: "ARG IMAGE_CPE=cpe:/a:redhat:openshift:4.23::el10"
+    - action: replace
+      match: "ARG TARGETARCH"
+      replacement: "ARG TARGETARCH=amd64"
+    - action: replace
+      match: "LABEL name=${IMAGE_NAME}"
+      replacement: ""
+    - action: replace
+      match: "LABEL architecture=${TARGETARCH}"
+      replacement: ""
+    - action: replace
+      match: 'RUN --mount=type=bind,target=/run/src --mount=type=secret,id=yumrepos,target=/run/src/secret.repo /run/src/build-node-image.sh'
+      replacement: |
+        RUN --mount=type=bind,target=/run/src --mount=type=secret,id=yumrepos,target=/run/src/secret.repo \
+            sed -e 's/dnf --repo="${YUM_REPO_NAMES}"/dnf/' \
+                -e '/cat \/run\/src\/\*\.repo >> \/etc\/yum\.repos\.d\/git\.repo/a sed -i "s/enabled=1/enabled=0/g" /etc/yum.repos.d/git.repo' \
+                /run/src/build-node-image.sh | bash
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-10
+  component: rhcos-node-image-container
+enabled_repos:
+- rhel-10-server-ose-rpms
+- rhel-102-baseos
+- rhel-102-appstream
+- rhel-102-fast-datapath
+for_payload: false
+for_release: false
+from:
+  builder:
+    - stream: rhel_coreos10
+name: openshift/rhcos-node-image-rhel10
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false
+konflux:
+  network_mode: open
+okd:
+  mode: disabled
+

--- a/repos/rhel-102-appstream.yml
+++ b/repos/rhel-102-appstream.yml
@@ -1,0 +1,22 @@
+- conf:
+    baseurl:
+      x86_64:  "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/appstream/os/"
+      aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/aarch64/appstream/os/"
+      ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/ppc64le/appstream/os/"
+      s390x:   "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/s390x/appstream/os/"
+    ci_alignment:
+      localdev:
+        enabled: true
+      profiles:
+      - el10
+    extra_options:
+      module_hotfixes: 1
+  content_set:
+    aarch64: rhel-10-for-aarch64-appstream-e4s-rpms__10_DOT_2
+    default: rhel-10-for-x86_64-appstream-e4s-rpms__10_DOT_2
+    ppc64le: rhel-10-for-ppc64le-appstream-e4s-rpms__10_DOT_2
+    s390x: rhel-10-for-s390x-appstream-e4s-rpms__10_DOT_2
+  name: rhel-102-appstream
+  reposync:
+    enabled: false
+  type: external

--- a/streams.yml
+++ b/streams.yml
@@ -112,3 +112,7 @@ centos_stream10:
 rhel_coreos:
   image: registry.ci.openshift.org/coreos/rhel-coreos-base:9.8
   skip_nvr_check: true
+
+rhel_coreos10:
+  image: registry.ci.openshift.org/coreos/rhel-coreos-base:10.2
+  skip_nvr_check: true


### PR DESCRIPTION
Introduces rhcos-node-image-rhel10 to support RHEL 10-based CoreOS node images. Adds rhel_coreos10 stream pointing to registry.ci.openshift.org/coreos/rhel-coreos-base:10.2

JIRA: https://redhat.atlassian.net/browse/ART-19529

Test build:
- https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/37499/
- https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-23/pipelineruns/ose-4-23-rhcos-node-image-rhel10-ztpcn
