### PR TITLE
[openshift-5.0]: align parent metadata for baremetal-operator and oc-mirror-plugin

### DIFF
--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -31,6 +31,7 @@ from:
   builder:
   - stream: rhel-8-golang
   - stream: rhel-9-golang
+  - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/oc-mirror-plugin-rhel9
 payload_name: oc-mirror

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -21,6 +21,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
+  - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-cluster-baremetal-operator-rhel9
 payload_name: cluster-baremetal-operator


### PR DESCRIPTION
## Summary

Add missing duplicate `rhel-9-golang` builder entries in ocp-build-data so parent counts match upstream Dockerfiles after ote-migration test-extension stages on openshift-5.0.

## Problem

Konflux rebase fails on Jenkins #38034 — `ose-cluster-baremetal-operator` has 2 parents in metadata vs 3 `FROM` lines; `oc-mirror-plugin` has 3 vs 4. ART Redis rebase-failure counters: 42 and 39 hits.

Same root cause as openshift-4.23 fix in #11275.

## Images

- `ose-cluster-baremetal-operator` — 2× `rhel-9-golang` + `openshift-enterprise-base-rhel9`
- `oc-mirror-plugin` — `rhel-8-golang`, 2× `rhel-9-golang` + `openshift-enterprise-base-rhel9`

## Test plan

- [ ] Manual `ocp4-konflux` retest with `BUILD_VERSION=5.0`, `IMAGE_LIST=ose-cluster-baremetal-operator,oc-mirror-plugin`, fork `DOOZER_DATA_PATH` + branch `art-fix-parent-metadata-5.0`