### PR TITLE
Add Go 1.26 builder stream for ACM 2.16

### DIFF
--- a/images/acm-cli.yml
+++ b/images/acm-cli.yml
@@ -32,7 +32,7 @@ enabled_repos:
 - rhel-9-appstream-rpms
 from:
   builder:
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang-1.26
     - stream: rhel-8-golang
   stream: rhel9
 name: rhacm2/acm-cli-rhel9

--- a/images/cert-policy-controller.yml
+++ b/images/cert-policy-controller.yml
@@ -20,7 +20,7 @@ enabled_repos:
 - rhel-9-appstream-rpms
 from:
   builder:
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang-1.26
   stream: rhel9
 name: rhacm2/cert-policy-controller-rhel9
 owners:

--- a/images/config-policy-controller.yml
+++ b/images/config-policy-controller.yml
@@ -17,7 +17,7 @@ dependents:
 - multiclusterhub-operator
 from:
   builder:
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang-1.26
   stream: rhel9
 name: rhacm2/config-policy-controller-rhel9
 owners:

--- a/images/governance-policy-addon-controller.yml
+++ b/images/governance-policy-addon-controller.yml
@@ -17,7 +17,7 @@ dependents:
 - multiclusterhub-operator
 from:
   builder:
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang-1.26
   stream: rhel9
 name: rhacm2/governance-policy-addon-controller-rhel9
 owners:

--- a/images/governance-policy-framework-addon.yml
+++ b/images/governance-policy-framework-addon.yml
@@ -17,7 +17,7 @@ dependents:
 - multiclusterhub-operator
 from:
   builder:
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang-1.26
   stream: rhel9
 name: rhacm2/governance-policy-framework-addon-rhel9
 owners:

--- a/images/governance-policy-propagator.yml
+++ b/images/governance-policy-propagator.yml
@@ -17,7 +17,7 @@ dependents:
 - multiclusterhub-operator
 from:
   builder:
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang-1.26
   stream: rhel9
 name: rhacm2/governance-policy-propagator-rhel9
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -4,6 +4,9 @@ rhel-9-golang:
     - rhel-9-golang-{GO_LATEST}
   image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9
 
+rhel-9-golang-1.26:
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9
+
 rhel-8-golang:
   image: registry.redhat.io/ubi8/go-toolset:1.25
 


### PR DESCRIPTION
Governance team repos and acm-cli have moved to Go 1.26, causing ART build failures. Add rhel-9-golang-1.26 stream entry and update affected image configs to use it.

Affected images:
- config-policy-controller
- governance-policy-propagator
- cert-policy-controller
- governance-policy-addon-controller
- governance-policy-framework-addon
- acm-cli