### PR TITLE
Disable reposync for embargoed repos (4.22)

### DIFF
--- a/repos/rhel-10-server-ose-rpms-embargoed.yml
+++ b/repos/rhel-10-server-ose-rpms-embargoed.yml
@@ -38,4 +38,6 @@
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-10
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-10
       type: brew
+  reposync:
+    enabled: false
   type: plashet

--- a/repos/rhel-8-server-ose-rpms-embargoed.yml
+++ b/repos/rhel-8-server-ose-rpms-embargoed.yml
@@ -38,4 +38,6 @@
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-8
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-8
       type: brew
+  reposync:
+    enabled: false
   type: plashet

--- a/repos/rhel-9-server-ose-rpms-embargoed.yml
+++ b/repos/rhel-9-server-ose-rpms-embargoed.yml
@@ -38,4 +38,6 @@
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-9
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-9
       type: brew
+  reposync:
+    enabled: false
   type: plashet


### PR DESCRIPTION
Target version: **4.22**

The embargoed plashet repos should not be reposynced. Add `reposync.enabled: false` to prevent them from being included in reposync operations.

This was already configured for branches 4.12–4.20 (in `group.yml`), but was missed when the repos moved to the `repos/` directory layout starting from 4.21.