### PR TITLE
Point default golang 1.26 streams at authz (openshift-4.23)

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.3-202605272015.p2.ged14a27.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.3-202605272015.p2.g8642f2e.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202605272015.p2.g8642f2e.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
## Summary
- Move default `rhel-8-golang` / `rhel-9-golang` streams to `registry.redhat.io/openshift/art-images-base` tags released via base-image-release Jenkins 9119/9120
- Drops quay `art-images` pullspecs for Go 1.26 default builder ([ART-14300](https://redhat.atlassian.net/browse/ART-14300))

## Tags
- rhel8: `openshift-golang-builder-container-v1.26.3-202605272015.p2.g8642f2e.el8`
- rhel9: `openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9`

## Test plan
- [ ] Merge after group.yml PRs #11271/#11272 land
- [ ] Stream assembly rebuild of a golang consumer on 4.23 passes EC without quay art-images waiver