### PR TITLE
[rhel-9-golang-1.19] Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -58,6 +58,8 @@ repos:
       ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
       optional: true
+    reposync:
+      enabled: false
 
   rhel-9-baseos-rpms:
     conf:


### PR DESCRIPTION
Set `reposync: enabled: false` on all repos.

Enforced by the validator as of https://github.com/openshift-eng/art-tools/pull/3099