### PR TITLE
ART-21335: add driver-toolkit-rhel10

### DIFF
--- a/images/driver-toolkit-rhel10.yml
+++ b/images/driver-toolkit-rhel10.yml
@@ -1,0 +1,52 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhel10
+    modifications:
+    - action: replace
+      match: "ARG RHEL_VERSION=''"
+      replacement: "ARG RHEL_VERSION='10.2'"
+    # Uncomment the following sections to pin specific kernel versions
+    # - action: replace
+    #   match: "ARG KERNEL_VERSION=''"
+    #   replacement: "ARG KERNEL_VERSION='1.2.3'"
+    # - action: replace
+    #   match: "ARG RT_KERNEL_VERSION=''"
+    #   replacement: "ARG RT_KERNEL_VERSION='1.2.3'"
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/driver-toolkit.git
+      web: https://github.com/openshift/driver-toolkit
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-10
+  component: driver-toolkit-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: driver-toolkit
+  delivery_repo_names:
+  - openshift5/driver-toolkit-rhel10
+enabled_repos:
+- rhel-10-server-ose-rpms-embargoed
+- rhel-102-baseos
+- rhel-102-appstream
+- rhel-10-server-ose-rpms
+for_payload: true
+from:
+  member: openshift-enterprise-base-rhel10
+name: openshift/driver-toolkit-rhel10
+payload_name: driver-toolkit-10
+owners:
+- edge-sro@redhat.com
+konflux:
+  vm_override:
+    aarch64: linux-d160-m2xlarge/arm64
+okd:
+  content:
+    source:
+      modifications:
+      - action: replace
+        match: "diff --side-by-side <(rpm -qi kernel-core | grep 'Source RPM') <(rpm -qi kernel-rt-core | grep 'Source RPM'); \\"
+        replacement: |-
+          diff --side-by-side <(rpm -qi kernel-core | grep 'Source RPM') <(rpm -qi kernel-rt-core | grep 'Source RPM') || true; \
+  enabled_repos:
+  - rhel-102-nfv

--- a/images/driver-toolkit-rhel10.yml
+++ b/images/driver-toolkit-rhel10.yml
@@ -38,6 +38,9 @@ payload_name: driver-toolkit-10
 owners:
 - edge-sro@redhat.com
 konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype
   vm_override:
     aarch64: linux-d160-m2xlarge/arm64
 okd:

--- a/images/driver-toolkit-rhel10.yml
+++ b/images/driver-toolkit-rhel10.yml
@@ -5,13 +5,13 @@ content:
     - action: replace
       match: "ARG RHEL_VERSION=''"
       replacement: "ARG RHEL_VERSION='10.2'"
-    # Uncomment the following sections to pin specific kernel versions
-    # - action: replace
-    #   match: "ARG KERNEL_VERSION=''"
-    #   replacement: "ARG KERNEL_VERSION='1.2.3'"
-    # - action: replace
-    #   match: "ARG RT_KERNEL_VERSION=''"
-    #   replacement: "ARG RT_KERNEL_VERSION='1.2.3'"
+    # Pin kernel versions to ensure kernel and kernel-rt match
+    - action: replace
+      match: "ARG KERNEL_VERSION=''"
+      replacement: "ARG KERNEL_VERSION='6.12.0-211.7.1.el10_2'"
+    - action: replace
+      match: "ARG RT_KERNEL_VERSION=''"
+      replacement: "ARG RT_KERNEL_VERSION='6.12.0-211.7.1.el10_2'"
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/driver-toolkit-rhel10.yml
+++ b/images/driver-toolkit-rhel10.yml
@@ -6,12 +6,12 @@ content:
       match: "ARG RHEL_VERSION=''"
       replacement: "ARG RHEL_VERSION='10.2'"
     # Pin kernel versions to ensure kernel and kernel-rt match
-    - action: replace
-      match: "ARG KERNEL_VERSION=''"
-      replacement: "ARG KERNEL_VERSION='6.12.0-211.7.1.el10_2'"
-    - action: replace
-      match: "ARG RT_KERNEL_VERSION=''"
-      replacement: "ARG RT_KERNEL_VERSION='6.12.0-211.7.1.el10_2'"
+    #- action: replace
+    #  match: "ARG KERNEL_VERSION=''"
+    #  replacement: "ARG KERNEL_VERSION='6.12.0-211.7.1.el10_2'"
+    #- action: replace
+    #  match: "ARG RT_KERNEL_VERSION=''"
+    #  replacement: "ARG RT_KERNEL_VERSION='6.12.0-211.7.1.el10_2'"
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/driver-toolkit-rhel10.yml
+++ b/images/driver-toolkit-rhel10.yml
@@ -42,13 +42,6 @@ konflux:
       backend: rpm-lockfile-prototype
   vm_override:
     aarch64: linux-d160-m2xlarge/arm64
+
 okd:
-  content:
-    source:
-      modifications:
-      - action: replace
-        match: "diff --side-by-side <(rpm -qi kernel-core | grep 'Source RPM') <(rpm -qi kernel-rt-core | grep 'Source RPM'); \\"
-        replacement: |-
-          diff --side-by-side <(rpm -qi kernel-core | grep 'Source RPM') <(rpm -qi kernel-rt-core | grep 'Source RPM') || true; \
-  enabled_repos:
-  - rhel-102-nfv
+  mode: disabled

--- a/images/driver-toolkit-rhel10.yml
+++ b/images/driver-toolkit-rhel10.yml
@@ -29,7 +29,6 @@ enabled_repos:
 - rhel-10-server-ose-rpms-embargoed
 - rhel-102-baseos
 - rhel-102-appstream
-- rhel-10-server-ose-rpms
 for_payload: true
 from:
   member: openshift-enterprise-base-rhel10


### PR DESCRIPTION
New RHEL 10 toolkit image following driver-toolkit pattern.

- Pins RHEL version to 10.2
- Configured for Konflux (aarch64 VM override)  
- OKD enabled with NFV repos