### PR TITLE
[rhel-8-golang-1.13] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -35,3 +35,5 @@ repos:
       ppc64le: rhocp-4.4-for-rhel-8-ppc64le-rpms
       s390x: rhocp-4.4-for-rhel-8-s390x-rpms
       optional: true
+    reposync:
+      enabled: false


### PR DESCRIPTION
Set `reposync: enabled: false` on all repos.

Enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099