### PR TITLE
[openshift-4.23] Set reposync: enabled on all repos

### DIFF
--- a/repos/openstack-17-for-rhel-9-rpms.yml
+++ b/repos/openstack-17-for-rhel-9-rpms.yml
@@ -13,4 +13,6 @@
     default: openstack-17.1-for-rhel-9-x86_64-rpms
     optional: true
   name: openstack-17-for-rhel-9-rpms
+  reposync:
+    enabled: false
   type: external

--- a/repos/rhel-10-server-ose-rpms.yml
+++ b/repos/rhel-10-server-ose-rpms.yml
@@ -40,4 +40,5 @@
       type: brew
   reposync:
     latest_only: false
+    enabled: false
   type: plashet

--- a/repos/rhel-101-appstream.yml
+++ b/repos/rhel-101-appstream.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-appstream
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-101-baseos.yml
+++ b/repos/rhel-101-baseos.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-baseos
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-101-fast-datapath.yml
+++ b/repos/rhel-101-fast-datapath.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-fast-datapath
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-101-highavailability.yml
+++ b/repos/rhel-101-highavailability.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-highavailability
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-101-nfv.yml
+++ b/repos/rhel-101-nfv.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-101-nfv
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-102-fast-datapath.yml
+++ b/repos/rhel-102-fast-datapath.yml
@@ -10,5 +10,5 @@
     optional: true
   name: rhel-102-fast-datapath
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-8-appstream-rpms.yml
+++ b/repos/rhel-8-appstream-rpms.yml
@@ -17,4 +17,6 @@
     ppc64le: rhel-8-for-ppc64le-appstream-rpms__8
     s390x: rhel-8-for-s390x-appstream-rpms__8
   name: rhel-8-appstream-rpms
+  reposync:
+    enabled: false
   type: external

--- a/repos/rhel-8-baseos-rpms.yml
+++ b/repos/rhel-8-baseos-rpms.yml
@@ -15,4 +15,6 @@
     ppc64le: rhel-8-for-ppc64le-baseos-rpms__8
     s390x: rhel-8-for-s390x-baseos-rpms__8
   name: rhel-8-baseos-rpms
+  reposync:
+    enabled: false
   type: external

--- a/repos/rhel-8-fast-datapath-rpms.yml
+++ b/repos/rhel-8-fast-datapath-rpms.yml
@@ -17,5 +17,5 @@
     s390x: fast-datapath-for-rhel-8-s390x-rpms
   name: rhel-8-fast-datapath-rpms
   reposync:
-    enabled: true
+    enabled: false
   type: external

--- a/repos/rhel-8-server-ose-rpms.yml
+++ b/repos/rhel-8-server-ose-rpms.yml
@@ -40,4 +40,5 @@
       type: brew
   reposync:
     latest_only: false
+    enabled: false
   type: plashet

--- a/repos/rhel-9-server-ironic-rpms.yml
+++ b/repos/rhel-9-server-ironic-rpms.yml
@@ -31,4 +31,5 @@
       type: brew
   reposync:
     latest_only: false
+    enabled: false
   type: plashet

--- a/repos/rhel-9-server-microshift-rpms.yml
+++ b/repos/rhel-9-server-microshift-rpms.yml
@@ -22,4 +22,6 @@
         product_version: OSE-{MAJOR}.{MINOR}-RHEL-9
         release_tag: rhaos-{MAJOR}.{MINOR}-rhel-9
       type: brew
+  reposync:
+    enabled: false
   type: plashet

--- a/repos/rhel-9-server-ose-rpms.yml
+++ b/repos/rhel-9-server-ose-rpms.yml
@@ -40,4 +40,5 @@
       type: brew
   reposync:
     latest_only: false
+    enabled: false
   type: plashet


### PR DESCRIPTION
Set `reposync: enabled` explicitly on all repos:
- `enabled: true` for ocp-artifacts repos (except embargoed)
- `enabled: false` for all other repos

This is enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099