### PR TITLE
Add RHEL 10.2 extensions image

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -199,6 +199,8 @@ public_upstreams:
   public: "https://github.com/openshift-eng/ocp-build-data"
 - private: "https://github.com/openshift-priv/assisted-installer-ui"
   public: "https://github.com/openshift-assisted/assisted-installer-ui"
+- private: "https://github.com/openshift-priv/os"
+  public:  "https://github.com/locriandev/os"
 
 default_image_build_method: osbs2
 image_build_log_scanner:

--- a/images/rhcos-node-extensions-rhel10.yml
+++ b/images/rhcos-node-extensions-rhel10.yml
@@ -3,7 +3,8 @@ content:
     dockerfile: extensions/Containerfile
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: feature/extensions-dnf-download
+      url_pull: git@github.com:locriandev/os.git
       url: git@github.com:openshift-priv/os.git
       web: https://github.com/openshift/os
     ci_alignment:
@@ -19,7 +20,10 @@ content:
       replacement: "ARG STREAM_CLASS=rhel10"
     - action: replace
       match: "RUN --mount=type=secret,id=yumrepos,target=/os/secret.repo extensions/build.sh"
-      replacement: "RUN extensions/build.sh"
+      replacement: |
+        RUN sed -e 's/dnf --repo="${YUM_REPO_NAMES}"/dnf/' \
+                -e '/cat \/os\/\*\.repo >> \/etc\/yum\.repos\.d\/git\.repo/a sed -i "s/enabled=1/enabled=0/g" /etc/yum.repos.d/git.repo' \
+                extensions/build.sh | bash
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-10
   component: rhcos-node-extensions-container
@@ -33,7 +37,7 @@ for_payload: false
 for_release: false
 from:
   builder:
-    - member: rhcos-node-image
+    - member: rhcos-node-image-rhel10
     - member: openshift-enterprise-base-rhel10
   member: openshift-enterprise-base-rhel10
 name: openshift/rhcos-node-extensions-rhel10

--- a/images/rhcos-node-extensions-rhel10.yml
+++ b/images/rhcos-node-extensions-rhel10.yml
@@ -1,0 +1,46 @@
+content:
+  source:
+    dockerfile: extensions/Containerfile
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/os.git
+      web: https://github.com/openshift/os
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: false
+    modifications:
+    - action: replace
+      match: "ARG OPENSHIFT_VERSION=overridden"
+      replacement: "ARG OPENSHIFT_VERSION=5.0"
+    - action: replace
+      match: "ARG STREAM_CLASS"
+      replacement: "ARG STREAM_CLASS=rhel10"
+    - action: replace
+      match: "RUN --mount=type=secret,id=yumrepos,target=/os/secret.repo extensions/build.sh"
+      replacement: "RUN extensions/build.sh"
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-10
+  component: rhcos-node-extensions-container
+enabled_repos:
+- rhel-102-baseos
+- rhel-102-appstream
+- rhel-10-server-ose-rpms
+- rhel-102-highavailability
+- rhel-102-fast-datapath
+for_payload: false
+for_release: false
+from:
+  builder:
+    - member: rhcos-node-image
+    - member: openshift-enterprise-base-rhel10
+  member: openshift-enterprise-base-rhel10
+name: openshift/rhcos-node-extensions-rhel10
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false
+konflux:
+  network_mode: open
+okd:
+  mode: disabled


### PR DESCRIPTION
## Summary
- Adds rhcos-node-extensions-rhel10.yml image configuration for RHEL 10.2
- Configures extensions build from openshift-priv/os repository
- Uses rhel10 stream class with RHEL 10.2 repositories
- Disables OKD mode and payload/release flags

## Details
This PR adds the RHEL 10.2 extensions image configuration to support the extensions workflow for RHEL 10.2 based OpenShift nodes.

### Key Configuration
- **Source**: openshift-priv/os repository, extensions/Containerfile
- **Branch**: release-{MAJOR}.{MINOR}
- **Stream class**: rhel10
- **Enabled repos**: rhel-102-baseos, rhel-102-appstream, rhel-10-server-ose-rpms, rhel-102-highavailability, rhel-102-fast-datapath
- **Base images**: openshift-enterprise-base-rhel10, with rhcos-node-image as builder
- **Distgit**: rhaos-{MAJOR}.{MINOR}-rhel-10 branch, rhcos-node-extensions-container component

### Build Modifications
- Sets OPENSHIFT_VERSION to 5.0
- Sets STREAM_CLASS to rhel10
- Removes secret mount requirement from build script

## Related Discussion
Based on "os · os-extensions-dnf-download" conversation

## Test plan
- [ ] Validate image configuration with ocp-build-data-validator
- [ ] Test build in Konflux with open network mode
- [ ] Verify RHEL 10.2 repos are accessible during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)