### PR TITLE
ART-21462: Add RHEL 8 repos and dos2unix for ose-containernetworking-plugins (4.18)

### DIFF
--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -22,8 +22,10 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-container-networking-plugins-rhel9
 enabled_repos:
-- rhel-9-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-baseos-rpms
 - rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
## Summary

The `ose-containernetworking-plugins` Dockerfile has three builder stages:
1. `rhel-9-golang` (rhel9)
2. `rhel-8-golang` (rhel8)
3. `rhel-8-golang` (windows)

Stage 3 runs `yum install -y dos2unix`, which requires RHEL 8 repos. In hermetic
mode, only RHEL 9 repos were configured in `enabled_repos`, so the RHEL 9 `dos2unix`
package was resolved instead — but it requires `glibc-2.34`, conflicting with the
RHEL 8 base image's `glibc-2.28`. The build fails on all architectures.

This PR adds `rhel-8-baseos-rpms` and `rhel-8-appstream-rpms` to `enabled_repos`
so the RHEL 8 builder stages can resolve packages from matching repos.

Fixes: [ART-21462](https://issues.redhat.com/browse/ART-21462)