### PR TITLE
golang-1.11: Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -31,6 +31,8 @@ repos:
       default: rhel-7-server-rpms
       ppc64le: rhel-7-for-power-le-rpms
       s390x: rhel-7-for-system-z-rpms
+    reposync:
+      enabled: false
   rhel-server-ose-build-rpms:
     conf:
       baseurl:
@@ -42,3 +44,5 @@ repos:
       ppc64le: rhel-7-for-power-le-ose-4.3-rpms
       s390x: rhel-7-for-system-z-ose-4.3-rpms
       optional: true
+    reposync:
+      enabled: false


### PR DESCRIPTION
Set `reposync: enabled: <bool>` on all repos.

Rules:
- `ocp-artifacts` hosted repos (non-embargoed): `enabled: true`
- Embargoed repos: `enabled: false`
- All other repos: `enabled: false`