### PR TITLE
Unfreeze automation and enable rpm-lockfile-prototype for 4.19

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,7 +4,7 @@
 #   - weekdays: always allow manual builds; forbid scheduled builds from Monday to Friday
 #   - no|false: always allow builds
 # Note that ocp4 builds are always permitted  for non-stream assemblies
-freeze_automation: true
+freeze_automation: false
 
 vars:
   MAJOR: 4
@@ -44,6 +44,7 @@ konflux:
   - s390x
   cachi2:
     lockfile:
+      backend: rpm-lockfile-prototype
       force: true
     enabled: true
     gomod_version_patch: true


### PR DESCRIPTION
## Summary
- Set `freeze_automation` back to `false` after the openssl-fips-provider subpackage issue has been resolved.
- Set cachi2 lockfile `backend: rpm-lockfile-prototype` (matching 4.23 configuration).

## Test plan
- [ ] Verify scheduled builds resume for 4.19
- [ ] Verify rpm-lockfile-prototype is used for lockfile generation