### PR TITLE
logging-6.3: Set reposync: enabled on all repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -100,7 +100,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_6
       s390x: rhel-9-for-s390x-baseos-eus-rpms__9_DOT_6
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-96-baseos-source:
     conf:
@@ -117,7 +117,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-baseos-source-eus-rpms__9_DOT_6
       s390x: rhel-9-for-s390x-baseos-source-eus-rpms__9_DOT_6
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-appstream-rpms:
     conf:
@@ -149,7 +149,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_6
       s390x: rhel-9-for-s390x-appstream-eus-rpms__9_DOT_6
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-96-appstream-source:
     conf:
@@ -166,7 +166,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-appstream-source-eus-rpms__9_DOT_6
       s390x: rhel-9-for-s390x-appstream-source-eus-rpms__9_DOT_6
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-96-appstream-debug:
     conf:
@@ -183,7 +183,7 @@ repos:
       ppc64le: rhel-9-for-ppc64le-appstream-debug-eus-rpms__9_DOT_6
       s390x: rhel-9-for-s390x-appstream-debug-eus-rpms__9_DOT_6
     reposync:
-      enabled: true
+      enabled: false
 
   rhel-9-codeready-builder-rpms:
     conf:


### PR DESCRIPTION
Set `reposync: enabled: <bool>` on all repos.

Rules:
- `ocp-artifacts` hosted repos (non-embargoed): `enabled: true`
- Embargoed repos: `enabled: false`
- All other repos: `enabled: false`