### PR TITLE
Add dependents: [backplane-operator] to all MCE 2.11 operand images

### DIFF
--- a/images/addon-manager.yml
+++ b/images/addon-manager.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/addon-manager-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/azure-service-operator.yml
+++ b/images/azure-service-operator.yml
@@ -27,6 +27,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/azure-service-operator-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/backplane-must-gather.yml
+++ b/images/backplane-must-gather.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/backplane-must-gather-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -12,6 +12,7 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/backplane-operator-rhel9
+  bundle_delivery_repo_name: multicluster-engine/mce-operator-bundle
 for_payload: false
 enabled_repos:
 - rhel-9-baseos-rpms
@@ -22,6 +23,12 @@ from:
     - stream: rhel-9-golang
   stream: rhel9
 name: multicluster-engine/backplane-operator-rhel9
+update-csv:
+  name: multicluster-engine
+  manifests-dir: bundle
+  bundle-dir: manifests
+  registry: image-registry.openshift-image-registry.svc:5000
+  registry-target-namespace: multicluster-engine
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/capoa-bootstrap.yml
+++ b/images/capoa-bootstrap.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/capoa-bootstrap-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang-1.25

--- a/images/capoa-control-plane.yml
+++ b/images/capoa-control-plane.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/capoa-control-plane-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang-1.25

--- a/images/cluster-api-provider-agent.yml
+++ b/images/cluster-api-provider-agent.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-provider-agent-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang-1.25

--- a/images/cluster-api-provider-aws.yml
+++ b/images/cluster-api-provider-aws.yml
@@ -20,6 +20,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-provider-aws-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-api-provider-azure.yml
+++ b/images/cluster-api-provider-azure.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-provider-azure-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/cluster-api-provider-kubevirt.yml
+++ b/images/cluster-api-provider-kubevirt.yml
@@ -20,6 +20,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-provider-kubevirt-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-api-webhook-config.yml
+++ b/images/cluster-api-webhook-config.yml
@@ -19,6 +19,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-webhook-config-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/cluster-curator-controller.yml
+++ b/images/cluster-curator-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-curator-controller-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/cluster-image-set-controller.yml
+++ b/images/cluster-image-set-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-image-set-controller-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/cluster-proxy.yml
+++ b/images/cluster-proxy.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-proxy-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/clusterclaims-controller.yml
+++ b/images/clusterclaims-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/clusterclaims-controller-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/clusterlifecycle-state-metrics.yml
+++ b/images/clusterlifecycle-state-metrics.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/clusterlifecycle-state-metrics-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/console-mce.yml
+++ b/images/console-mce.yml
@@ -20,6 +20,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/console-mce-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-nodejs-24

--- a/images/discovery-operator.yml
+++ b/images/discovery-operator.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/discovery-operator-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/hive.yml
+++ b/images/hive.yml
@@ -22,6 +22,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/hive-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/hypershift-addon-operator.yml
+++ b/images/hypershift-addon-operator.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/hypershift-addon-operator-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/hypershift-cli.yml
+++ b/images/hypershift-cli.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/hypershift-cli-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang-1.25

--- a/images/hypershift-release.yml
+++ b/images/hypershift-release.yml
@@ -17,6 +17,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/hypershift-release-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang-1.25

--- a/images/image-based-install-operator.yml
+++ b/images/image-based-install-operator.yml
@@ -18,6 +18,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/image-based-install-operator-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/kube-rbac-proxy-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/managed-serviceaccount.yml
+++ b/images/managed-serviceaccount.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/managed-serviceaccount-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/managedcluster-import-controller-addon.yml
+++ b/images/managedcluster-import-controller-addon.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/managedcluster-import-controller-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/multicloud-manager.yml
+++ b/images/multicloud-manager.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/multicloud-manager-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/placement.yml
+++ b/images/placement.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/placement-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/provider-credential-controller.yml
+++ b/images/provider-credential-controller.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/provider-credential-controller-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/registration-operator.yml
+++ b/images/registration-operator.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/registration-operator-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/registration.yml
+++ b/images/registration.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/registration-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/work.yml
+++ b/images/work.yml
@@ -13,6 +13,8 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/work-rhel9
 for_payload: false
+dependents:
+- backplane-operator
 from:
   builder:
     - stream: rhel-9-golang


### PR DESCRIPTION
## Summary

Add `dependents: [backplane-operator]` to all 31 MCE 2.11 operand image configs. This ensures ART automatically rebuilds the MCE operator bundle whenever any operand image is updated, so the bundle always contains the latest SHA digests.

Follows the same pattern as ACM 2.16 (PR #11092).

## Changed files (31)

All image configs under `images/` except `backplane-operator.yml` (the bundle operator itself):

addon-manager, azure-service-operator, backplane-must-gather, capoa-bootstrap, capoa-control-plane, cluster-api-provider-agent, cluster-api-provider-aws, cluster-api-provider-azure, cluster-api-provider-kubevirt, cluster-api-webhook-config, cluster-curator-controller, cluster-image-set-controller, cluster-proxy, clusterclaims-controller, clusterlifecycle-state-metrics, console-mce, discovery-operator, hive, hypershift-addon-operator, hypershift-cli, hypershift-release, image-based-install-operator, kube-rbac-proxy, managed-serviceaccount, managedcluster-import-controller-addon, multicloud-manager, placement, provider-credential-controller, registration-operator, registration, work

Ref: [HYPBLD-854](https://redhat.atlassian.net/browse/HYPBLD-854)

Made with [Cursor](https://cursor.com)