### PR TITLE
[openshift-4.16] Temporarily freeze automation to prevent mass rebuild loops

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,7 +4,7 @@
 #   - weekdays: always allow manual builds; forbid scheduled builds from Monday to Friday
 #   - no|false: always allow builds
 # Note that ocp4 builds are always permitted  for non-stream assemblies
-freeze_automation: false
+freeze_automation: true
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
Freeze automation to prevent mass rebuilds loops. openssl-fips-provider-so subpackage is missing in 9.4 repos causing openshift-base-rhel9 build failures and mass rebuild loops.

https://redhat.atlassian.net/browse/RHEL-188430

Error:
```
Problem: cannot install the best update candidate for package openssl-fips-provider-3.0.7-2.el9.ppc64le
  - nothing provides openssl-fips-provider-so = 3.0.7-11.el9_0 needed by openssl-fips-provider-3.0.7-11.el9_0.ppc64le from rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_4
```