### PR TITLE
Bump MCE 2.11 version to 2.11.4

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -2,7 +2,7 @@ freeze_automation: false
 name: mce-2.11
 csv_namespace: multicluster-engine
 product: mce
-version: 2.11.0
+version: 2.11.4
 
 vars:
   GO_LATEST: "1.25"


### PR DESCRIPTION
## Summary

Update `group.yml` version from `2.11.0` to `2.11.4` to match the current MCE z-stream release.

Ref: [HYPBLD-854](https://redhat.atlassian.net/browse/HYPBLD-854)

Made with [Cursor](https://cursor.com)