### PR TITLE
Exclude coreutils-single from E4S baseos repo to fix lockfile conflicts

### DIFF
--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -10,6 +10,7 @@
       profiles:
       - el9
     extra_options:
+      excludepkgs: coreutils-single*
       module_hotfixes: 1
   content_set:
     aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_8


### PR DESCRIPTION
## Summary
- The E4S 9.8 baseos repo provides both `coreutils` and `coreutils-single`, which are mutually exclusive
- `rpm-lockfile-prototype` cannot resolve this conflict when generating lockfiles for images like `dpu-marvell-cp-agent`
- Adds `excludepkgs: coreutils-single*` to `repos/rhel-9-baseos-rpms.yml` to prevent the conflict

## Test plan
- [ ] Verify `dpu-marvell-cp-agent` lockfile generation succeeds on next build cycle
- [ ] Check no other images regress (OCP images use `coreutils`, never `coreutils-single`)

Resolves: [ART-20309](https://redhat.atlassian.net/browse/ART-20309)

🤖 Generated with [Claude Code](https://claude.com/claude-code)