### PR TITLE
Test: Point multiclusterhub-operator to fork with image-references fix

### DIFF
--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -5,6 +5,7 @@ content:
       branch:
         target: release-2.16
       url: git@github.com:openshift-priv/stolostron-multiclusterhub-operator.git
+      url_pull: https://github.com/ashwindasr/multiclusterhub-operator.git
       web: https://github.com/stolostron/multiclusterhub-operator
 distgit:
   component: acm-multiclusterhub-operator-container


### PR DESCRIPTION
## Summary

- Temporarily adds `url_pull` to `multiclusterhub-operator.yml` pointing to `ashwindasr/multiclusterhub-operator` fork which includes the operator self-reference in `bundle/image-references`.

## Purpose

This is a **test PR** to verify the Konflux bundle build fix before the upstream PR merges.

The root cause of the bundle build failure (`olm_bundle_konflux #25499`) is that `multiclusterhub-operator` is missing from `bundle/image-references` in the upstream repo. Without it, the ART rebaser does not replace the operator's `:latest` self-reference in the CSV, and the bundler fails trying to look up `multiclusterhub-operator-latest` in Quay.

## Related PRs

- stolostron/multiclusterhub-operator#4321 - Adds operator to image-references (upstream fix)
- openshift-eng/ocp-build-data#11536 - Drops `-rhel9` suffix from operator name

## Revert

This PR should be reverted (or the `url_pull` line removed) once the upstream PR merges and syncs to `openshift-priv`.

Made with [Cursor](https://cursor.com)