### PR TITLE
Switch sriov-network-config-daemon to rpm-lockfile-prototype (openshift-5.0)

### DIFF
--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -37,5 +37,9 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-sriov-network-config-daemon-rhel9
 name_in_bundle: sriov-network-config-daemon
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype
 owners:
 - multus-dev@redhat.com


### PR DESCRIPTION
## Summary
- Switch sriov-network-config-daemon to use rpm-lockfile-prototype backend
- Resolves RPM dependencies at lockfile generation time, avoiding the need for entitlement certs in the build pod

## Test plan
- [ ] Verify Konflux build succeeds with the lockfile backend