### PR TITLE
use - separator for separating major, minor rhel version

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -61,7 +61,7 @@ repos:
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
       optional: true
 
-  rhel-86-baseos-rpms:
+  rhel-8-6-baseos-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/baseos/os/
@@ -76,7 +76,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-86-appstream-rpms:
+  rhel-8-6-appstream-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/appstream/os/
@@ -91,7 +91,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-86-codeready-builder-rpms:
+  rhel-8-6-codeready-builder-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/codeready-builder/os/
@@ -106,7 +106,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-810-baseos-rpms:
+  rhel-8-10-baseos-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/baseos/os/
@@ -121,7 +121,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-810-appstream-rpms:
+  rhel-8-10-appstream-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/appstream/os/
@@ -136,7 +136,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-810-codeready-builder-rpms:
+  rhel-8-10-codeready-builder-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.10/aarch64/codeready-builder/os/
@@ -169,7 +169,7 @@ repos:
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
       optional: true
 
-  rhel-90-baseos-rpms:
+  rhel-9-0-baseos-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/baseos/os/
@@ -184,7 +184,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-90-appstream-rpms:
+  rhel-9-0-appstream-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/appstream/os/
@@ -199,7 +199,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-90-codeready-builder-rpms:
+  rhel-9-0-codeready-builder-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/codeready-builder/os/
@@ -214,7 +214,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-96-baseos-rpms:
+  rhel-9-6-baseos-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/
@@ -229,7 +229,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-96-appstream-rpms:
+  rhel-9-6-appstream-rpms:
     conf:
       extra_options:
         excludepkgs: golang*
@@ -246,7 +246,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-96-codeready-builder-rpms:
+  rhel-9-6-codeready-builder-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/codeready-builder/os/
@@ -261,7 +261,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-94-baseos-rpms:
+  rhel-9-4-baseos-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/
@@ -276,7 +276,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-94-appstream-rpms:
+  rhel-9-4-appstream-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/
@@ -291,7 +291,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-94-codeready-builder-rpms:
+  rhel-9-4-codeready-builder-rpms:
     conf:
       baseurl:
         aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/aarch64/codeready-builder/os/

--- a/images/openshift-golang-builder-1-19.rhel8.yml
+++ b/images/openshift-golang-builder-1-19.rhel8.yml
@@ -15,13 +15,13 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-86-baseos-rpms
+- rhel-8-6-baseos-rpms
 # for clang
-- rhel-86-appstream-rpms
-- rhel-86-codeready-builder-rpms
+- rhel-8-6-appstream-rpms
+- rhel-8-6-codeready-builder-rpms
 
 from:
-  stream: rhel-86
+  stream: rhel-8-6
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-19.rhel9.yml
+++ b/images/openshift-golang-builder-1-19.rhel9.yml
@@ -15,13 +15,13 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-9-golang-rpms
-- rhel-90-baseos-rpms
+- rhel-9-0-baseos-rpms
 # for clang
-- rhel-90-appstream-rpms
-- rhel-90-codeready-builder-rpms
+- rhel-9-0-appstream-rpms
+- rhel-9-0-codeready-builder-rpms
 
 from:
-  stream: rhel-90
+  stream: rhel-9-0
 
 image_build_method: osbs2
 

--- a/images/openshift-golang-builder-1-20.rhel8.yml
+++ b/images/openshift-golang-builder-1-20.rhel8.yml
@@ -15,13 +15,13 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-86-baseos-rpms
+- rhel-8-6-baseos-rpms
 # for clang
-- rhel-86-appstream-rpms
-- rhel-86-codeready-builder-rpms
+- rhel-8-6-appstream-rpms
+- rhel-8-6-codeready-builder-rpms
 
 from:
-  stream: rhel-86
+  stream: rhel-8-6
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-20.rhel9.yml
+++ b/images/openshift-golang-builder-1-20.rhel9.yml
@@ -15,12 +15,12 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-9-golang-rpms
-- rhel-90-baseos-rpms
+- rhel-9-0-baseos-rpms
 # for clang
-- rhel-90-appstream-rpms
-- rhel-90-codeready-builder-rpms
+- rhel-9-0-appstream-rpms
+- rhel-9-0-codeready-builder-rpms
 from:
-  stream: rhel-90
+  stream: rhel-9-0
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-21.rhel8.yml
+++ b/images/openshift-golang-builder-1-21.rhel8.yml
@@ -15,13 +15,13 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-86-baseos-rpms
+- rhel-8-6-baseos-rpms
 # for clang
-- rhel-86-appstream-rpms
-- rhel-86-codeready-builder-rpms
+- rhel-8-6-appstream-rpms
+- rhel-8-6-codeready-builder-rpms
 
 from:
-  stream: rhel-86
+  stream: rhel-8-6
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-21.rhel9.yml
+++ b/images/openshift-golang-builder-1-21.rhel9.yml
@@ -14,14 +14,14 @@ content:
       path: go_wrapper.sh
       overwriting: true
 enabled_repos:
-- rhel-94-baseos-rpms
+- rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms
 # for clang
-- rhel-94-appstream-rpms
-- rhel-94-codeready-builder-rpms
+- rhel-9-4-appstream-rpms
+- rhel-9-4-codeready-builder-rpms
 
 from:
-  stream: rhel-94
+  stream: rhel-9-4
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-22.rhel8.yml
+++ b/images/openshift-golang-builder-1-22.rhel8.yml
@@ -15,13 +15,13 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-810-baseos-rpms
+- rhel-8-10-baseos-rpms
 # for clang
-- rhel-810-appstream-rpms
-- rhel-810-codeready-builder-rpms
+- rhel-8-10-appstream-rpms
+- rhel-8-10-codeready-builder-rpms
 
 from:
-  stream: rhel-810
+  stream: rhel-8-10
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-22.rhel9.yml
+++ b/images/openshift-golang-builder-1-22.rhel9.yml
@@ -14,14 +14,14 @@ content:
       path: go_wrapper.sh
       overwriting: true
 enabled_repos:
-- rhel-94-baseos-rpms
+- rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms
 # for clang
-- rhel-94-appstream-rpms
-- rhel-94-codeready-builder-rpms
+- rhel-9-4-appstream-rpms
+- rhel-9-4-codeready-builder-rpms
 
 from:
-  stream: rhel-94
+  stream: rhel-9-4
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-23.rhel8.yml
+++ b/images/openshift-golang-builder-1-23.rhel8.yml
@@ -15,12 +15,12 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-810-baseos-rpms
+- rhel-8-10-baseos-rpms
 # for clang
-- rhel-810-appstream-rpms
-- rhel-810-codeready-builder-rpms
+- rhel-8-10-appstream-rpms
+- rhel-8-10-codeready-builder-rpms
 from:
-  stream: rhel-810
+  stream: rhel-8-10
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-23.rhel9.yml
+++ b/images/openshift-golang-builder-1-23.rhel9.yml
@@ -14,14 +14,14 @@ content:
       path: go_wrapper.sh
       overwriting: true
 enabled_repos:
-- rhel-94-baseos-rpms
+- rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms
 # for clang
-- rhel-94-appstream-rpms
-- rhel-94-codeready-builder-rpms
+- rhel-9-4-appstream-rpms
+- rhel-9-4-codeready-builder-rpms
 
 from:
-  stream: rhel-94
+  stream: rhel-9-4
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-24.rhel8.yml
+++ b/images/openshift-golang-builder-1-24.rhel8.yml
@@ -15,13 +15,13 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-810-baseos-rpms
+- rhel-8-10-baseos-rpms
 # for clang
-- rhel-810-appstream-rpms
-- rhel-810-codeready-builder-rpms
+- rhel-8-10-appstream-rpms
+- rhel-8-10-codeready-builder-rpms
 
 from:
-  stream: rhel-810
+  stream: rhel-8-10
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-24.rhel9-4.yml
+++ b/images/openshift-golang-builder-1-24.rhel9-4.yml
@@ -14,14 +14,14 @@ content:
       path: go_wrapper.sh
       overwriting: true
 enabled_repos:
-- rhel-94-baseos-rpms
+- rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms
 # for clang
-- rhel-94-appstream-rpms
-- rhel-94-codeready-builder-rpms
+- rhel-9-4-appstream-rpms
+- rhel-9-4-codeready-builder-rpms
 
 from:
-  stream: rhel-94
+  stream: rhel-9-4
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-25.rhel8.yml
+++ b/images/openshift-golang-builder-1-25.rhel8.yml
@@ -15,13 +15,13 @@ content:
       overwriting: true
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-810-baseos-rpms
+- rhel-8-10-baseos-rpms
 # for clang
-- rhel-810-appstream-rpms
-- rhel-810-codeready-builder-rpms
+- rhel-8-10-appstream-rpms
+- rhel-8-10-codeready-builder-rpms
 
 from:
-  stream: rhel-810
+  stream: rhel-8-10
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-25.rhel9-4.yml
+++ b/images/openshift-golang-builder-1-25.rhel9-4.yml
@@ -14,14 +14,14 @@ content:
       path: go_wrapper.sh
       overwriting: true
 enabled_repos:
-- rhel-94-baseos-rpms
+- rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms
 # for clang
-- rhel-94-appstream-rpms
-- rhel-94-codeready-builder-rpms
+- rhel-9-4-appstream-rpms
+- rhel-9-4-codeready-builder-rpms
 
 from:
-  stream: rhel-94
+  stream: rhel-9-4
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-25.rhel9-6.yml
+++ b/images/openshift-golang-builder-1-25.rhel9-6.yml
@@ -16,14 +16,14 @@ content:
       path: go_wrapper.sh
       overwriting: true
 enabled_repos:
-- rhel-96-baseos-rpms
+- rhel-9-6-baseos-rpms
 - rhel-9-golang-rpms
 # for clang
-- rhel-96-appstream-rpms
-- rhel-96-codeready-builder-rpms
+- rhel-9-6-appstream-rpms
+- rhel-9-6-codeready-builder-rpms
 
 from:
-  stream: rhel-96
+  stream: rhel-9-6
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds (RHEL 9.6)

--- a/images/openshift-golang-builder-1-26.rhel8.yml
+++ b/images/openshift-golang-builder-1-26.rhel8.yml
@@ -22,13 +22,13 @@ targets:
 
 enabled_repos:
 - rhel-8-golang-rpms
-- rhel-810-baseos-rpms
+- rhel-8-10-baseos-rpms
 # for clang
-- rhel-810-appstream-rpms
-- rhel-810-codeready-builder-rpms
+- rhel-8-10-appstream-rpms
+- rhel-8-10-codeready-builder-rpms
 
 from:
-  stream: rhel-810
+  stream: rhel-8-10
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/images/openshift-golang-builder-1-26.rhel9.yml
+++ b/images/openshift-golang-builder-1-26.rhel9.yml
@@ -21,14 +21,14 @@ targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
 
 enabled_repos:
-- rhel-94-baseos-rpms
+- rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms
 # for clang
-- rhel-94-appstream-rpms
-- rhel-94-codeready-builder-rpms
+- rhel-9-4-appstream-rpms
+- rhel-9-4-codeready-builder-rpms
 
 from:
-  stream: rhel-94
+  stream: rhel-9-4
 
 labels:
   io.k8s.description: golang builder image for Red Hat internal builds

--- a/streams.yml
+++ b/streams.yml
@@ -1,20 +1,20 @@
 ---
-rhel-86:
+rhel-8-6:
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.6-754
 
-rhel-810:
+rhel-8-10:
   # ubi8-container-8.10-901.1717584420
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8@sha256:143123d85045df426c5bbafc6863659880ebe276eb02c77ee868b88d08dbd05d
 
-rhel-90:
+rhel-9-0:
 # rhel-els-container-9.0.0-974
   image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:c00fe5ad75658431c97b3a225db5625a97c8f3a28253af7ec3aa622db235ff64
 
-rhel-94:
+rhel-9-4:
 # rhel-els-container-9.4-943.1726661131
   image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:2aaaf576ca73226a6f00af0fd0f0f1e08d5f6a269d15f9b5305d3d5bde94d4f7
 
-rhel-96:
+rhel-9-6:
 # ubi9-container-9.6-440.1760321968
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9@sha256:08a8d763ab10280a510d12180363adbe08264a7448bcdfdf92dfaaed4549899c
 


### PR DESCRIPTION
Using `-` separator for separating major and minor `rhel` versions