### PR TITLE
[openshift-4.23]: fix partner golang streams canonical builder pullspecs

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -46,7 +46,7 @@ rhel-8-golang-1.25:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.26:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.3-202605272015.p2.g8642f2e.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202605272015.p2.g8642f2e.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.26-openshift-{MAJOR}.{MINOR}
@@ -54,7 +54,7 @@ partner-rhel-8-golang-1.26:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.26-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-9-golang-1.26:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.26.3-202605272015.p2.ged14a27.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.26-openshift-{MAJOR}.{MINOR}
@@ -62,7 +62,7 @@ partner-rhel-9-golang-1.26:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.26-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.25:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604081607.p2.g2aa6a05.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604081607.p2.g2aa6a05.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.25-openshift-{MAJOR}.{MINOR}
@@ -70,7 +70,7 @@ partner-rhel-8-golang-1.25:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.25-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-9-golang-1.25:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.8-202604150744.p2.gf28329a.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.25-openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
## Summary
Point all `partner-rhel-*-golang-*` streams at the same released `registry.redhat.io` pullspecs as their matching `rhel-*-golang*` streams.

## Problem
**Before:** Partner golang streams used `quay.io/redhat-user-workloads/.../golang-builder-v*...` pullspecs. Doozer's `canonical_builders_from_upstream` matcher parses golang version from the image tag; the partner quay tag (`golang-builder-v1.26.3`) matches, while the `rhel-*-golang` registry.redhat.io tag (`openshift-golang-builder-container-v1.26.3`) does not. Consumer images rebased with a quay.io golang builder parent and failed build-time EC (`conforma-build-ec-stage`).

**After:** All four partner stream `image` fields match their corresponding `rhel-*-golang*` streams on `registry.redhat.io`. The canonical matcher skips partner entries (tag does not parse), doozer falls back to `rhel-*-golang-{version}`, and rebased Dockerfiles use released registry.redhat.io builders.

Same fix as openshift-eng/ocp-build-data#11290 for 5.0.
