### PR TITLE
openshift-enterprise-tests: disable git tag fetching in clone task

### DIFF
--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -33,6 +33,8 @@ from:
   - stream: rhel-9-golang
   member: ose-tools
 canonical_builders_from_upstream: false
+konflux:
+  clone_git_tags: false
 labels:
   License: GPLv2+
   io.k8s.description: OpenShift is a platform for developing, building, and deploying containerized applications.


### PR DESCRIPTION
## Summary

- Set `konflux.clone_git_tags: false` for `openshift-enterprise-tests`

The openshift/origin repo has 72 stale tags (v1.0.0 through v4.1.0) that cause OOM kills during the Konflux clone-repository task. This image does not use tags at build time.

## Dependencies

- Requires [openshift-eng/art-tools#3117](https://github.com/openshift-eng/art-tools/pull/3117) to be merged first (adds `clone_git_tags` config support)

Resolves: [ART-21478](https://redhat.atlassian.net/browse/ART-21478)