### PR TITLE
[rhel-10-golang-1.24] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -53,6 +53,8 @@ repos:
       ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-10-ppc64le-rpms
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-10-s390x-rpms
       optional: true
+    reposync:
+      enabled: false
 
   rhel-10-baseos-rpms:
     conf:


### PR DESCRIPTION
Set `reposync: enabled: false` on all repos.

Enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099