### PR TITLE
rhel-8-golang-1.26: fix content sets

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -69,10 +69,10 @@ repos:
         s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
         x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
     content_set:
-      default: rhel-8-for-x86_64-baseos-rpms__8
-      aarch64: rhel-8-for-aarch64-baseos-rpms__8
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms__8
-      s390x: rhel-8-for-s390x-baseos-rpms__8
+      default: rhel-8-for-x86_64-baseos-rpms
+      aarch64: rhel-8-for-aarch64-baseos-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms
+      s390x: rhel-8-for-s390x-baseos-rpms
     reposync:
       enabled: false
 
@@ -84,10 +84,10 @@ repos:
         s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
         x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
     content_set:
-      default: rhel-8-for-x86_64-appstream-rpms__8
-      aarch64: rhel-8-for-aarch64-appstream-rpms__8
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms__8
-      s390x: rhel-8-for-s390x-appstream-rpms__8
+      default: rhel-8-for-x86_64-appstream-rpms
+      aarch64: rhel-8-for-aarch64-appstream-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms
+      s390x: rhel-8-for-s390x-appstream-rpms
     reposync:
       enabled: false
 
@@ -99,9 +99,9 @@ repos:
         s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/codeready-builder/os/
         x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os/
     content_set:
-      default: codeready-builder-for-rhel-8-x86_64-rpms__8
-      aarch64: codeready-builder-for-rhel-8-aarch64-rpms__8
-      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms__8
-      s390x:   codeready-builder-for-rhel-8-s390x-rpms__8
+      default: codeready-builder-for-rhel-8-x86_64-rpms
+      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
+      s390x:   codeready-builder-for-rhel-8-s390x-rpms
     reposync:
       enabled: false


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED