### PR TITLE
[openshift-4.18] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -233,6 +233,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-8-baseos-rpms:
     conf:
@@ -320,7 +321,7 @@ repos:
       s390x: fast-datapath-for-rhel-8-s390x-rpms
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   openstack-17-for-rhel-9-rpms:
     conf:
@@ -427,6 +428,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-9-server-ironic-rpms:
     conf:
@@ -450,6 +452,7 @@ repos:
       optional: true  # [lmeyer] have not requested creation yet
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-9-fast-datapath-rpms:
     conf:
@@ -470,7 +473,7 @@ repos:
       s390x: fast-datapath-for-rhel-9-s390x-rpms
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-rt-rpms:
     conf:
@@ -510,7 +513,7 @@ repos:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
       aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
     reposync:
-      enabled: false
+      enabled: true
 
 default_image_build_method: osbs2
 image_build_log_scanner:


### PR DESCRIPTION
Set `reposync: enabled` explicitly on all repos:
- `enabled: true` for ocp-artifacts repos (except embargoed)
- `enabled: false` for all other repos

This is enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099