### PR TITLE
ART-21084 [openshift-5.0]: enable OKD via group.yml okd.enabled

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -53,6 +53,7 @@ konflux:
   build_attempts: 1
 
 okd:
+  enabled: true
   branch: rhaos-{MAJOR}.{MINOR}-rhel-10
   konflux:
     build_priority: 8


### PR DESCRIPTION
## Summary
Add `okd.enabled: true` to group.yml so OKD build/scan enablement is declared in build-data.

## Problem
**Before:** OKD version enablement lived in art-tools constants and Jenkins lists with no per-version build-data flag.

**After:** openshift-5.0 declares OKD enabled via `group.yml`; art-tools and Jenkins align to this signal.

Related: [ART-21084](https://redhat.atlassian.net/browse/ART-21084)