### PR TITLE
openshift-enterprise-tests: disable git tag fetching in clone task

### DIFF
--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -42,3 +42,6 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-tests
 payload_name: tests
+
+konflux:
+  clone_git_tags: false


### PR DESCRIPTION
The openshift/origin repo has 72 stale tags (v1.0.0 through v4.1.0)
that add significant git object data during clone, pushing the
clone-repository task past its 2Gi memory limit and causing OOM kills.
This image does not use tags at build time.

Sets `konflux.clone_git_tags: false` to prevent fetching tags during clone.

Resolves: [ART-21478](https://redhat.atlassian.net/browse/ART-21478)