### PR TITLE
golang-1.19: Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -34,6 +34,8 @@ repos:
       default: rhel-7-server-rpms
       ppc64le: rhel-7-for-power-le-rpms
       s390x: rhel-7-for-system-z-rpms
+    reposync:
+      enabled: false
   rhel-server-ose-build-rpms:
     conf:
       baseurl:
@@ -45,3 +47,5 @@ repos:
       ppc64le: rhel-7-for-power-le-ose-{MAJOR}.{MINOR}-rpms
       s390x: rhel-7-for-system-z-ose-{MAJOR}.{MINOR}-rpms
       optional: true
+    reposync:
+      enabled: false


### PR DESCRIPTION
Set `reposync: enabled: <bool>` on all repos.

Rules:
- `ocp-artifacts` hosted repos (non-embargoed): `enabled: true`
- Embargoed repos: `enabled: false`
- All other repos: `enabled: false`