### PR TITLE
Add valid-subscription-label to multiclusterhub-operator

### DIFF
--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -29,6 +29,7 @@ update-csv:
   bundle-dir: manifests
   registry: image-registry.openshift-image-registry.svc:5000
   registry-target-namespace: open-cluster-management
+  valid-subscription-label: '["OpenShift Platform Plus", "Red Hat Advanced Cluster Management for Kubernetes"]'
 owners:
 - acm-cicd@redhat.com
 jira:


### PR DESCRIPTION
Bundle build fails without this field in update-csv.