### PR TITLE
installer-ove-ui-4.22: ISO build fixes (d320 VM, agent-installer-utils main)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -22,6 +22,7 @@ konflux:
   - clair-scan
   build_step_resources:
     memory: "8Gi"
+    ephemeral-storage: "250Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
   - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.22.0-rc.0-x86_64"

--- a/group.yml
+++ b/group.yml
@@ -24,9 +24,9 @@ konflux:
     memory: "8Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
-  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.22.0-rc.0-x86_64"
+  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.22.9-x86_64"
   - "MAJOR_MINOR_VERSION=4.22"
-  - "PATCH_VERSION=0"
+  - "PATCH_VERSION=9"
   - "ARCH=x86_64"
 
 assemblies:

--- a/group.yml
+++ b/group.yml
@@ -22,7 +22,6 @@ konflux:
   - clair-scan
   build_step_resources:
     memory: "8Gi"
-    ephemeral-storage: "250Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
   - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.22.0-rc.0-x86_64"

--- a/images/art-agent-installer-iso.yml
+++ b/images/art-agent-installer-iso.yml
@@ -29,4 +29,4 @@ owners:
 konflux:
   no_shell: true  # Skip .oit injected RUN commands (e.g. yum repo setup) since this image does not use RPMs
   vm_override:
-    x86_64: "linux-root/amd64"
+    x86_64: "linux-d320-m8xlarge/amd64"

--- a/images/art-agent-installer-iso.yml
+++ b/images/art-agent-installer-iso.yml
@@ -4,8 +4,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        # Temporary: pick up AGENT-1536 (mtv-operator release-v2.12) until backported to release-4.22
-        target: main
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/agent-installer-utils.git
       web: https://github.com/openshift/agent-installer-utils
 distgit:

--- a/images/art-agent-installer-iso.yml
+++ b/images/art-agent-installer-iso.yml
@@ -4,7 +4,8 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        # Temporary: pick up AGENT-1536 (mtv-operator release-v2.12) until backported to release-4.22
+        target: main
       url: git@github.com:openshift-priv/agent-installer-utils.git
       web: https://github.com/openshift/agent-installer-utils
 distgit:


### PR DESCRIPTION
## Summary

WIP changes for onboarding `art-agent-installer-iso` on Konflux (`kflux-ocp-p01`) for installer-ove-ui 4.22 GA ([ART-14754](https://redhat.atlassian.net/browse/ART-14754)). For review / discussion — not ready to merge as-is.

- Switch MPC VM from `linux-root/amd64` to `linux-d320-m8xlarge/amd64` (d320 provides ~320GB disk for ISO assembly; `linux-root` hit ENOSPC writing `appliance.iso` on ART cluster)
- Build from `agent-installer-utils` `release-4.22` ([AGENT-1536](https://redhat.atlassian.net/browse/AGENT-1536) mtv-operator fix is on that branch)
- No `group.yml` changes vs base (`RELEASE_VALUE` unchanged)

## Context from failed builds

| Config | Result |
|--------|--------|
| `linux-root` (+/- 250Gi ephemeral) | ENOSPC during `live-iso` / `appliance.iso` |
| `linux-d320` + 250Gi ephemeral | Build OK (~58 GB), pipeline failed at `sbom-syft-generate` (doozer sets 1Gi on syft when build has ephemeral-storage) |
| `linux-d320` + no ephemeral | Successful Konflux build (Jun 2025 reference) |

## Files changed vs `installer-ove-ui-4.22`

- `images/art-agent-installer-iso.yml` — `vm_override` + git branch target

## Test plan

- [x] Layered-products build with GROUP=`installer-ove-ui-4.22`, ASSEMBLY=`test`, IMAGE_LIST=`art-agent-installer-iso` — [Jenkins #12833](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/12833/) (SUCCESS)
- [x] Verify build completes on d320 and syft/SBOM steps pass — [Jenkins #12833](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/12833/) (SUCCESS)