### PR TITLE
ART-19543: Add rhcos-node-image-extensions for RHEL9

### DIFF
--- a/images/rhcos-node-extensions.yml
+++ b/images/rhcos-node-extensions.yml
@@ -1,0 +1,46 @@
+content:
+  source:
+    dockerfile: extensions/Containerfile
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/os.git
+      web: https://github.com/openshift/os
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: false
+    modifications:
+    - action: replace
+      match: "ARG STREAM_CLASS"
+      replacement: "ARG STREAM_CLASS=rhel9"
+    - action: replace
+      match: "RUN --mount=type=secret,id=yumrepos,target=/os/secret.repo extensions/build.sh"
+      replacement: |
+        RUN rm -f /os/c10s.repo && touch /os/empty.repo && \
+            sed -e 's/--repo="${repo_list}"//' extensions/build.sh | bash
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: rhcos-node-extensions-container
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-fast-datapath-rpms
+- rhel-9-server-ose-rpms
+- rhel-9-nfv
+- rhel-9-highavailability
+for_payload: false
+for_release: false
+from:
+  builder:
+    - member: rhcos-node-image
+    - member: openshift-enterprise-base-rhel9
+  member: openshift-enterprise-base-rhel9
+name: openshift/rhcos-node-extensions-rhel9
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false
+konflux:
+  network_mode: open
+okd:
+  mode: disabled


### PR DESCRIPTION
Test build: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/ose-5-0-rhcos-node-extensions-t6mzj