### PR TITLE
ART-21334: exclude broken openssl-fips-provider from yum update (arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN if [ -x /usr/bin/microdnf ]; then \
     fi
 
 RUN echo 'skip_missing_names_on_install=0' >> /etc/yum.conf \
- && yum update -y  \
+ && yum update -y --nobest --exclude=openssl-fips-provider \
  && yum clean all
 
 # EUS / ELS images do not have repositories configured, and anyway they would


### PR DESCRIPTION
The rhel-9-for-aarch64-baseos-e4s-rpms (9.4) repo pushed openssl-fips-provider-3.0.7-11.el9_0 which requires a virtual provide (`openssl-fips-provider-so`) that was never published. Every arm64 build running `yum update -y` fails since June 28.

Adds `--nobest --exclude=openssl-fips-provider` as a temporary workaround until the RHEL repo team fixes the broken package.

Test build: ocp4-konflux #39385 (4.17, assembly=test, image=openshift-base-rhel9)

Resolves: https://redhat.atlassian.net/browse/ART-21334