### PR TITLE
Enable base-image release for golang 1.26 rhel9 builder

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -18,9 +18,11 @@ konflux:
     lockfile:
       backend: rpm-lockfile-prototype
 
-# revert after manually verifying base-image-release works for the desired golang builder nvr
+software_lifecycle:
+  phase: pre-release
+
 base_image_release:
-  enabled: false
+  enabled: true
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub

--- a/group.yml
+++ b/group.yml
@@ -18,8 +18,6 @@ konflux:
     lockfile:
       backend: rpm-lockfile-prototype
 
-software_lifecycle:
-  phase: pre-release
 
 base_image_release:
   enabled: true


### PR DESCRIPTION
## Summary

Re-enable `base_image_release.enabled: true` for manual silent release to authz.

`software_lifecycle.phase: pre-release` is **not** required on rhel9 — enabled-only Jenkins run passed Conforma on the prod release plan.

## Test plan

- [x] Enabled-only test: [base-image-release #9122](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%2Fbase-image-release/9122/) — `releasePlan=ocp-art-images-base-silent`, release **SUCCESS**
- [x] Tag on authz: `registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9`