### PR TITLE
Add auto_label for cluster-api, machine-api, and cloud-provider images

### DIFF
--- a/images/ose-aws-cloud-controller-manager.yml
+++ b/images/ose-aws-cloud-controller-manager.yml
@@ -14,6 +14,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-cloud-controller-manager-container

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -14,6 +14,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-cluster-api-controllers-container

--- a/images/ose-azure-cloud-controller-manager.yml
+++ b/images/ose-azure-cloud-controller-manager.yml
@@ -14,6 +14,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-cloud-controller-manager-container

--- a/images/ose-azure-cloud-node-manager.yml
+++ b/images/ose-azure-cloud-node-manager.yml
@@ -14,6 +14,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-cloud-node-manager-container

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -14,6 +14,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-cluster-api-controllers-container

--- a/images/ose-azure-service-operator.yml
+++ b/images/ose-azure-service-operator.yml
@@ -11,6 +11,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-service-operator-container

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -11,6 +11,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-api-container

--- a/images/ose-cluster-capi-operator.yml
+++ b/images/ose-cluster-capi-operator.yml
@@ -10,6 +10,12 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-capi-operator-container

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -6,6 +6,14 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-cloud-controller-manager-operator.git
       web: https://github.com/openshift/cluster-cloud-controller-manager-operator
+    ci_alignment:
+      streams_prs:
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-cloud-controller-manager-operator-container

--- a/images/ose-cluster-control-plane-machine-set-operator.yml
+++ b/images/ose-cluster-control-plane-machine-set-operator.yml
@@ -15,6 +15,12 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-control-plane-machine-set-operator-container

--- a/images/ose-cluster-machine-approver.yml
+++ b/images/ose-cluster-machine-approver.yml
@@ -10,6 +10,12 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-machine-approver-container

--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -15,6 +15,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-cloud-controller-manager-container

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -15,6 +15,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-cluster-api-controllers-container

--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -14,6 +14,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
     pkg_managers: []
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -15,6 +15,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibmcloud-cluster-api-controllers-container

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -12,6 +12,12 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibmcloud-machine-controllers-container

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -10,6 +10,12 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-operator-container

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -13,6 +13,12 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-aws-container

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -13,6 +13,12 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-azure-container

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -14,6 +14,12 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-gcp-container

--- a/images/ose-nutanix-cloud-controller-manager.yml
+++ b/images/ose-nutanix-cloud-controller-manager.yml
@@ -13,6 +13,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-nutanix-cloud-controller-manager-container

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -11,6 +11,12 @@ content:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-nutanix-machine-controllers-container

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -13,6 +13,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vsphere-cloud-controller-manager-container

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -13,6 +13,12 @@ content:
         commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - jira/valid-bug
+        - lgtm
+        - verified
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vsphere-cluster-api-controllers-container


### PR DESCRIPTION
Configure auto_label with `approved`, `backport-risk-assessed`, `jira/valid-bug`, `lgtm`, and `verified` labels for 24 image configs across cluster-api, machine-api, and cloud-provider repositories to enable automated merging of ART-generated PRs.