### PR TITLE
Add iptables to rhel-102-early-kernel includepkgs

### DIFF
--- a/repos/rhel-102-early-kernel.yml
+++ b/repos/rhel-102-early-kernel.yml
@@ -5,7 +5,7 @@
       ppc64le: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.22/stream/el10/latest/ppc64le/os
       s390x: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/4.22/stream/el10/latest/s390x/os
     extra_options:
-      includepkgs: kernel,kernel-*
+      includepkgs: kernel,kernel-*,iptables,iptables-*
       gpgcheck: '1'
   content_set:
     optional: true


### PR DESCRIPTION
The reposync for rhel-102-early-kernel only syncs kernel packages (includepkgs: kernel,kernel-*), but iptables is now needed for RHCOS 10.2 builds (see coreos/rhel-coreos-config#254). The CI-side .repo files in openshift/release were already updated (PR #80475) to request iptables from this repo, but the server-side reposync config still filters it out, causing metadata-present-but-RPMs-missing.

Jira: [ART-20341](https://redhat.atlassian.net/browse/ART-20341)