### PR TITLE
Migrate rhel 8 golang 1.26 to golang

### DIFF
--- a/Dockerfiles/1-26.rhel8.Dockerfile
+++ b/Dockerfiles/1-26.rhel8.Dockerfile
@@ -49,10 +49,10 @@ RUN dnf update -y && \
         zip && \
     dnf install -y "golang-*$VERSION*" && \
     mkdir -p /go/src
-# provide a cross-compiler for windows/mac binaries (amd64 only)
+# provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .
-RUN [ $(go env GOARCH) != "amd64" ] || (\
-    # only install cross-compiler dependencies on amd64
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+    # only install cross-compiler dependencies on x86_64
     yum install -y --setopt=tsflags=nodocs \
     # Required packages for mac cross-compilation
     llvm-toolset-17* cmake3 gcc-c++ libxml2-devel \
@@ -69,7 +69,8 @@ RUN [ $(go env GOARCH) != "amd64" ] || (\
     cp -avr cross/osxcross/target/SDK /usr/local/SDK && \
     echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
     /sbin/ldconfig && \
-    rm -rf cross)
+    rm -rf cross; \
+fi
 
 # above is conditional; clean up unconditionally
 RUN rm -f cross.tar.gz && yum clean all -y

--- a/group.yml
+++ b/group.yml
@@ -202,7 +202,7 @@ repos:
     conf:
       extra_options:
         module_hotfixes: 1
-        includepkgs: module-build-macros delve golang* go-toolset* goversioninfo
+        includepkgs: module-build-macros golang* goversioninfo
       baseurl:
         aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
         ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/

--- a/group.yml
+++ b/group.yml
@@ -20,7 +20,7 @@ konflux:
       backend: rpm-lockfile-prototype
 
 base_image_release:
-  enabled: false
+  enabled: true
 
 branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 
@@ -223,10 +223,10 @@ repos:
         s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/baseos/os/
         x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/
     content_set:
-      default: rhel-8-for-x86_64-baseos-rpms__8
-      aarch64: rhel-8-for-aarch64-baseos-rpms__8
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms__8
-      s390x: rhel-8-for-s390x-baseos-rpms__8
+      default: rhel-8-for-x86_64-baseos-rpms
+      aarch64: rhel-8-for-aarch64-baseos-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms
+      s390x: rhel-8-for-s390x-baseos-rpms
     reposync:
       enabled: false
 
@@ -238,10 +238,10 @@ repos:
         s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/appstream/os/
         x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/
     content_set:
-      default: rhel-8-for-x86_64-appstream-rpms__8
-      aarch64: rhel-8-for-aarch64-appstream-rpms__8
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms__8
-      s390x: rhel-8-for-s390x-appstream-rpms__8
+      default: rhel-8-for-x86_64-appstream-rpms
+      aarch64: rhel-8-for-aarch64-appstream-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms
+      s390x: rhel-8-for-s390x-appstream-rpms
     reposync:
       enabled: false
 
@@ -253,10 +253,10 @@ repos:
         s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/codeready-builder/os/
         x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/codeready-builder/os/
     content_set:
-      default: codeready-builder-for-rhel-8-x86_64-rpms__8
-      aarch64: codeready-builder-for-rhel-8-aarch64-rpms__8
-      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms__8
-      s390x:   codeready-builder-for-rhel-8-s390x-rpms__8
+      default: codeready-builder-for-rhel-8-x86_64-rpms
+      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
+      s390x:   codeready-builder-for-rhel-8-s390x-rpms
     reposync:
       enabled: false
 

--- a/group.yml
+++ b/group.yml
@@ -215,13 +215,13 @@ repos:
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
       optional: true
 
-  rhel-8-baseos-rpms:
+  rhel-810-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/baseos/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/baseos/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/
     content_set:
       default: rhel-8-for-x86_64-baseos-rpms__8
       aarch64: rhel-8-for-aarch64-baseos-rpms__8
@@ -230,13 +230,13 @@ repos:
     reposync:
       enabled: false
 
-  rhel-8-appstream-rpms:
+  rhel-810-appstream-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/appstream/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/appstream/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/
     content_set:
       default: rhel-8-for-x86_64-appstream-rpms__8
       aarch64: rhel-8-for-aarch64-appstream-rpms__8
@@ -245,13 +245,13 @@ repos:
     reposync:
       enabled: false
 
-  rhel-8-codeready-builder-rpms:
+  rhel-810-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/codeready-builder/os/
-        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/codeready-builder/os/
-        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/ppc64le/codeready-builder/os/
+        s390x:   https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/s390x/codeready-builder/os/
+        x86_64:  https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/x86_64/codeready-builder/os/
     content_set:
       default: codeready-builder-for-rhel-8-x86_64-rpms__8
       aarch64: codeready-builder-for-rhel-8-aarch64-rpms__8

--- a/images/openshift-golang-builder-1-26.rhel8.yml
+++ b/images/openshift-golang-builder-1-26.rhel8.yml
@@ -22,10 +22,10 @@ targets:
 
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-8-baseos-rpms
+- rhel-810-baseos-rpms
 # for clang
-- rhel-8-appstream-rpms
-- rhel-8-codeready-builder-rpms
+- rhel-810-appstream-rpms
+- rhel-810-codeready-builder-rpms
 
 from:
   stream: rhel-810


### PR DESCRIPTION
## Summary
Migrate rhel-8-golang-1.26 variant files to the unified golang mono-branch.

## Changes
This PR adds the rhel8 golang 1-26 variant files to the golang mono-branch:
- `Dockerfiles/1-26.rhel8.Dockerfile`
- `images/openshift-golang-builder-1-26.rhel8.yml`
- Updates to `streams.yml` with rhel-8 stream definition

## Naming Convention
Following the pattern established in PR #10624:
- **Dockerfile:** `{go-version}.{rhel-version}.Dockerfile`
- **YAML:** `openshift-golang-builder-{go-version}.{rhel-version}.yml`
- **Stream keys:** Specific RHEL versions (e.g., `rhel-86`, `rhel-94`)

## Migration Context
Part of the effort to consolidate all rhel-{8,9}-golang-1.{19-26} branches into the unified golang mono-branch. This approach allows a single branch to serve all OCP versions through runtime variable injection by doozer.

🤖 Generated by Claude Code