### PR TITLE
mta-solution-server: enable cachi2 prefetch with permissive mode

### DIFF
--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -4,6 +4,8 @@ cachito:
       - path: kai_mcp_solution_server
 content:
   source:
+    pkg_managers:
+      - pip
     dockerfile: konflux.solution-server.Dockerfile
     git:
       branch:

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -2,6 +2,8 @@ cachito:
   packages:
     pip:
       - path: kai_mcp_solution_server
+        requirements_build_files:
+          - requirements-build.txt
 content:
   source:
     pkg_managers:
@@ -9,7 +11,7 @@ content:
     dockerfile: konflux.solution-server.Dockerfile
     git:
       branch:
-        target: release-0.9
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-kai.git
       web: https://github.com/migtools/mta-kai
 jira:

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -1,3 +1,7 @@
+cachito:
+  packages:
+    pip:
+      - path: kai_mcp_solution_server
 content:
   source:
     dockerfile: konflux.solution-server.Dockerfile

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -27,6 +27,9 @@ enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms
 - rhel-9-codeready-builder-rpms
+- rhel-98-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-codeready-builder-rpms
 from:
   builder:
     - stream: rhel9

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -31,4 +31,5 @@ dependents:
 konflux:
   network_mode: open
   cachi2:
-    enabled: false
+    enabled: true
+    prefetch_mode: permissive


### PR DESCRIPTION
## Summary

- Enable cachi2 prefetch for `mta-solution-server` with `prefetch_mode: permissive` (requires [art-tools PR #3047](https://github.com/openshift-eng/art-tools/pull/3047))
- Set pip prefetch path to `kai_mcp_solution_server` subdirectory (where the Dockerfile actually installs from)
- Add `requirements_build_files` for build dependencies like `setuptools`, `maturin` (from [mta-kai PR #4](https://github.com/migtools/mta-kai/pull/4))
- Explicitly declare `pkg_managers: [pip]` to avoid auto-detect picking up stale root-level `requirements.txt`
- Switch source branch from `release-0.9` to `main` (where mta-kai PR #4 is merged)
- Add RHEL 9.8 repos (matching `mta-analyzer-addon` pattern) to provide Cargo 1.88+ needed by `maturin==1.14.0`

## Test plan

- [x] Prefetch passes with permissive mode — all pip dependencies fetched successfully
- [ ] Build passes with RHEL 9.8 repos providing Cargo 1.88+ for maturin
- [ ] Jenkins job: `build/layered-products` with `GROUP=mta-8.2`, `ASSEMBLY=test`, this ocp-build-data branch, and art-tools PR #3047

## Dependencies

- art-tools [PR #3047](https://github.com/openshift-eng/art-tools/pull/3047) — adds `prefetch_mode` config support
- mta-kai [PR #4](https://github.com/migtools/mta-kai/pull/4) — adds `requirements-build.txt` (merged to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)