### PR TITLE
[openshift-4.19] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -224,6 +224,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-8-baseos-rpms:
     conf:
@@ -311,7 +312,7 @@ repos:
       s390x: fast-datapath-for-rhel-8-s390x-rpms
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   openstack-17-for-rhel-9-rpms:
     conf:
@@ -418,6 +419,7 @@ repos:
       optional: true
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-9-server-ironic-rpms:
     conf:
@@ -441,6 +443,7 @@ repos:
       optional: true  # [lmeyer] have not requested creation yet
     reposync:
       latest_only: false
+      enabled: true
 
   rhel-9-fast-datapath-rpms:
     conf:
@@ -461,7 +464,7 @@ repos:
       s390x: fast-datapath-for-rhel-9-s390x-rpms
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-rt-rpms:
     conf:
@@ -501,7 +504,7 @@ repos:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
       aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
     reposync:
-      enabled: false
+      enabled: true
 
   rhel-96-baseos:
     conf:
@@ -518,7 +521,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_6
       s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_6
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-96-appstream:
     conf:
@@ -535,7 +538,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_6
       s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-96-nfv:
     conf:
@@ -550,7 +553,7 @@ repos:
     content_set:
       default: rhel-9-for-x86_64-nfv-e4s-rpms__9_DOT_6
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-96-highavailability:
     conf:
@@ -567,7 +570,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-highavailability-e4s-rpms__9_DOT_6
       s390x: rhel-9-for-s390x-highavailability-e4s-rpms__9_DOT_6
     reposync:
-      enabled: true
+      enabled: false
   rhel-100-baseos:
     conf:
       baseurl:
@@ -580,7 +583,7 @@ repos:
     content_set:
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-100-appstream:
     conf:
@@ -594,7 +597,7 @@ repos:
     content_set:
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-100-nfv:
     conf:
@@ -609,7 +612,7 @@ repos:
     content_set:
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-100-highavailability:
     conf:
@@ -623,7 +626,7 @@ repos:
     content_set:
       optional: true
     reposync:
-      enabled: true
+      enabled: false
 
 default_image_build_method: osbs2
 image_build_log_scanner:


### PR DESCRIPTION
Set `reposync: enabled` explicitly on all repos:
- `enabled: true` for ocp-artifacts repos (except embargoed)
- `enabled: false` for all other repos

This is enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099