### PR TITLE
MON-4574: Onboard `openshift/kubernetes-sigs-resource-state-metrics`

### DIFF
--- a/images/kubernetes-sigs-resource-state-metrics.yml
+++ b/images/kubernetes-sigs-resource-state-metrics.yml
@@ -1,0 +1,42 @@
+content:
+  source:
+    dockerfile: Dockerfile.ocp
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/kubernetes-sigs-resource-state-metrics.git
+      web: https://github.com/openshift/kubernetes-sigs-resource-state-metrics
+    path: ''
+    ci_alignment:
+      streams_prs:
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - cherry-pick-approved
+        - lgtm
+        - staff-eng-approved
+        - jira/valid-reference
+        - verified
+        ci_build_root:
+          member: ci-openshift-build-root-latest.rhel9
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: kubernetes-sigs-resource-state-metrics-container
+delivery:
+  repo_name: ose-resource-state-metrics
+  delivery_repo_names:
+  - openshift4/ose-resource-state-metrics-rhel9
+for_payload: true
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+labels:
+  License: ASL 2.0
+  io.k8s.description: This is a component that exposes metrics about Kubernetes custom resources.
+  io.k8s.display-name: resource-state-metrics
+  io.openshift.tags: kubernetes
+name: openshift/ose-resource-state-metrics-rhel9
+payload_name: resource-state-metrics
+owners:
+- team-monitoring@redhat.com


### PR DESCRIPTION
#### This should ideally go through the ProdSec Threat Model assessment first, before making its way into the payload. As such, this is blocked by [MON-4573](https://redhat.atlassian.net/browse/MON-4573).

#### This PR targets `openshift-4.23`, not `main`

Onboards the newly introduced `openshift/kubernetes-sigs-resource-state-metrics` repository. Some points for the reviewer:
* RSM has auto-generated release branches from OCP 4.23 to OCP 5.1, as such this config is being added to OCP 4.23 (earliest branch that's present in the repository) only. Subsequent additions for future branches should happen automatically.
* Other CMO workloads with older configurations, such as `openshift/kube-state-metrics`, use `stream: rhel-9-golang-ci-build-root` (the 4.17 style), and not `member: ci-openshift-build-root-latest.rhel9` (the 4.23 style) in the `ci_build_root` section. Since the configuration for RSM is new, we are sticking to the newer conventions here.