### PR TITLE
Drop -rhel9 suffix from multiclusterhub-operator name

### DIFF
--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -11,7 +11,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/multiclusterhub-operator
+  - rhacm2/multiclusterhub-operator-rhel9
   bundle_delivery_repo_name: rhacm2/acm-operator-bundle
 for_payload: false
 enabled_repos:

--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -11,7 +11,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/multiclusterhub-operator-rhel9
+  - rhacm2/multiclusterhub-operator
   bundle_delivery_repo_name: rhacm2/acm-operator-bundle
 for_payload: false
 enabled_repos:
@@ -22,7 +22,7 @@ from:
     - stream: rhel9
     - stream: rhel-9-golang
   stream: rhel9
-name: rhacm2/multiclusterhub-operator-rhel9
+name: rhacm2/multiclusterhub-operator
 update-csv:
   name: advanced-cluster-management
   manifests-dir: bundle


### PR DESCRIPTION
The CSV uses multiclusterhub-operator:latest (without -rhel9) because ACM's own bundle generation pipeline requires that name. The Konflux bundler constructs pullspecs directly from the CSV image name, so the ocp-build-data name field needs to match.