### PR TITLE
ART-21509: Introduce base-rhel9 base image [mta-8.2]

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -72,6 +72,8 @@ mr_approvers:
     - vaashiro
 
 public_upstreams:
+- private: "https://github.com/openshift-priv/ocp-build-data"
+  public:  "https://github.com/openshift-eng/ocp-build-data"
 - private: "https://github.com/openshift-priv"
   public:  "https://github.com/migtools"
 

--- a/group.yml
+++ b/group.yml
@@ -35,7 +35,6 @@ konflux:
     enabled: true
     gomod_version_patch: true
     lockfile:
-      force: true
       backend: rpm-lockfile-prototype
   sast:
     enabled: true

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -1,0 +1,28 @@
+base_only: true
+content:
+  source:
+    git:
+      branch:
+        target: openshift-base-rhel9
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: base-rhel9-container
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+for_payload: false
+for_release: false
+from:
+  stream: rhel9
+name: art-core/base-rhel9
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - ca-certificates
+      - findutils

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -10,8 +10,8 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: base-rhel9-container
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 for_payload: false
 for_release: false
 from:

--- a/images/mta-analyzer-addon.yml
+++ b/images/mta-analyzer-addon.yml
@@ -20,10 +20,8 @@ delivery:
   - mta/mta-analyzer-addon-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
-- rhel-98-baseos-rpms
 - rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 - rhel-98-codeready-builder-rpms
 from:
   builder:

--- a/images/mta-analyzer-lsp.yml
+++ b/images/mta-analyzer-lsp.yml
@@ -20,8 +20,8 @@ delivery:
   - mta/mta-analyzer-lsp-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/mta-analyzer-lsp.yml
+++ b/images/mta-analyzer-lsp.yml
@@ -25,7 +25,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-analyzer-lsp-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-analyzer-rpc.yml
+++ b/images/mta-analyzer-rpc.yml
@@ -27,7 +27,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-analyzer-rpc-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-analyzer-rpc.yml
+++ b/images/mta-analyzer-rpc.yml
@@ -22,8 +22,8 @@ delivery:
   - mta/mta-analyzer-rpc-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/mta-cli.yml
+++ b/images/mta-cli.yml
@@ -20,8 +20,8 @@ delivery:
   - mta/mta-cli-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/mta-cli.yml
+++ b/images/mta-cli.yml
@@ -25,7 +25,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-    - stream: rhel9
+    - member: base-rhel9
     - member: mta-static-report
     - member: mta-analyzer-lsp
     - member: mta-go-external-provider

--- a/images/mta-discovery-addon.yml
+++ b/images/mta-discovery-addon.yml
@@ -20,8 +20,6 @@ delivery:
   - mta/mta-discovery-addon-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
 - rhel-98-appstream-rpms
 - rhel-98-baseos-rpms
 - rhel-98-codeready-builder-rpms

--- a/images/mta-discovery-addon.yml
+++ b/images/mta-discovery-addon.yml
@@ -28,7 +28,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-discovery-addon-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-dotnet-external-provider.yml
+++ b/images/mta-dotnet-external-provider.yml
@@ -26,8 +26,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 from:
   builder:
-    - stream: rhel9
-  stream: rhel9
+    - member: base-rhel9
+  member: base-rhel9
 name: mta/mta-dotnet-external-provider-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-dotnet-external-provider.yml
+++ b/images/mta-dotnet-external-provider.yml
@@ -22,8 +22,8 @@ delivery:
   - mta/mta-dotnet-external-provider-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - member: base-rhel9

--- a/images/mta-go-external-provider.yml
+++ b/images/mta-go-external-provider.yml
@@ -22,8 +22,8 @@ delivery:
   - mta/mta-go-external-provider-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/mta-go-external-provider.yml
+++ b/images/mta-go-external-provider.yml
@@ -27,7 +27,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-go-external-provider-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-hub.yml
+++ b/images/mta-hub.yml
@@ -29,9 +29,9 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-    - stream: rhel9
+    - member: base-rhel9
     - member: mta-static-report
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-hub-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-hub.yml
+++ b/images/mta-hub.yml
@@ -20,9 +20,6 @@ delivery:
   - mta/mta-hub-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
-- rhel-9-codeready-builder-rpms
 - rhel-98-appstream-rpms
 - rhel-98-baseos-rpms
 - rhel-98-codeready-builder-rpms

--- a/images/mta-java-external-provider.yml
+++ b/images/mta-java-external-provider.yml
@@ -21,8 +21,8 @@ delivery:
   - mta/mta-java-external-provider-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -16,8 +16,8 @@ delivery:
   - mta/mta-jdtls-server-base-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - member: base-rhel9

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -42,10 +42,10 @@ konflux:
       enabled: true
       resources:
         - url: https://download.eclipse.org/jdtls/milestones/1.60.0/jdt-language-server-1.60.0-202606262232.tar.gz
-          filename: jdt-language-server-1.60.0-202606262232.tar.gz
+          filename: jdtls-product.tar.gz
         - url: https://indy.corp.redhat.com/api/content/maven/hosted/pnc-builds/io/konveyor/tackle/java-analyzer-bundle.core/8.1.0.CR1-redhat-00003/java-analyzer-bundle.core-8.1.0.CR1-redhat-00003.jar
-          filename: java-analyzer-bundle.core-8.1.0.CR1-redhat-00003.jar
+          filename: java-analyzer-bundle.core.jar
         - url: https://indy.corp.redhat.com/api/content/maven/hosted/pnc-builds/org/jetbrains/java/decompiler/fernflower/8.1.0.GA-redhat-00001/fernflower-8.1.0.GA-redhat-00001.jar
-          filename: fernflower-8.1.0.GA-redhat-00001.jar
+          filename: fernflower.jar
         - url: https://github.com/konveyor/maven-search-index/releases/download/v2025-11-11/maven-index-data-v20251112021242.zip
-          filename: maven-index-data-v20251112021242.zip
+          filename: maven-index-data.zip

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -41,8 +41,8 @@ konflux:
     artifact_lockfile:
       enabled: true
       resources:
-        - url: https://download.eclipse.org/jdtls/milestones/1.51.0/jdt-language-server-1.51.0-202510022025.tar.gz
-          filename: jdt-language-server-1.51.0-202510022025.tar.gz
+        - url: https://download.eclipse.org/jdtls/milestones/1.60.0/jdt-language-server-1.60.0-202606262232.tar.gz
+          filename: jdt-language-server-1.60.0-202606262232.tar.gz
         - url: https://indy.corp.redhat.com/api/content/maven/hosted/pnc-builds/io/konveyor/tackle/java-analyzer-bundle.core/8.1.0.CR1-redhat-00003/java-analyzer-bundle.core-8.1.0.CR1-redhat-00003.jar
           filename: java-analyzer-bundle.core-8.1.0.CR1-redhat-00003.jar
         - url: https://indy.corp.redhat.com/api/content/maven/hosted/pnc-builds/org/jetbrains/java/decompiler/fernflower/8.1.0.GA-redhat-00001/fernflower-8.1.0.GA-redhat-00001.jar

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -20,8 +20,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 from:
   builder:
-    - stream: rhel9
-  stream: rhel9
+    - member: base-rhel9
+  member: base-rhel9
 name: mta/mta-jdtls-server-base-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-nodejs-external-provider.yml
+++ b/images/mta-nodejs-external-provider.yml
@@ -21,8 +21,8 @@ delivery:
   - mta/mta-nodejs-external-provider-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/mta-nodejs-external-provider.yml
+++ b/images/mta-nodejs-external-provider.yml
@@ -26,7 +26,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-nodejs-external-provider-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-operator.yml
+++ b/images/mta-operator.yml
@@ -23,8 +23,8 @@ delivery:
   - mta/mta-rhel9-operator
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   stream: rhel-9-ansible-operator
 name: mta/mta-rhel9-operator

--- a/images/mta-ops.yml
+++ b/images/mta-ops.yml
@@ -29,7 +29,3 @@ from:
 name: mta/mta-ops-rhel9
 owners:
 - mta-devs@redhat.com
-konflux:
-  cachi2:
-    lockfile:
-      backend: rpm-lockfile-prototype

--- a/images/mta-ops.yml
+++ b/images/mta-ops.yml
@@ -20,8 +20,8 @@ delivery:
   - mta/mta-ops-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/mta-ops.yml
+++ b/images/mta-ops.yml
@@ -25,7 +25,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-ops-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-platform-addon.yml
+++ b/images/mta-platform-addon.yml
@@ -28,7 +28,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-platform-addon-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-platform-addon.yml
+++ b/images/mta-platform-addon.yml
@@ -20,8 +20,6 @@ delivery:
   - mta/mta-platform-addon-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
 - rhel-98-appstream-rpms
 - rhel-98-baseos-rpms
 - rhel-98-codeready-builder-rpms

--- a/images/mta-python-external-provider.yml
+++ b/images/mta-python-external-provider.yml
@@ -35,7 +35,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-python-external-provider-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -21,8 +21,8 @@ enabled_repos:
 - rhel-9-codeready-builder-rpms
 from:
   builder:
-    - stream: rhel9
-  stream: rhel9
+    - member: base-rhel9
+  member: base-rhel9
 name: mta/mta-solution-server-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -16,9 +16,9 @@ delivery:
   - mta/mta-solution-server-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
-- rhel-9-codeready-builder-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
+- rhel-98-codeready-builder-rpms
 from:
   builder:
     - member: base-rhel9

--- a/images/mta-static-report.yml
+++ b/images/mta-static-report.yml
@@ -25,8 +25,8 @@ delivery:
   - mta/mta-static-report-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/mta-static-report.yml
+++ b/images/mta-static-report.yml
@@ -31,7 +31,7 @@ from:
   builder:
     - stream: rhel-9-golang
     - stream: rhel-9-nodejs-18
-  stream: rhel9
+  member: base-rhel9
 name: mta/mta-static-report-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-ui.yml
+++ b/images/mta-ui.yml
@@ -25,8 +25,8 @@ delivery:
   - mta/mta-ui-rhel9
 for_payload: false
 enabled_repos:
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-nodejs-22

--- a/streams.yml
+++ b/streams.yml
@@ -21,4 +21,4 @@ rhel-9-ansible-operator:
 rhel9:
   # ubi9-container-9.6-440.1756861791
   # image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9@sha256:18411066c15bbc9c76e86bdd01bd41e89076ed73fd508875148fee92ef057c02
-  image: registry.redhat.io/ubi9/ubi:latest
+  image: registry.redhat.io/ubi9/ubi-minimal:latest


### PR DESCRIPTION
## Summary
- Add `images/base-rhel9.yml` (`art-core/base-rhel9`, modeled on oadp-1.6)
- Switch MTA images from `stream: rhel9` to `member: base-rhel9` (runtime and builder stages)
- Update `streams.yml` `rhel9` entry: `ubi9/ubi:latest` → `ubi9/ubi-minimal:latest` (floating tag, not digest-pinned)
- **Switch all images to RHEL 9.8 E4S RPM repos** (`rhel-98-*`), replacing RHEL 9.6 EUS (`rhel-9-*`)
- **Bump JDTLS artifact lockfile to 1.60.0** (`mta-jdtls-server-base`) — Eclipse removed the 1.51.0 milestone tarball
- **Generic cachi2 artifact filenames** in lockfile (`jdtls-product.tar.gz`, etc.) aligned with [migtools/mta-java-analyzer-bundle#15](https://github.com/migtools/mta-java-analyzer-bundle/pull/15)

### Rationale: RHEL 9.8 repo alignment

`base-rhel9` is built from floating `ubi-minimal:latest`, which tracks **RHEL 9.8** content (`openssl-libs` 3.5.x, updated crypto-policies, etc.). Several MTA Dockerfiles run `dnf install` on the runtime stage (e.g. `openssl`, `nodejs`, `npm`).

Jenkins layered-products **#8088** showed that images still on **9.6-only** lockfile repos fail with depsolve conflicts: cachi2 mounts 9.6 EUS repos while `@System` already has 9.8 packages from `base-rhel9` (e.g. `openssl-libs-3.5.5-4.el9_8` vs `openssl-3.2.2-7.el9_6`).

MTA 8.2 had already started a partial migration (some addon images had hybrid 9.6+9.8 repos; `mta-python-external-provider` was 9.8-only). This change completes the migration to **9.8-only** `enabled_repos` for the whole group, matching the floating UBI base.

> **Note:** MTA 8.1 (PR #11595) intentionally stays on **RHEL 9.6 EUS** with a pinned UBI digest for z-stream stability — 9.8 repo migration and JDTLS 1.60.0 apply to **8.2 only** (8.1 JDTLS path TBD with MTA team).

### Upstream dependencies (merged)

| Repo | PR | Change |
|------|-----|--------|
| migtools/mta-java-analyzer-bundle | [#15](https://github.com/migtools/mta-java-analyzer-bundle/pull/15) | Generic cachi2 `cp` paths in `konflux.Dockerfile` |
| migtools/mta-java-analyzer-bundle | [#16](https://github.com/migtools/mta-java-analyzer-bundle/pull/16) | Remove debug `RUN dnf module list` (microdnf on `base-rhel9`) |

Both forwarded to `openshift-priv/migtools-mta-java-analyzer-bundle` @ `9fde0c7`.

## Test plan

### Validation passed

Jenkins layered-products **[#8226](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/8226/)** — **SUCCESS**, **19/19 images**, ~67 min

| Parameter | Value |
|-----------|-------|
| GROUP | `mta-8.2` |
| ASSEMBLY | `test` |
| DOOZER_DATA_PATH | `https://github.com/fbladilo/ocp-build-data` |
| DOOZER_DATA_GITREF | `mta-8.2-base-rhel9` |
| IMAGE_BUILD_STRATEGY | `all` |
| IGNORE_LOCKS | `true` |
| DRY_RUN / MOCK | `false` |

Earlier debugging runs: **#8088** (9.6/9.8 openssl skew) → **#8163** (JDTLS rebase fixed, PLR failed on `dnf module list`) → **#8226** (full green after upstream #15/#16).

### Optional follow-up

- Update `konflux-release-data` conforma policy for JDTLS 1.60.0 SHA256 if EC tests require it