### PR TITLE
Add valid-subscription-label to backplane-operator update-csv

### DIFF
--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -29,6 +29,7 @@ update-csv:
   bundle-dir: manifests
   registry: image-registry.openshift-image-registry.svc:5000
   registry-target-namespace: multicluster-engine
+  valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
 owners:
 - acm-cicd@redhat.com
 jira:


### PR DESCRIPTION
## Summary

Add `valid-subscription-label` to `update-csv` in `backplane-operator.yml`. Bundle build fails without this field (same fix as Erin's ACM PR #11521).

Value sourced from the MCE CSV template (`stolostron/mce-operator-bundle`):
```
["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]
```

Ref: HYPBLD-854

Made with [Cursor](https://cursor.com)