### PR TITLE
[rhel-8-golang-1.16] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -50,6 +50,8 @@ repos:
       ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
       optional: true
+    reposync:
+      enabled: false
 
   rhel-8-newer-golang-rpms:
     conf:
@@ -71,6 +73,8 @@ repos:
       ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
       optional: true
+    reposync:
+      enabled: false
 
   rhel-8-appstream-rpms:
     conf:


### PR DESCRIPTION
Set `reposync: enabled: false` on all repos.

Enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099