### PR TITLE
start building oadp-1.3.10

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,7 +1,7 @@
 name: oadp-1.3
 csv_namespace: oadp
 product: oadp
-version: 1.3.9
+version: 1.3.10
 
 vars:
   # The go versions used by the various CI builder images.
@@ -13,8 +13,8 @@ vars:
   #               aliases:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
-  GO_LATEST: "1.25"
-  GO_EXTRA: "1.25"  # There is no extra version at this time, so just duplicate latest.
+  GO_LATEST: "1.26"
+  GO_EXTRA: "1.26"  # There is no extra version at this time, so just duplicate latest.
   MAJOR: 4
   MINOR: 12
 

--- a/streams.yml
+++ b/streams.yml
@@ -1,11 +1,11 @@
 ---
 ose-cli:
-  image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.19
+  image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21
 
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604150744.p2.gf28329a.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9
 
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163


### PR DESCRIPTION
Can reduce the ocp platforms to just ocp 4.14?
https://github.com/openshift-eng/ocp-build-data/blob/oadp-1.3/group.yml#L47-L52

@rayfordj ^