### PR TITLE
Revert "Pin openssl-fips-provider to 3.0.7-2.el9 to avoid broken dependency (4.15 cherrypick)"

### DIFF
--- a/images/openshift-base-rhel9.yml
+++ b/images/openshift-base-rhel9.yml
@@ -22,10 +22,6 @@ content:
       # rpms for the appropriate release.
       transform: rhel-9/base-repos
       upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-{MAJOR}.{MINOR}
-    modifications:
-      - action: replace
-        match: "yum update -y"
-        replacement: "yum update -y --exclude=openssl-fips-provider* && yum install -y openssl-fips-provider-3.0.7-2.el9"
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-base-rhel9-container

--- a/releases.yml
+++ b/releases.yml
@@ -5582,4 +5582,3 @@ releases:
                 exempt_rpms:
                   - redhat-release* # documents rhel release notes and concerns
                   - tzdata
-                  - openssl-fips-provider # broken dep on openssl-fips-provider-so; exclude to avoid build failures


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#11553