### PR TITLE
Update mtv-integrations builder to Go 1.26 for ACM 2.16

### DIFF
--- a/images/mtv-integrations.yml
+++ b/images/mtv-integrations.yml
@@ -17,7 +17,7 @@ dependents:
 - multiclusterhub-operator
 from:
   builder:
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang-1.26
   stream: rhel9
 name: rhacm2/mtv-integrations-rhel9
 owners:


### PR DESCRIPTION
## Summary
- Updates `mtv-integrations` builder stream from `rhel-9-golang` (1.25) to `rhel-9-golang-1.26`
- Upstream `Dockerfile.rhtap` on `release-2.16` uses `openshift-golang-builder:rhel_9_1.26`

## Test plan
- [ ] ART build picks up the updated builder stream