### PR TITLE
[ART-21271] Remove vestigial yarn tarball download (5.0)

### DIFF
--- a/images/agent-installer-ui.yml
+++ b/images/agent-installer-ui.yml
@@ -20,11 +20,6 @@ content:
       replacement: node .yarn/releases/yarn-3.8.7.cjs build:all;
     pkg_managers:
     - yarn
-    artifacts:
-      from_urls:
-      - target: 3.8.7.tar.gz
-        url: https://ocp-artifacts.engineering.redhat.com/github/yarnpkg/berry/archive/refs/tags/@yarnpkg/cli/3.8.7.tar.gz
-        sha256: 589c2940e999efb2dd32a26ff5342e255295ade01bbd3395c8d4024a2546bf58
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
## Summary

Remove the unused `artifacts.from_urls` yarn berry tarball download from `agent-installer-ui`. ART modifications already bypass it and call vendored `.yarn/releases/yarn-3.8.7.cjs` directly — the downloaded tarball is never used at build time.

## Test

- Jenkins build [#39002](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/39002/) — SUCCESS
- Konflux build PLR: [ose-5-0-agent-installer-ui-k6f65](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/ose-5-0-agent-installer-ui-k6f65) — Succeeded
- Konflux EC PLR: [openshift-5-0-ec-ose-5-0-agent-installer-ui-q9wsn](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/openshift-5-0-ec-ose-5-0-agent-installer-ui-q9wsn) — Succeeded

[ART-21271](https://redhat.atlassian.net/browse/ART-21271)