### PR TITLE
[openshift-4.17] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -231,6 +231,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-8-baseos-rpms:
     conf:
@@ -338,7 +339,7 @@ repos:
       s390x: fast-datapath-for-rhel-8-s390x-rpms
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   openstack-16-for-rhel-8-rpms:
     conf:
@@ -359,7 +360,7 @@ repos:
       # don't have content set for aarch64 or s390x
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   openstack-17-for-rhel-9-rpms:
     conf:
@@ -466,6 +467,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-9-server-ironic-rpms:
     conf:
@@ -489,6 +491,7 @@ repos:
       optional: true  # [lmeyer] have not requested creation yet
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-9-fast-datapath-rpms:
     conf:
@@ -509,7 +512,7 @@ repos:
       s390x: fast-datapath-for-rhel-9-s390x-rpms
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-rt-rpms:
     conf:


### PR DESCRIPTION
Set `reposync: enabled` explicitly on all repos:
- `enabled: true` for ocp-artifacts repos (except embargoed)
- `enabled: false` for all other repos

This is enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099