### PR TITLE
Revert "[openshift-4.17] Pin openssl-fips-provider to 3.0.7-2.el9 to avoid broken dependency"

### DIFF
--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -25,10 +25,6 @@ content:
     okd_alignment:
       resolve_as:
         stream: centos_stream9
-    modifications:
-      - action: replace
-        match: "yum update -y"
-        replacement: "yum update -y --exclude=openssl-fips-provider* && yum install -y openssl-fips-provider-3.0.7-2.el9"
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-base-rhel9-container

--- a/releases.yml
+++ b/releases.yml
@@ -3173,4 +3173,3 @@ releases:
                 exempt_rpms:
                   - redhat-release* # documents rhel release notes and concerns
                   - tzdata
-                  - openssl-fips-provider # broken dep on openssl-fips-provider-so; exclude to avoid build failures


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#11551