### PR TITLE
ART-21508: Introduce base-rhel9 base image [mta-8.1]

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -72,6 +72,8 @@ mr_approvers:
     - vaashiro
 
 public_upstreams:
+- private: "https://github.com/openshift-priv/ocp-build-data"
+  public:  "https://github.com/openshift-eng/ocp-build-data"
 - private: "https://github.com/openshift-priv"
   public:  "https://github.com/migtools"
 

--- a/group.yml
+++ b/group.yml
@@ -34,6 +34,9 @@ konflux:
   cachi2:
     enabled: true
     gomod_version_patch: true
+    lockfile:
+      force: true
+      backend: rpm-lockfile-prototype
   sast:
     enabled: true
   network_mode: hermetic

--- a/group.yml
+++ b/group.yml
@@ -35,7 +35,6 @@ konflux:
     enabled: true
     gomod_version_patch: true
     lockfile:
-      force: true
       backend: rpm-lockfile-prototype
   sast:
     enabled: true

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -20,9 +20,3 @@ name: art-core/base-rhel9
 owners:
 - aos-team-art@redhat.com
 canonical_builders_from_upstream: false
-konflux:
-  cachi2:
-    lockfile:
-      rpms:
-      - ca-certificates
-      - findutils

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -1,0 +1,28 @@
+base_only: true
+content:
+  source:
+    git:
+      branch:
+        target: openshift-base-rhel9
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: base-rhel9-container
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+for_payload: false
+for_release: false
+from:
+  stream: rhel9
+name: art-core/base-rhel9
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - ca-certificates
+      - findutils

--- a/images/mta-analyzer-lsp.yml
+++ b/images/mta-analyzer-lsp.yml
@@ -27,7 +27,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-analyzer-lsp-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-analyzer-rpc.yml
+++ b/images/mta-analyzer-rpc.yml
@@ -27,7 +27,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-analyzer-rpc-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-cli.yml
+++ b/images/mta-cli.yml
@@ -25,7 +25,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-    - stream: rhel9
+    - member: base-rhel9
     - member: mta-static-report
     - member: mta-analyzer-lsp
     - member: mta-generic-external-provider

--- a/images/mta-discovery-addon.yml
+++ b/images/mta-discovery-addon.yml
@@ -28,7 +28,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-discovery-addon-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-dotnet-external-provider.yml
+++ b/images/mta-dotnet-external-provider.yml
@@ -26,8 +26,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 from:
   builder:
-    - stream: rhel9
-  stream: rhel9
+    - member: base-rhel9
+  member: base-rhel9
 name: mta/mta-dotnet-external-provider-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-generic-external-provider.yml
+++ b/images/mta-generic-external-provider.yml
@@ -29,7 +29,7 @@ from:
   builder:
     - stream: rhel-9-golang
     - member: mta-golang-dependency-provider
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-generic-external-provider-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-golang-dependency-provider.yml
+++ b/images/mta-golang-dependency-provider.yml
@@ -27,7 +27,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-golang-dependency-provider-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-hub.yml
+++ b/images/mta-hub.yml
@@ -29,9 +29,9 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-    - stream: rhel9
+    - member: base-rhel9
     - member: mta-static-report
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-hub-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -43,7 +43,7 @@ konflux:
     artifact_lockfile:
       enabled: true
       resources:
-        - url: https://download.eclipse.org/jdtls/milestones/1.51.0/jdt-language-server-1.51.0-202510022025.tar.gz
+        - url: https://download.eclipse.org/jdtls/milestones/1.60.0/jdt-language-server-1.60.0-202606262232.tar.gz
           filename: jdtls-product.tar.gz
         - url: https://indy.corp.redhat.com/api/content/maven/hosted/pnc-builds/io/konveyor/tackle/java-analyzer-bundle.core/8.1.0.CR1-redhat-00004/java-analyzer-bundle.core-8.1.0.CR1-redhat-00004.jar
           filename: java-analyzer-bundle.core.jar

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -22,8 +22,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 from:
   builder:
-    - stream: rhel9
-  stream: rhel9
+    - member: base-rhel9
+  member: base-rhel9
 name: mta/mta-jdtls-server-base-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-platform-addon.yml
+++ b/images/mta-platform-addon.yml
@@ -28,7 +28,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-platform-addon-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -21,8 +21,8 @@ enabled_repos:
 - rhel-9-codeready-builder-rpms
 from:
   builder:
-    - stream: rhel9
-  stream: rhel9
+    - member: base-rhel9
+  member: base-rhel9
 name: mta/mta-solution-server-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-static-report.yml
+++ b/images/mta-static-report.yml
@@ -31,7 +31,7 @@ from:
   builder:
     - stream: rhel-9-golang
     - stream: rhel-9-nodejs-18
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-static-report-rhel9
 owners:
 - mta-devs@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -18,4 +18,4 @@ rhel-9-ansible-operator:
 rhel9:
   # ubi9-container-9.6-440.1756861791
   # image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9@sha256:18411066c15bbc9c76e86bdd01bd41e89076ed73fd508875148fee92ef057c02
-  image: registry.redhat.io/ubi9/ubi:latest
+  image: registry.redhat.io/ubi9/ubi-minimal:latest

--- a/streams.yml
+++ b/streams.yml
@@ -16,5 +16,4 @@ rhel-9-ansible-operator:
   image: registry.redhat.io/openshift4/ose-ansible-rhel9-operator:v4.18
 
 rhel9:
-  # Pin to RHEL 9.6 to match 9.6 EUS lockfile repos (avoid openssl drift from :latest)
   image: registry.redhat.io/ubi9/ubi:9.6

--- a/streams.yml
+++ b/streams.yml
@@ -16,6 +16,5 @@ rhel-9-ansible-operator:
   image: registry.redhat.io/openshift4/ose-ansible-rhel9-operator:v4.18
 
 rhel9:
-  # ubi9-container-9.6-440.1756861791
-  # image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9@sha256:18411066c15bbc9c76e86bdd01bd41e89076ed73fd508875148fee92ef057c02
-  image: registry.redhat.io/ubi9/ubi-minimal:latest
+  # Pin to RHEL 9.6 to match 9.6 EUS lockfile repos (avoid openssl drift from :latest)
+  image: registry.redhat.io/ubi9/ubi:9.6


### PR DESCRIPTION
## Summary
- Add `images/base-rhel9.yml` (`art-core/base-rhel9`, modeled on oadp-1.6)
- Switch MTA images from `stream: rhel9` to `member: base-rhel9` (runtime and builder stages)
- Pin `streams.yml` `rhel9` to `registry.redhat.io/ubi9/ubi:9.6` (8.1 is a 9.6 release; `:latest` drifted to 9.8 and broke openssl depsolve against 9.6 EUS lockfiles)
- Bump `mta-jdtls-server-base` JDTLS artifact lockfile to 1.60.0
- Enable `rpm-lockfile-prototype` lockfile backend group-wide; remove unused `lockfile.rpms` from `base-rhel9.yml`

### RHEL 9.6 EUS — no 9.8 migration

MTA 8.1 is an active **z-stream** with shipped releases. This PR intentionally **does not** move to RHEL 9.8 E4S repos. RPM lockfiles stay on **9.6 EUS** (`rhel-9-*`). The 9.8 repo migration is scoped to **MTA 8.2** (PR #11596).

## Test plan

Jenkins [`aos-cd-builds/build/layered-products`](https://buildvm.openshift.eng.bos.redhat.com:8443/job/aos-cd-builds/job/build%252Flayered-products/) with:

| Parameter | Value |
|-----------|-------|
| GROUP | `mta-8.1` |
| ASSEMBLY | `test` |
| DOOZER_DATA_PATH | `https://github.com/fbladilo/ocp-build-data` |
| DOOZER_DATA_GITREF | `mta-8.1-base-rhel9` |
| IMAGE_BUILD_STRATEGY | `all` |
| IMAGE_LIST | *(empty)* |
| DRY_RUN | `false` |
| MOCK | `false` |

### Results

- [x] [#8774](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/8774/) — **SUCCESS** — all images in `mta-8.1` group (`IMAGE_BUILD_STRATEGY=all`)