### PR TITLE
[ART-21271] Remove vestigial yarn tarball download (4.21)

### DIFF
--- a/images/agent-installer-ui.yml
+++ b/images/agent-installer-ui.yml
@@ -20,11 +20,6 @@ content:
       replacement: node .yarn/releases/yarn-3.4.1.cjs build:all;
     pkg_managers:
     - yarn
-    artifacts:
-      from_urls:
-      - target: 3.4.1.tar.gz
-        url: https://ocp-artifacts.engineering.redhat.com/github/yarnpkg/berry/archive/refs/tags/@yarnpkg/cli/3.4.1.tar.gz
-        sha256: d77eb555be73c3fc30b35b1a37fb85c098bac612e9239812708007d452b05731
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
## Summary

Remove the unused `artifacts.from_urls` yarn berry tarball download from `agent-installer-ui`. ART modifications already bypass it and call vendored `.yarn/releases/yarn-3.4.1.cjs` directly — the downloaded tarball is never used at build time.

## Test

- Jenkins build [#38999](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/38999/) — SUCCESS
- Konflux build PLR: [ose-4-21-agent-installer-ui-nl7cr](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-21/pipelineruns/ose-4-21-agent-installer-ui-nl7cr) — Succeeded
- Konflux EC PLR: [openshift-4-21-ec-ose-4-21-agent-installer-ui-pmdkp](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-21/pipelineruns/openshift-4-21-ec-ose-4-21-agent-installer-ui-pmdkp) — Succeeded

[ART-21271](https://redhat.atlassian.net/browse/ART-21271)