### PR TITLE
Remove oc-mirror from the payload

### DIFF
--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -26,7 +26,7 @@ delivery:
   repo_name: oc-mirror-plugin
   delivery_repo_names:
   - openshift5/oc-mirror-plugin-rhel9
-for_payload: true
+for_payload: false
 from:
   builder:
   - stream: rhel-8-golang


### PR DESCRIPTION
Removing oc-mirror from being included in the payload. TBD on whether we'll need this file at all moving forward after using solely konflux for releases moving forward. If so, this PR will switch to removing this configuration entirely.

https://redhat.atlassian.net/browse/CLID-653 