### PR TITLE
[rhel-8-golang-1.23] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -59,6 +59,8 @@ repos:
       ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
       optional: true
+    reposync:
+      enabled: false
 
   rhel-8-baseos-rpms:
     conf:


### PR DESCRIPTION
Set `reposync: enabled: false` on all repos.

Enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099