### PR TITLE
Unfreeze automation for 4.17

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,7 +4,7 @@
 #   - weekdays: always allow manual builds; forbid scheduled builds from Monday to Friday
 #   - no|false: always allow builds
 # Note that ocp4 builds are always permitted  for non-stream assemblies
-freeze_automation: true
+freeze_automation: false
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
## Summary
- Set `freeze_automation` back to `false` after the openssl-fips-provider subpackage issue has been resolved.

## Test plan
- [ ] Verify scheduled builds resume for 4.17