### PR TITLE
[openshift-4.21] Set reposync: enabled on all repos

### DIFF
--- a/repos/openstack-17-for-rhel-9-rpms.yml
+++ b/repos/openstack-17-for-rhel-9-rpms.yml
@@ -13,4 +13,6 @@
     default: openstack-17.1-for-rhel-9-x86_64-rpms
     optional: true
   name: openstack-17-for-rhel-9-rpms
+  reposync:
+    enabled: false
   type: external

--- a/repos/rhel-10-server-ose-rpms.yml
+++ b/repos/rhel-10-server-ose-rpms.yml
@@ -40,4 +40,5 @@
       type: brew
   reposync:
     latest_only: false
+    enabled: false
   type: plashet

--- a/repos/rhel-101-appstream.yml
+++ b/repos/rhel-101-appstream.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-appstream
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-101-baseos.yml
+++ b/repos/rhel-101-baseos.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-baseos
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-101-fast-datapath.yml
+++ b/repos/rhel-101-fast-datapath.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-fast-datapath
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-101-highavailability.yml
+++ b/repos/rhel-101-highavailability.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-highavailability
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-101-nfv.yml
+++ b/repos/rhel-101-nfv.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-nfv
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-8-appstream-rpms.yml
+++ b/repos/rhel-8-appstream-rpms.yml
@@ -17,4 +17,6 @@
     ppc64le: rhel-8-for-ppc64le-appstream-rpms__8
     s390x: rhel-8-for-s390x-appstream-rpms__8
   name: rhel-8-appstream-rpms
+  reposync:
+    enabled: false
   type: external

--- a/repos/rhel-8-baseos-rpms.yml
+++ b/repos/rhel-8-baseos-rpms.yml
@@ -15,4 +15,6 @@
     ppc64le: rhel-8-for-ppc64le-baseos-rpms__8
     s390x: rhel-8-for-s390x-baseos-rpms__8
   name: rhel-8-baseos-rpms
+  reposync:
+    enabled: false
   type: external

--- a/repos/rhel-8-fast-datapath-rpms.yml
+++ b/repos/rhel-8-fast-datapath-rpms.yml
@@ -17,5 +17,5 @@
     s390x: fast-datapath-for-rhel-8-s390x-rpms
   name: rhel-8-fast-datapath-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-8-server-ose-rpms.yml
+++ b/repos/rhel-8-server-ose-rpms.yml
@@ -40,4 +40,5 @@
       type: brew
   reposync:
     latest_only: false
+    enabled: false
   type: plashet

--- a/repos/rhel-9-appstream-rpms.yml
+++ b/repos/rhel-9-appstream-rpms.yml
@@ -18,5 +18,5 @@
     s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
   name: rhel-9-appstream-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-baseos-rpms.yml
+++ b/repos/rhel-9-baseos-rpms.yml
@@ -18,5 +18,5 @@
     s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_6
   name: rhel-9-baseos-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-codeready-builder-rpms.yml
+++ b/repos/rhel-9-codeready-builder-rpms.yml
@@ -15,4 +15,6 @@
     ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_6
     s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_6
   name: rhel-9-codeready-builder-rpms
+  reposync:
+    enabled: false
   type: external

--- a/repos/rhel-9-fast-datapath-rpms.yml
+++ b/repos/rhel-9-fast-datapath-rpms.yml
@@ -17,5 +17,5 @@
     s390x: fast-datapath-for-rhel-9-s390x-rpms
   name: rhel-9-fast-datapath-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-highavailability-rpms.yml
+++ b/repos/rhel-9-highavailability-rpms.yml
@@ -18,5 +18,5 @@
     s390x: rhel-9-for-s390x-highavailability-e4s-rpms__9_DOT_6
   name: rhel-9-highavailability-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-nfv-rpms.yml
+++ b/repos/rhel-9-nfv-rpms.yml
@@ -15,5 +15,5 @@
     default: rhel-9-for-x86_64-nfv-e4s-rpms__9_DOT_6
   name: rhel-9-nfv-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-9-rt-rpms.yml
+++ b/repos/rhel-9-rt-rpms.yml
@@ -10,4 +10,6 @@
     default: rhel-9-for-x86_64-rt-e4s-rpms__9_DOT_4
     optional: true
   name: rhel-9-rt-rpms
+  reposync:
+    enabled: false
   type: external

--- a/repos/rhel-9-server-ironic-rpms.yml
+++ b/repos/rhel-9-server-ironic-rpms.yml
@@ -31,4 +31,5 @@
       type: brew
   reposync:
     latest_only: false
+    enabled: false
   type: plashet

--- a/repos/rhel-9-server-microshift-rpms.yml
+++ b/repos/rhel-9-server-microshift-rpms.yml
@@ -22,4 +22,6 @@
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-9
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-9
       type: brew
+  reposync:
+    enabled: false
   type: plashet

--- a/repos/rhel-9-server-ose-rpms.yml
+++ b/repos/rhel-9-server-ose-rpms.yml
@@ -40,4 +40,5 @@
       type: brew
   reposync:
     latest_only: false
+    enabled: false
   type: plashet


### PR DESCRIPTION
Set `reposync: enabled` explicitly on all repos:
- `enabled: true` for ocp-artifacts repos (except embargoed)
- `enabled: false` for all other repos

This is enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099