### PR TITLE
Add rpm-lockfile-prototype backend to openshift-enterprise-base

### DIFF
--- a/images/openshift-enterprise-base.yml
+++ b/images/openshift-enterprise-base.yml
@@ -65,3 +65,7 @@ labels:
 name: openshift/ose-base
 owners:
 - lmeyer@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype


### PR DESCRIPTION
## Summary
- Adds `konflux.cachi2.lockfile.backend: rpm-lockfile-prototype` to `openshift-enterprise-base.yml` (RHEL 8) for 4.17

## Test plan
- [ ] Verify the YAML is valid and the lockfile backend is picked up by the build system

🤖 Generated with [Claude Code](https://claude.com/claude-code)