### PR TITLE
HYPBLD-847 - Add obo-prometheus-operator image config

### DIFF
--- a/images/obo-prometheus-operator.yml
+++ b/images/obo-prometheus-operator.yml
@@ -1,0 +1,32 @@
+cachito:
+  enabled: true
+  packages:
+    gomod:
+    - path: rhobs-obo-prometheus-operator
+content:
+  source:
+    dockerfile: Containerfile.prom-operator
+    git:
+      branch:
+        target: release-2.16
+      url: git@github.com:openshift-priv/stolostron-obo-prometheus-operator.git
+      web: https://github.com/stolostron/obo-prometheus-operator
+distgit:
+  component: acm-obo-prometheus-operator-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+  - rhacm2/obo-prometheus-rhel9-operator
+for_payload: false
+dependents:
+- multiclusterhub-operator
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: rhacm2/obo-prometheus-rhel9-operator
+owners:
+- acm-cicd@redhat.com
+jira:
+  project: ACM
+  component: acm-obo-prometheus-operator-container

--- a/images/obo-prometheus-operator.yml
+++ b/images/obo-prometheus-operator.yml
@@ -5,6 +5,8 @@ cachito:
     - path: rhobs-obo-prometheus-operator
 content:
   source:
+    pkg_managers:
+    - gomod
     dockerfile: Containerfile.prom-operator
     git:
       branch:


### PR DESCRIPTION
The obo-prometheus-operator is a separate component from prometheus-operator, sourced from stolostron/obo-prometheus-operator (which wraps rhobs/obo-prometheus-operator via git submodule). It was introduced in ACM 2.16 and delivers to rhacm2/obo-prometheus-rhel9-operator.

This component was originally excluded during initial ocp-build-data setup as deprecated, but ACM developers confirm it is a required live component that must remain distinct from the regular prometheus-operator.

Note: openshift-priv mirror (stolostron-obo-prometheus-operator) may need to be created for hermetic builds.

Ref: [HYPBLD-847](https://redhat.atlassian.net/browse/HYPBLD-847)