### PR TITLE
karpenter-operator: Add mr_approvers:

### DIFF
--- a/images/karpenter-operator.yml
+++ b/images/karpenter-operator.yml
@@ -29,3 +29,8 @@ owners:
 - jkyros@redhat.com
 - joelsmith@redhat.com
 - mimccune@redhat.com
+# Shipment MR approvers for out-of-cadence on-demand pre-GA releases
+mr_approvers:
+  QE:
+    - jkyros
+    - macao


### PR DESCRIPTION
Placeholder; to be updated by image owners.  For now, we just need _something_ valid for testing art-tools & automation to support the release-from-fbc ocp-optional release process.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED