### PR TITLE
[openshift-4.12] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -219,6 +219,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-8-baseos-rpms:
     conf:
@@ -277,6 +278,8 @@ repos:
       default: rhel-8-for-x86_64-rt-tus-rpms__8_DOT_6
       # don't have content set for other arches
       optional: true
+    reposync:
+      enabled: false
 
   rhel-8-appstream-rpms:
     conf:
@@ -324,7 +327,7 @@ repos:
       s390x: fast-datapath-for-rhel-8-s390x-rpms
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   openstack-16-for-rhel-8-rpms:
     conf:
@@ -345,7 +348,7 @@ repos:
       # don't have content set for aarch64 or s390x
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-baseos-rpms:
     conf:
@@ -493,6 +496,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-9-server-ironic-rpms:
     conf:
@@ -516,6 +520,7 @@ repos:
       optional: true  # [lmeyer] have not requested creation yet
     reposync:
       latest_only: false
+      enabled: true
 
 default_image_build_method: osbs2
 image_build_log_scanner:


### PR DESCRIPTION
Set `reposync: enabled` explicitly on all repos:
- `enabled: true` for ocp-artifacts repos (except embargoed)
- `enabled: false` for all other repos

This is enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099