### PR TITLE
[rhel-9-golang-1.18] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -35,6 +35,8 @@ repos:
       # These content sets are not used, so just putting something here
       default: bogus
       optional: true
+    reposync:
+      enabled: false
 
   rhel-9-appstream-rpms:
     # need for mingw64
@@ -50,3 +52,5 @@ repos:
       aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_0
       ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_0
       s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_0
+    reposync:
+      enabled: false


### PR DESCRIPTION
Set `reposync: enabled: false` on all repos.

Enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099