### PR TITLE
[openshift-4.14] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -225,6 +225,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-8-baseos-rpms:
     conf:
@@ -312,7 +313,7 @@ repos:
       s390x: fast-datapath-for-rhel-8-s390x-rpms
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   openstack-16-for-rhel-8-rpms:
     conf:
@@ -333,7 +334,7 @@ repos:
       # don't have content set for aarch64 or s390x
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-baseos-rpms:
     conf:
@@ -440,6 +441,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-94-baseos-rpms:
     conf:
@@ -528,6 +530,7 @@ repos:
       optional: true  # [lmeyer] have not requested creation yet
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-9-fast-datapath-rpms:
     conf:
@@ -548,7 +551,7 @@ repos:
       s390x: fast-datapath-for-rhel-9-s390x-rpms
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-rt-rpms:
     conf:


### PR DESCRIPTION
Set `reposync: enabled` explicitly on all repos:
- `enabled: true` for ocp-artifacts repos (except embargoed)
- `enabled: false` for all other repos

This is enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099