### PR TITLE
[4.19] Remove delivery.repo_name attribute from all images

### DIFF
--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: atomic-openshift-cluster-autoscaler-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-autoscaler
   delivery_repo_names:
   - openshift4/ose-cluster-autoscaler-rhel9
 for_payload: true

--- a/images/aws-karpenter-provider-aws.yml
+++ b/images/aws-karpenter-provider-aws.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: aws-karpenter-provider-aws-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: aws-karpenter-provider-aws
   delivery_repo_names:
   - openshift4/aws-karpenter-provider-aws-rhel9
 for_payload: true

--- a/images/aws-kms-encryption-provider.yml
+++ b/images/aws-kms-encryption-provider.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: aws-kms-encryption-provider-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: aws-kms-encryption-provider
   delivery_repo_names:
   - openshift4/aws-kms-encryption-provider-rhel9
 for_payload: true

--- a/images/azure-file-csi-driver-operator.yml
+++ b/images/azure-file-csi-driver-operator.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-file-csi-driver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-azure-file-csi-driver-operator
   delivery_repo_names:
   - openshift4/ose-azure-file-csi-driver-operator-rhel9
 for_payload: true

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-file-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-azure-file-csi-driver
   delivery_repo_names:
   - openshift4/ose-azure-file-csi-driver-rhel9
 enabled_repos:

--- a/images/azure-kms-encryption-provider.yml
+++ b/images/azure-kms-encryption-provider.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: azure-kms-encryption-provider-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: azure-kms-encryption-provider
   delivery_repo_names:
   - openshift4/azure-kms-encryption-provider-rhel9
 for_payload: true

--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: baremetal-machine-controller-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-baremetal-machine-controllers
   delivery_repo_names:
   - openshift4/ose-baremetal-machine-controllers-rhel9
 for_payload: true

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-runtimecfg-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-baremetal-runtimecfg
   delivery_repo_names:
   - openshift4/ose-baremetal-runtimecfg-rhel9
 enabled_repos:

--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cloud-event-proxy-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cloud-event-proxy
   delivery_repo_names:
   - openshift4/ose-cloud-event-proxy-rhel9
 for_payload: false

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-etcd-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-etcd-operator
   delivery_repo_names:
   - openshift4/ose-cluster-etcd-rhel9-operator
 for_payload: true

--- a/images/cluster-monitoring-operator.yml
+++ b/images/cluster-monitoring-operator.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-monitoring-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-monitoring-operator
   delivery_repo_names:
   - openshift4/ose-cluster-monitoring-rhel9-operator
 for_payload: true

--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-network-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-network-operator
   delivery_repo_names:
   - openshift4/ose-cluster-network-rhel9-operator
 for_payload: true

--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -15,8 +15,6 @@ distgit:
   bundle_component: cluster-nfd-operator-metadata-container
   component: cluster-nfd-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-nfd-operator
   bundle_delivery_repo_name: openshift4/ose-cluster-nfd-operator-bundle
   delivery_repo_names:
   - openshift4/ose-cluster-nfd-rhel9-operator

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-node-tuning-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-node-tuning-operator
   delivery_repo_names:
   - openshift4/ose-cluster-node-tuning-rhel9-operator
 enabled_repos:

--- a/images/cluster-policy-controller.yml
+++ b/images/cluster-policy-controller.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-policy-controller-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-policy-controller
   delivery_repo_names:
   - openshift4/ose-cluster-policy-controller-rhel9
 for_payload: true

--- a/images/cluster-storage-operator.yml
+++ b/images/cluster-storage-operator.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-storage-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-storage-operator
   delivery_repo_names:
   - openshift4/ose-cluster-storage-rhel9-operator
 for_payload: true

--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: cluster-version-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-version-operator
   delivery_repo_names:
   - openshift4/ose-cluster-version-rhel9-operator
 for_payload: true

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -15,8 +15,6 @@ distgit:
   bundle_component: ose-clusterresourceoverride-operator-metadata-container
   component: ose-clusterresourceoverride-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-clusterresourceoverride-operator
   bundle_delivery_repo_name: openshift4/ose-clusterresourceoverride-operator-bundle
   delivery_repo_names:
   - openshift4/ose-clusterresourceoverride-rhel9-operator

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-clusterresourceoverride-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-clusterresourceoverride
   delivery_repo_names:
   - openshift4/ose-clusterresourceoverride-rhel9
 for_payload: false

--- a/images/configmap-reload.yml
+++ b/images/configmap-reload.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: configmap-reload-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-configmap-reloader
   delivery_repo_names:
   - openshift4/ose-configmap-reloader-rhel9
 for_payload: true

--- a/images/container-networking-plugins-microshift.yml
+++ b/images/container-networking-plugins-microshift.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: container-networking-plugins-microshift-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: container-networking-plugins-microshift
   delivery_repo_names:
   - openshift4/container-networking-plugins-microshift-rhel9
 enabled_repos:

--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: coredns-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-coredns
   delivery_repo_names:
   - openshift4/ose-coredns-rhel9
 for_payload: true

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-attacher-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-external-attacher
   delivery_repo_names:
   - openshift4/ose-csi-external-attacher-rhel9
 for_payload: true

--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-driver-manila-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-driver-manila-operator
   delivery_repo_names:
   - openshift4/ose-csi-driver-manila-rhel9-operator
 for_payload: true

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-driver-manila-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-driver-manila
   delivery_repo_names:
   - openshift4/ose-csi-driver-manila-rhel9
 for_payload: true

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-driver-nfs-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-driver-nfs
   delivery_repo_names:
   - openshift4/ose-csi-driver-nfs-rhel9
 enabled_repos:

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -23,8 +23,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-livenessprobe-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-livenessprobe
   delivery_repo_names:
   - openshift4/ose-csi-livenessprobe-rhel9
 for_payload: true

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -23,8 +23,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-node-driver-registrar-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-node-driver-registrar
   delivery_repo_names:
   - openshift4/ose-csi-node-driver-registrar-rhel9
 for_payload: true

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: csi-provisioner-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-external-provisioner
   delivery_repo_names:
   - openshift4/ose-csi-external-provisioner-rhel9
 for_payload: true

--- a/images/dpu-cni.yml
+++ b/images/dpu-cni.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: dpu-cni-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-dpu-cni
   delivery_repo_names:
   - openshift4/ose-dpu-cni-rhel9
 for_payload: false

--- a/images/dpu-daemon.yml
+++ b/images/dpu-daemon.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: dpu-daemon-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-dpu-daemon
   delivery_repo_names:
   - openshift4/ose-dpu-daemon-rhel9
 enabled_repos:

--- a/images/dpu-intel-ipu-p4sdk.yml
+++ b/images/dpu-intel-ipu-p4sdk.yml
@@ -28,7 +28,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: dpu-intel-ipu-p4sdk-container
 delivery:
-  repo_name: ose-dpu-intel-ipu-p4sdk
   delivery_repo_names:
   - openshift4/ose-dpu-intel-ipu-p4sdk-rhel9
 for_payload: false

--- a/images/dpu-intel-ipu-vsp.yml
+++ b/images/dpu-intel-ipu-vsp.yml
@@ -35,7 +35,6 @@ enabled_repos:
 - rhel-9-fast-datapath-rpms
 - rhel-9-server-ose-rpms-embargoed
 delivery:
-  repo_name: ose-dpu-intel-ipu-vsp
   delivery_repo_names:
   - openshift4/ose-dpu-intel-ipu-vsp-rhel9
 for_payload: false

--- a/images/dpu-operator.yml
+++ b/images/dpu-operator.yml
@@ -15,8 +15,6 @@ distgit:
   bundle_component: dpu-operator-bundle-container
   component: dpu-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-dpu-operator
   bundle_delivery_repo_name: openshift4/ose-dpu-operator-bundle
   delivery_repo_names:
   - openshift4/ose-dpu-rhel9-operator

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: driver-toolkit-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: driver-toolkit
   delivery_repo_names:
   - openshift4/driver-toolkit-rhel9
 enabled_repos:

--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-egress-router-cni-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: egress-router-cni
   delivery_repo_names:
   - openshift4/egress-router-cni-rhel9
 enabled_repos:

--- a/images/gcp-workload-identity-federation-webhook.yml
+++ b/images/gcp-workload-identity-federation-webhook.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: gcp-workload-identity-federation-webhook-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-gcp-workload-identity-federation-webhook
   delivery_repo_names:
   - openshift4/ose-gcp-workload-identity-federation-webhook-rhel9
 for_payload: true

--- a/images/golang-github-openshift-oauth-proxy.yml
+++ b/images/golang-github-openshift-oauth-proxy.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: golang-github-openshift-oauth-proxy-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-oauth-proxy
   delivery_repo_names:
   - openshift4/ose-oauth-proxy-rhel9
 for_payload: true

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: golang-github-prometheus-alertmanager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-prometheus-alertmanager
   delivery_repo_names:
   - openshift4/ose-prometheus-alertmanager-rhel9
 enabled_repos:

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: golang-github-prometheus-node_exporter-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-prometheus-node-exporter
   delivery_repo_names:
   - openshift4/ose-prometheus-node-exporter-rhel9
 enabled_repos:

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: golang-github-prometheus-prometheus-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-prometheus
   delivery_repo_names:
   - openshift4/ose-prometheus-rhel9
 enabled_repos:

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-hypershift-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-hypershift
   delivery_repo_names:
   - openshift4/ose-hypershift-rhel9
 for_payload: true

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ib-sriov-cni-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-sriov-infiniband-cni
   delivery_repo_names:
   - openshift4/ose-sriov-infiniband-cni-rhel9
 for_payload: false

--- a/images/ingress-node-firewall-daemon.yml
+++ b/images/ingress-node-firewall-daemon.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ingress-node-firewall-daemon-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ingress-node-firewall
   delivery_repo_names:
   - openshift4/ingress-node-firewall-rhel9
 dependents:

--- a/images/ingress-node-firewall-operator.yml
+++ b/images/ingress-node-firewall-operator.yml
@@ -15,8 +15,6 @@ distgit:
   bundle_component: ingress-node-firewall-operator-bundle-container
   component: ingress-node-firewall-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ingress-node-firewall-operator
   bundle_delivery_repo_name: openshift4/ingress-node-firewall-operator-bundle
   delivery_repo_names:
   - openshift4/ingress-node-firewall-rhel9-operator

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -25,8 +25,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ironic-agent-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ironic-agent
   delivery_repo_names:
   - openshift4/ose-ironic-agent-rhel9
 for_payload: true

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ironic-rhcos-downloader-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ironic-machine-os-downloader
   delivery_repo_names:
   - openshift4/ose-ironic-machine-os-downloader-rhel9
 enabled_repos:

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ironic-static-ip-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ironic-static-ip-manager
   delivery_repo_names:
   - openshift4/ose-ironic-static-ip-manager-rhel9
 enabled_repos:

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -25,8 +25,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ironic-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ironic
   delivery_repo_names:
   - openshift4/ose-ironic-rhel9
 enabled_repos:

--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: kube-compare-artifacts-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: kube-compare-artifacts
   delivery_repo_names:
   - openshift4/kube-compare-artifacts-rhel9
 for_payload: false

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: kube-proxy-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-kube-proxy
   delivery_repo_names:
   - openshift4/ose-kube-proxy-rhel9
 enabled_repos:

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -27,8 +27,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: kube-rbac-proxy-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-kube-rbac-proxy
   delivery_repo_names:
   - openshift4/ose-kube-rbac-proxy-rhel9
 for_payload: true

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: kube-state-metrics-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-kube-state-metrics
   delivery_repo_names:
   - openshift4/ose-kube-state-metrics-rhel9
 for_payload: true

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -20,8 +20,6 @@ distgit:
   component: ose-linuxptp-daemon-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ptp
   delivery_repo_names:
   - openshift4/ose-ptp-rhel9
 enabled_repos:

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: local-storage-diskmaker-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-local-storage-diskmaker
   delivery_repo_names:
   - openshift4/ose-local-storage-diskmaker-rhel9
 enabled_repos:

--- a/images/local-storage-mustgather.yml
+++ b/images/local-storage-mustgather.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-local-storage-mustgather-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-local-storage-mustgather
   delivery_repo_names:
   - openshift4/ose-local-storage-mustgather-rhel9
 dependents:

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: local-storage-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-local-storage-operator
   bundle_delivery_repo_name: openshift4/ose-local-storage-operator-bundle
   delivery_repo_names:
   - openshift4/ose-local-storage-rhel9-operator

--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: marketplace-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-operator-marketplace
   delivery_repo_names:
   - openshift4/ose-operator-marketplace-rhel9
 for_payload: true

--- a/images/monitoring-plugin.yml
+++ b/images/monitoring-plugin.yml
@@ -26,8 +26,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: monitoring-plugin-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-monitoring-plugin
   delivery_repo_names:
   - openshift4/ose-monitoring-plugin-rhel9
 for_payload: true

--- a/images/multus-cni-container-microshift.yml
+++ b/images/multus-cni-container-microshift.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: multus-cni-container-microshift-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-multus-cni-microshift
   delivery_repo_names:
   - openshift4/ose-multus-cni-microshift-rhel9
 enabled_repos:

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: multus-cni-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-multus-cni
   delivery_repo_names:
   - openshift4/ose-multus-cni-rhel9
 enabled_repos:

--- a/images/multus-networkpolicy.yml
+++ b/images/multus-networkpolicy.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-networkpolicy-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-multus-networkpolicy
   delivery_repo_names:
   - openshift4/ose-multus-networkpolicy-rhel9
 enabled_repos:

--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: networking-console-plugin-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-networking-console-plugin
   delivery_repo_names:
   - openshift4/ose-networking-console-plugin-rhel9
 enabled_repos:

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -24,8 +24,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: nmstate-console-plugin-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: nmstate-console-plugin
   delivery_repo_names:
   - openshift4/nmstate-console-plugin-rhel9
 enabled_repos:

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: node-feature-discovery-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-node-feature-discovery
   delivery_repo_names:
   - openshift4/ose-node-feature-discovery-rhel9
 for_payload: false

--- a/images/oauth-server.yml
+++ b/images/oauth-server.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: oauth-server-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-oauth-server
   delivery_repo_names:
   - openshift4/ose-oauth-server-rhel9
 for_payload: true

--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: oc-mirror-plugin-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: oc-mirror-plugin
   delivery_repo_names:
   - openshift4/oc-mirror-plugin-rhel9
 for_payload: true

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -29,8 +29,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-ansible-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ansible-operator
   delivery_repo_names:
   - openshift4/ose-ansible-rhel9-operator
 enabled_repos:

--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-builder-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-docker-builder
   delivery_repo_names:
   - openshift4/ose-docker-builder-rhel9
 enabled_repos:

--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -15,8 +15,6 @@ distgit:
   component: openshift-enterprise-cli-container
   namespace: containers
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cli
   delivery_repo_names:
   - openshift4/ose-cli-rhel9
 for_payload: true

--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-cluster-capacity-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-capacity
   delivery_repo_names:
   - openshift4/ose-cluster-capacity-rhel9
 for_payload: false

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-console-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-console-operator
   delivery_repo_names:
   - openshift4/ose-console-rhel9-operator
 for_payload: true

--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -17,7 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-console-container
 delivery:
-  repo_name: ose-console
   delivery_repo_names:
   - openshift4/ose-console-rhel9
 for_payload: true

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -11,8 +11,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-deployer-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-deployer
   delivery_repo_names:
   - openshift4/ose-deployer-rhel9
 for_payload: true

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -11,8 +11,6 @@ distgit:
   component: openshift-enterprise-egress-dns-proxy-container
   namespace: containers
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-egress-dns-proxy
   delivery_repo_names:
   - openshift4/ose-egress-dns-proxy-rhel9
 enabled_repos:

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -10,8 +10,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-egress-router-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-egress-router
   delivery_repo_names:
   - openshift4/ose-egress-router-rhel9
 enabled_repos:

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -10,8 +10,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-haproxy-router-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-haproxy-router
   delivery_repo_names:
   - openshift4/ose-haproxy-router-rhel9
 enabled_repos:

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-helm-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-helm-operator
   delivery_repo_names:
   - openshift4/ose-helm-rhel9-operator
 for_payload: false

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-hyperkube-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-hyperkube
   delivery_repo_names:
   - openshift4/ose-hyperkube-rhel9
 enabled_repos:

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -12,8 +12,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-keepalived-ipfailover-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-keepalived-ipfailover
   delivery_repo_names:
   - openshift4/ose-keepalived-ipfailover-rhel9
 enabled_repos:

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-pod-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-pod
   delivery_repo_names:
   - openshift4/ose-pod-rhel9
 for_payload: true

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-enterprise-registry-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-docker-registry
   delivery_repo_names:
   - openshift4/ose-docker-registry-rhel9
 enabled_repos:

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -15,8 +15,6 @@ distgit:
   component: openshift-enterprise-tests-container
   namespace: containers
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-tests
   delivery_repo_names:
   - openshift4/ose-tests-rhel9
 enabled_repos:

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -16,8 +16,6 @@ distgit:
   component: openshift-kubernetes-nmstate-handler-rhel-9-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-kubernetes-nmstate-handler
   delivery_repo_names:
   - openshift4/ose-kubernetes-nmstate-handler-rhel9
 enabled_repos:

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -15,8 +15,6 @@ distgit:
   bundle_component: ose-kubernetes-nmstate-operator-bundle-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: kubernetes-nmstate-operator
   bundle_delivery_repo_name: openshift4/kubernetes-nmstate-operator-bundle
   delivery_repo_names:
   - openshift4/kubernetes-nmstate-rhel9-operator

--- a/images/openshift-state-metrics.yml
+++ b/images/openshift-state-metrics.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openshift-state-metrics-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-openshift-state-metrics
   delivery_repo_names:
   - openshift4/ose-openshift-state-metrics-rhel9
 for_payload: true

--- a/images/openstack-cluster-api-controllers.yml
+++ b/images/openstack-cluster-api-controllers.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openstack-cluster-api-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-openstack-cluster-api-controllers
   delivery_repo_names:
   - openshift4/ose-openstack-cluster-api-controllers-rhel9
 for_payload: true

--- a/images/openstack-resource-controller.yml
+++ b/images/openstack-resource-controller.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: openstack-resource-controller-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: openstack-resource-controller
   delivery_repo_names:
   - openshift4/openstack-resource-controller-rhel9
 for_payload: true

--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: operator-lifecycle-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-operator-lifecycle-manager
   delivery_repo_names:
   - openshift4/ose-operator-lifecycle-manager-rhel9
 for_payload: true

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: operator-registry-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-operator-registry
   delivery_repo_names:
   - openshift4/ose-operator-registry-rhel9
 for_payload: true

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-api-server-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-agent-installer-api-server
   delivery_repo_names:
   - openshift4/ose-agent-installer-api-server-rhel9
 enabled_repos:

--- a/images/ose-agent-installer-csr-approver.yml
+++ b/images/ose-agent-installer-csr-approver.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-csr-approver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-agent-installer-csr-approver
   delivery_repo_names:
   - openshift4/ose-agent-installer-csr-approver-rhel9
 enabled_repos:

--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-node-agent-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-agent-installer-node-agent
   delivery_repo_names:
   - openshift4/ose-agent-installer-node-agent-rhel9
 enabled_repos:

--- a/images/ose-agent-installer-orchestrator.yml
+++ b/images/ose-agent-installer-orchestrator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-orchestrator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-agent-installer-orchestrator
   delivery_repo_names:
   - openshift4/ose-agent-installer-orchestrator-rhel9
 for_payload: true

--- a/images/ose-agent-installer-utils.yml
+++ b/images/ose-agent-installer-utils.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-agent-installer-utils-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-agent-installer-utils
   delivery_repo_names:
   - openshift4/ose-agent-installer-utils-rhel9
 enabled_repos:

--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-apiserver-network-proxy-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-apiserver-network-proxy
   delivery_repo_names:
   - openshift4/ose-apiserver-network-proxy-rhel9
 for_payload: true

--- a/images/ose-aws-cloud-controller-manager.yml
+++ b/images/ose-aws-cloud-controller-manager.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-cloud-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-aws-cloud-controller-manager
   delivery_repo_names:
   - openshift4/ose-aws-cloud-controller-manager-rhel9
 for_payload: true

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-cluster-api-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-aws-cluster-api-controllers
   delivery_repo_names:
   - openshift4/ose-aws-cluster-api-controllers-rhel9
 for_payload: true

--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-ebs-csi-driver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-aws-ebs-csi-driver-operator
   delivery_repo_names:
   - openshift4/ose-aws-ebs-csi-driver-rhel9-operator
 for_payload: true

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-ebs-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-aws-ebs-csi-driver
   delivery_repo_names:
   - openshift4/ose-aws-ebs-csi-driver-rhel9
 enabled_repos:

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -21,8 +21,6 @@ distgit:
   component: ose-aws-efs-csi-driver-operator-container
   bundle_component: ose-aws-efs-csi-driver-operator-bundle-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-aws-efs-csi-driver-operator
   bundle_delivery_repo_name: openshift4/ose-aws-efs-csi-driver-operator-bundle
   delivery_repo_names:
   - openshift4/ose-aws-efs-csi-driver-rhel9-operator

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -23,8 +23,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-efs-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-aws-efs-csi-driver-container
   delivery_repo_names:
   - openshift4/ose-aws-efs-csi-driver-container-rhel9
 for_payload: false

--- a/images/ose-aws-pod-identity-webhook.yml
+++ b/images/ose-aws-pod-identity-webhook.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-aws-pod-identity-webhook-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-aws-pod-identity-webhook
   delivery_repo_names:
   - openshift4/ose-aws-pod-identity-webhook-rhel9
 for_payload: true

--- a/images/ose-azure-cloud-controller-manager.yml
+++ b/images/ose-azure-cloud-controller-manager.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-cloud-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-azure-cloud-controller-manager
   delivery_repo_names:
   - openshift4/ose-azure-cloud-controller-manager-rhel9
 for_payload: true

--- a/images/ose-azure-cloud-node-manager.yml
+++ b/images/ose-azure-cloud-node-manager.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-cloud-node-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-azure-cloud-node-manager
   delivery_repo_names:
   - openshift4/ose-azure-cloud-node-manager-rhel9
 for_payload: true

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-cluster-api-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-azure-cluster-api-controllers
   delivery_repo_names:
   - openshift4/ose-azure-cluster-api-controllers-rhel9
 for_payload: true

--- a/images/ose-azure-disk-csi-driver-operator.yml
+++ b/images/ose-azure-disk-csi-driver-operator.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-disk-csi-driver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-azure-disk-csi-driver-operator
   delivery_repo_names:
   - openshift4/ose-azure-disk-csi-driver-rhel9-operator
 for_payload: true

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-disk-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-azure-disk-csi-driver
   delivery_repo_names:
   - openshift4/ose-azure-disk-csi-driver-rhel9
 enabled_repos:

--- a/images/ose-azure-service-operator.yml
+++ b/images/ose-azure-service-operator.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-service-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: azure-service-operator
   delivery_repo_names:
   - openshift4/azure-service-rhel9-operator
 for_payload: true

--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-azure-workload-identity-webhook-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-azure-workload-identity-webhook
   delivery_repo_names:
   - openshift4/ose-azure-workload-identity-webhook-rhel9
 for_payload: true

--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-cluster-api-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-baremetal-cluster-api-controllers
   delivery_repo_names:
   - openshift4/ose-baremetal-cluster-api-controllers-rhel9
 for_payload: true

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-installer-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-baremetal-installer
   delivery_repo_names:
   - openshift4/ose-baremetal-installer-rhel9
 enabled_repos:

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-baremetal-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-baremetal-operator
   delivery_repo_names:
   - openshift4/ose-baremetal-rhel9-operator
 for_payload: true

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -15,8 +15,6 @@ distgit:
   component: ose-cli-artifacts-container
   namespace: containers
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cli-artifacts
   delivery_repo_names:
   - openshift4/ose-cli-artifacts-rhel9
 for_payload: true

--- a/images/ose-cloud-credential-operator.yml
+++ b/images/ose-cloud-credential-operator.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cloud-credential-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cloud-credential-operator
   delivery_repo_names:
   - openshift4/ose-cloud-credential-rhel9-operator
 for_payload: true

--- a/images/ose-cloud-network-config-controller.yml
+++ b/images/ose-cloud-network-config-controller.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cloud-network-config-controller-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: cloud-network-config-controller
   delivery_repo_names:
   - openshift4/cloud-network-config-controller-rhel9
 for_payload: true

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-api-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-api
   delivery_repo_names:
   - openshift4/ose-cluster-api-rhel9
 for_payload: true

--- a/images/ose-cluster-authentication-operator.yml
+++ b/images/ose-cluster-authentication-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-authentication-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-authentication-operator
   delivery_repo_names:
   - openshift4/ose-cluster-authentication-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-autoscaler-operator.yml
+++ b/images/ose-cluster-autoscaler-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-autoscaler-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-autoscaler-operator
   delivery_repo_names:
   - openshift4/ose-cluster-autoscaler-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-baremetal-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-baremetal-operator
   delivery_repo_names:
   - openshift4/ose-cluster-baremetal-operator-rhel9
 for_payload: true

--- a/images/ose-cluster-bootstrap.yml
+++ b/images/ose-cluster-bootstrap.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-bootstrap-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-bootstrap
   delivery_repo_names:
   - openshift4/ose-cluster-bootstrap-rhel9
 for_payload: true

--- a/images/ose-cluster-capi-operator.yml
+++ b/images/ose-cluster-capi-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-capi-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-capi-operator
   delivery_repo_names:
   - openshift4/ose-cluster-capi-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-cloud-controller-manager-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-cloud-controller-manager-operator
   delivery_repo_names:
   - openshift4/ose-cluster-cloud-controller-manager-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-config-api.yml
+++ b/images/ose-cluster-config-api.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-config-api-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-config-api
   delivery_repo_names:
   - openshift4/ose-cluster-config-api-rhel9
 for_payload: true

--- a/images/ose-cluster-config-operator.yml
+++ b/images/ose-cluster-config-operator.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-config-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-config-operator
   delivery_repo_names:
   - openshift4/ose-cluster-config-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-control-plane-machine-set-operator.yml
+++ b/images/ose-cluster-control-plane-machine-set-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-control-plane-machine-set-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-control-plane-machine-set-operator
   delivery_repo_names:
   - openshift4/ose-cluster-control-plane-machine-set-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-csi-snapshot-controller-operator.yml
+++ b/images/ose-cluster-csi-snapshot-controller-operator.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-csi-snapshot-controller-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-csi-snapshot-controller-operator
   delivery_repo_names:
   - openshift4/ose-cluster-csi-snapshot-controller-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-dns-operator.yml
+++ b/images/ose-cluster-dns-operator.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-dns-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-dns-operator
   delivery_repo_names:
   - openshift4/ose-cluster-dns-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-image-registry-operator.yml
+++ b/images/ose-cluster-image-registry-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-image-registry-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-image-registry-operator
   delivery_repo_names:
   - openshift4/ose-cluster-image-registry-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-ingress-operator.yml
+++ b/images/ose-cluster-ingress-operator.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-ingress-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-ingress-operator
   delivery_repo_names:
   - openshift4/ose-cluster-ingress-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-kube-apiserver-operator.yml
+++ b/images/ose-cluster-kube-apiserver-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-apiserver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-kube-apiserver-operator
   delivery_repo_names:
   - openshift4/ose-cluster-kube-apiserver-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-kube-cluster-api-operator.yml
+++ b/images/ose-cluster-kube-cluster-api-operator.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-cluster-api-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-kube-cluster-api-operator
   delivery_repo_names:
   - openshift4/ose-cluster-kube-cluster-api-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-kube-controller-manager-operator.yml
+++ b/images/ose-cluster-kube-controller-manager-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-controller-manager-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-kube-controller-manager-operator
   delivery_repo_names:
   - openshift4/ose-cluster-kube-controller-manager-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-scheduler-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-kube-scheduler-operator
   delivery_repo_names:
   - openshift4/ose-cluster-kube-scheduler-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-kube-storage-version-migrator-operator.yml
+++ b/images/ose-cluster-kube-storage-version-migrator-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-kube-storage-version-migrator-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-kube-storage-version-migrator-operator
   delivery_repo_names:
   - openshift4/ose-cluster-kube-storage-version-migrator-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-machine-approver.yml
+++ b/images/ose-cluster-machine-approver.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-machine-approver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-machine-approver
   delivery_repo_names:
   - openshift4/ose-cluster-machine-approver-rhel9
 for_payload: true

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-olm-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-olm-operator
   delivery_repo_names:
   - openshift4/ose-cluster-olm-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-openshift-apiserver-operator.yml
+++ b/images/ose-cluster-openshift-apiserver-operator.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-openshift-apiserver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-openshift-apiserver-operator
   delivery_repo_names:
   - openshift4/ose-cluster-openshift-apiserver-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-openshift-controller-manager-operator.yml
+++ b/images/ose-cluster-openshift-controller-manager-operator.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-openshift-controller-manager-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-openshift-controller-manager-operator
   delivery_repo_names:
   - openshift4/ose-cluster-openshift-controller-manager-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-ovirt-csi-operator.yml
+++ b/images/ose-cluster-ovirt-csi-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-ovirt-csi-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ovirt-csi-driver-operator
   delivery_repo_names:
   - openshift4/ovirt-csi-driver-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-samples-operator.yml
+++ b/images/ose-cluster-samples-operator.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-samples-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-samples-operator
   delivery_repo_names:
   - openshift4/ose-cluster-samples-rhel9-operator
 for_payload: true

--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-cluster-update-keys-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-cluster-update-keys
   delivery_repo_names:
   - openshift4/ose-cluster-update-keys-rhel9
 for_payload: true

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -17,7 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-containernetworking-plugins-container
 delivery:
-  repo_name: ose-container-networking-plugins
   delivery_repo_names:
   - openshift4/ose-container-networking-plugins-rhel9
 enabled_repos:

--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-external-resizer-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-external-resizer
   delivery_repo_names:
   - openshift4/ose-csi-external-resizer-rhel9
 dependents:

--- a/images/ose-csi-external-snapshotter.yml
+++ b/images/ose-csi-external-snapshotter.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-external-snapshotter-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-external-snapshotter
   delivery_repo_names:
   - openshift4/ose-csi-external-snapshotter-rhel9
 dependents:

--- a/images/ose-csi-snapshot-controller.yml
+++ b/images/ose-csi-snapshot-controller.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-csi-snapshot-controller-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-csi-snapshot-controller
   delivery_repo_names:
   - openshift4/ose-csi-snapshot-controller-rhel9
 for_payload: true

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -10,8 +10,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-egress-http-proxy-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-egress-http-proxy
   delivery_repo_names:
   - openshift4/ose-egress-http-proxy-rhel9
 enabled_repos:

--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -34,8 +34,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-etcd-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-etcd
   delivery_repo_names:
   - openshift4/ose-etcd-rhel9
 enabled_repos:

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -10,8 +10,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-frr-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: frr
   delivery_repo_names:
   - openshift4/frr-rhel9
 enabled_repos:

--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-cloud-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-gcp-cloud-controller-manager
   delivery_repo_names:
   - openshift4/ose-gcp-cloud-controller-manager-rhel9
 name: openshift/ose-gcp-cloud-controller-manager-rhel9

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-cluster-api-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-gcp-cluster-api-controllers
   delivery_repo_names:
   - openshift4/ose-gcp-cluster-api-controllers-rhel9
 for_payload: true

--- a/images/ose-gcp-filestore-csi-driver-operator.yml
+++ b/images/ose-gcp-filestore-csi-driver-operator.yml
@@ -22,8 +22,6 @@ distgit:
   component: ose-gcp-filestore-csi-driver-operator-container
   bundle_component: ose-gcp-filestore-csi-driver-operator-bundle-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-gcp-filestore-csi-driver-operator
   bundle_delivery_repo_name: openshift4/ose-gcp-filestore-csi-driver-operator-bundle
   delivery_repo_names:
   - openshift4/ose-gcp-filestore-csi-driver-rhel9-operator

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-filestore-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-gcp-filestore-csi-driver
   delivery_repo_names:
   - openshift4/ose-gcp-filestore-csi-driver-rhel9
 dependents:

--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-pd-csi-driver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-gcp-pd-csi-driver-operator
   delivery_repo_names:
   - openshift4/ose-gcp-pd-csi-driver-operator-rhel9
 for_payload: true

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-pd-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-gcp-pd-csi-driver
   delivery_repo_names:
   - openshift4/ose-gcp-pd-csi-driver-rhel9
 enabled_repos:

--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibm-cloud-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ibm-cloud-controller-manager
   delivery_repo_names:
   - openshift4/ose-ibm-cloud-controller-manager-rhel9
 for_payload: true

--- a/images/ose-ibm-vpc-block-csi-driver-operator.yml
+++ b/images/ose-ibm-vpc-block-csi-driver-operator.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibm-vpc-block-csi-driver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ibm-vpc-block-csi-driver-operator
   delivery_repo_names:
   - openshift4/ose-ibm-vpc-block-csi-driver-rhel9-operator
 for_payload: true

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibm-vpc-block-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ibm-vpc-block-csi-driver
   delivery_repo_names:
   - openshift4/ose-ibm-vpc-block-csi-driver-rhel9
 enabled_repos:

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibmcloud-cluster-api-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ibmcloud-cluster-api-controllers
   delivery_repo_names:
   - openshift4/ose-ibmcloud-cluster-api-controllers-rhel9
 for_payload: true

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ibmcloud-machine-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ibmcloud-machine-controllers
   delivery_repo_names:
   - openshift4/ose-ibmcloud-machine-controllers-rhel9
 for_payload: true

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-image-customization-controller-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-image-customization-controller
   delivery_repo_names:
   - openshift4/ose-image-customization-controller-rhel9
 enabled_repos:

--- a/images/ose-insights-operator.yml
+++ b/images/ose-insights-operator.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-insights-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-insights-operator
   delivery_repo_names:
   - openshift4/ose-insights-rhel9-operator
 for_payload: true

--- a/images/ose-insights-runtime-exporter.yml
+++ b/images/ose-insights-runtime-exporter.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-insights-runtime-exporter-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: insights-runtime-exporter
   delivery_repo_names:
   - openshift4/insights-runtime-exporter-rhel9
 from:

--- a/images/ose-insights-runtime-extractor.yml
+++ b/images/ose-insights-runtime-extractor.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-insights-runtime-extractor-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: insights-runtime-extractor
   delivery_repo_names:
   - openshift4/insights-runtime-extractor-rhel9
 enabled_repos:

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-installer-artifacts-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-installer-artifacts
   delivery_repo_names:
   - openshift4/ose-installer-artifacts-rhel9
 for_payload: true

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -28,8 +28,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-installer-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-installer
   delivery_repo_names:
   - openshift4/ose-installer-rhel9
 for_payload: true

--- a/images/ose-kube-metrics-server.yml
+++ b/images/ose-kube-metrics-server.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-kube-metrics-server-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: kube-metrics-server
   delivery_repo_names:
   - openshift4/kube-metrics-server-rhel9
 for_payload: true

--- a/images/ose-kube-storage-version-migrator.yml
+++ b/images/ose-kube-storage-version-migrator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-kube-storage-version-migrator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-kube-storage-version-migrator
   delivery_repo_names:
   - openshift4/ose-kube-storage-version-migrator-rhel9
 for_payload: true

--- a/images/ose-kubevirt-cloud-controller-manager.yml
+++ b/images/ose-kubevirt-cloud-controller-manager.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-kubevirt-cloud-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-kubevirt-cloud-controller-manager
   delivery_repo_names:
   - openshift4/ose-kubevirt-cloud-controller-manager-rhel9
 for_payload: true

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-kubevirt-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: kubevirt-csi-driver
   delivery_repo_names:
   - openshift4/kubevirt-csi-driver-rhel9
 enabled_repos:

--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-libvirt-machine-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-libvirt-machine-controllers
   delivery_repo_names:
   - openshift4/ose-libvirt-machine-controllers-rhel9
 enabled_repos:

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-machine-api-operator
   delivery_repo_names:
   - openshift4/ose-machine-api-rhel9-operator
 for_payload: true

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-aws-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-machine-api-provider-aws
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-aws-rhel9
 for_payload: true

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-azure-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-machine-api-provider-azure
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-azure-rhel9
 for_payload: true

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-gcp-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-machine-api-provider-gcp
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-gcp-rhel9
 for_payload: true

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-api-provider-openstack-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-machine-api-provider-openstack
   delivery_repo_names:
   - openshift4/ose-machine-api-provider-openstack-rhel9
 for_payload: true

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-config-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-machine-config-operator
   delivery_repo_names:
   - openshift4/ose-machine-config-rhel9-operator
 enabled_repos:

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -13,8 +13,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-machine-os-images-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-machine-os-images
   delivery_repo_names:
   - openshift4/ose-machine-os-images-rhel9
 enabled_repos:

--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-metallb-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: metallb-operator
   bundle_delivery_repo_name: openshift4/ose-metallb-operator-bundle
   delivery_repo_names:
   - openshift4/metallb-rhel9-operator

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-metallb-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: metallb
   delivery_repo_names:
   - openshift4/metallb-rhel9
 dependents:

--- a/images/ose-multus-admission-controller.yml
+++ b/images/ose-multus-admission-controller.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-admission-controller-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-multus-admission-controller
   delivery_repo_names:
   - openshift4/ose-multus-admission-controller-rhel9
 for_payload: true

--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-route-override-cni-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-multus-route-override-cni
   delivery_repo_names:
   - openshift4/ose-multus-route-override-cni-rhel9
 for_payload: true

--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-multus-whereabouts-ipam-cni-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-multus-whereabouts-ipam-cni
   delivery_repo_names:
   - openshift4/ose-multus-whereabouts-ipam-cni-rhel9
 for_payload: true

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-must-gather-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-must-gather
   delivery_repo_names:
   - openshift4/ose-must-gather-rhel9
 enabled_repos:

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -10,8 +10,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-network-interface-bond-cni-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-network-interface-bond-cni
   delivery_repo_names:
   - openshift4/ose-network-interface-bond-cni-rhel9
 for_payload: true

--- a/images/ose-network-metrics-daemon.yml
+++ b/images/ose-network-metrics-daemon.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-network-metrics-daemon-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-network-metrics-daemon
   delivery_repo_names:
   - openshift4/ose-network-metrics-daemon-rhel9
 for_payload: true

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-network-tools-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: network-tools
   delivery_repo_names:
   - openshift4/network-tools-rhel9
 enabled_repos:

--- a/images/ose-nutanix-cloud-controller-manager.yml
+++ b/images/ose-nutanix-cloud-controller-manager.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-nutanix-cloud-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-nutanix-cloud-controller-manager
   delivery_repo_names:
   - openshift4/ose-nutanix-cloud-controller-manager-rhel9
 for_payload: true

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-nutanix-machine-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-nutanix-machine-controllers
   delivery_repo_names:
   - openshift4/ose-nutanix-machine-controllers-rhel9
 for_payload: true

--- a/images/ose-oauth-apiserver.yml
+++ b/images/ose-oauth-apiserver.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-oauth-apiserver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-oauth-apiserver
   delivery_repo_names:
   - openshift4/ose-oauth-apiserver-rhel9
 for_payload: true

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-catalogd-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-olm-catalogd
   delivery_repo_names:
   - openshift4/ose-olm-catalogd-rhel9
 for_payload: true

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-olm-operator-controller-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-olm-operator-controller
   delivery_repo_names:
   - openshift4/ose-olm-operator-controller-rhel9
 for_payload: true

--- a/images/ose-openshift-apiserver.yml
+++ b/images/ose-openshift-apiserver.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openshift-apiserver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-openshift-apiserver
   delivery_repo_names:
   - openshift4/ose-openshift-apiserver-rhel9
 for_payload: true

--- a/images/ose-openshift-controller-manager.yml
+++ b/images/ose-openshift-controller-manager.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openshift-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-openshift-controller-manager
   delivery_repo_names:
   - openshift4/ose-openshift-controller-manager-rhel9
 for_payload: true

--- a/images/ose-openstack-cinder-csi-driver-operator.yml
+++ b/images/ose-openstack-cinder-csi-driver-operator.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cinder-csi-driver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-openstack-cinder-csi-driver-operator
   delivery_repo_names:
   - openshift4/ose-openstack-cinder-csi-driver-rhel9-operator
 for_payload: true

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cinder-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-openstack-cinder-csi-driver
   delivery_repo_names:
   - openshift4/ose-openstack-cinder-csi-driver-rhel9
 enabled_repos:

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-openstack-cloud-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-openstack-cloud-controller-manager
   delivery_repo_names:
   - openshift4/ose-openstack-cloud-controller-manager-rhel9
 for_payload: true

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -15,8 +15,6 @@ distgit:
   component: ose-operator-framework-tools-container
   namespace: containers
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-operator-framework-tools
   delivery_repo_names:
   - openshift4/ose-operator-framework-tools-rhel9
 for_payload: true

--- a/images/ose-ovirt-csi-driver.yml
+++ b/images/ose-ovirt-csi-driver.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ovirt-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ovirt-csi-driver
   delivery_repo_names:
   - openshift4/ovirt-csi-driver-rhel9
 enabled_repos:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-ovn-kubernetes-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ovn-kubernetes
   delivery_repo_names:
   - openshift4/ose-ovn-kubernetes-rhel9
 enabled_repos:

--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-block-csi-driver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-powervs-block-csi-driver-operator
   delivery_repo_names:
   - openshift4/ose-powervs-block-csi-driver-rhel9-operator
 for_payload: true

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-block-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-powervs-block-csi-driver
   delivery_repo_names:
   - openshift4/ose-powervs-block-csi-driver-rhel9
 enabled_repos:

--- a/images/ose-powervs-cloud-controller-manager.yml
+++ b/images/ose-powervs-cloud-controller-manager.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-cloud-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-powervs-cloud-controller-manager
   delivery_repo_names:
   - openshift4/ose-powervs-cloud-controller-manager-rhel9
 for_payload: true

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-powervs-machine-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-powervs-machine-controllers
   delivery_repo_names:
   - openshift4/ose-powervs-machine-controllers-rhel9
 for_payload: true

--- a/images/ose-route-controller-manager.yml
+++ b/images/ose-route-controller-manager.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-route-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: openshift-route-controller-manager
   delivery_repo_names:
   - openshift4/openshift-route-controller-manager-rhel9
 for_payload: true

--- a/images/ose-secrets-store-csi-driver-operator.yml
+++ b/images/ose-secrets-store-csi-driver-operator.yml
@@ -18,8 +18,6 @@ distgit:
   component: ose-secrets-store-csi-driver-operator-container
   bundle_component: ose-secrets-store-csi-driver-operator-bundle-container # name in brew
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-secrets-store-csi-driver-operator
   bundle_delivery_repo_name: openshift4/ose-secrets-store-csi-driver-operator-bundle
   delivery_repo_names:
   - openshift4/ose-secrets-store-csi-driver-rhel9-operator

--- a/images/ose-secrets-store-csi-driver.yml
+++ b/images/ose-secrets-store-csi-driver.yml
@@ -20,7 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-secrets-store-csi-driver-container
 delivery:
-  repo_name: ose-secrets-store-csi-driver
   delivery_repo_names:
   - openshift4/ose-secrets-store-csi-driver-rhel9
 enabled_repos:

--- a/images/ose-secrets-store-csi-mustgather.yml
+++ b/images/ose-secrets-store-csi-mustgather.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-secrets-store-csi-mustgather-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-secrets-store-csi-mustgather
   delivery_repo_names:
   - openshift4/ose-secrets-store-csi-mustgather-rhel9
 for_payload: false

--- a/images/ose-service-ca-operator.yml
+++ b/images/ose-service-ca-operator.yml
@@ -14,8 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-service-ca-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-service-ca-operator
   delivery_repo_names:
   - openshift4/ose-service-ca-rhel9-operator
 for_payload: true

--- a/images/ose-smb-csi-driver-operator.yml
+++ b/images/ose-smb-csi-driver-operator.yml
@@ -18,8 +18,6 @@ distgit:
   component: ose-smb-csi-driver-operator-container
   bundle_component: ose-smb-csi-driver-operator-bundle-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-smb-csi-driver-operator
   bundle_delivery_repo_name: openshift4/ose-smb-csi-driver-operator-bundle
   delivery_repo_names:
   - openshift4/ose-smb-csi-driver-rhel9-operator

--- a/images/ose-smb-csi-driver.yml
+++ b/images/ose-smb-csi-driver.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-smb-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-smb-csi-driver
   delivery_repo_names:
   - openshift4/ose-smb-csi-driver-rhel9
 dependents:

--- a/images/ose-sriov-network-metrics-exporter.yml
+++ b/images/ose-sriov-network-metrics-exporter.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-sriov-network-metrics-exporter-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-sriov-network-metrics-exporter
   delivery_repo_names:
   - openshift4/ose-sriov-network-metrics-exporter-rhel9
 for_payload: false

--- a/images/ose-sriov-rdma-cni.yml
+++ b/images/ose-sriov-rdma-cni.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-sriov-rdma-cni-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-sriov-rdma-cni
   delivery_repo_names:
   - openshift4/ose-sriov-rdma-cni-rhel9
 for_payload: false

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -15,8 +15,6 @@ distgit:
   component: ose-tools-container
   namespace: containers
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-tools
   delivery_repo_names:
   - openshift4/ose-tools-rhel9
 enabled_repos:

--- a/images/ose-vmware-vsphere-csi-driver-operator.yml
+++ b/images/ose-vmware-vsphere-csi-driver-operator.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vmware-vsphere-csi-driver-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-vsphere-csi-driver-operator
   delivery_repo_names:
   - openshift4/ose-vmware-vsphere-csi-driver-rhel9-operator
   - openshift4/ose-vsphere-csi-driver-rhel9-operator

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vmware-vsphere-csi-driver-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-vsphere-csi-driver
   delivery_repo_names:
   - openshift4/ose-vmware-vsphere-csi-driver-rhel9
   - openshift4/ose-vsphere-csi-driver-rhel9

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vsphere-cloud-controller-manager-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-vsphere-cloud-controller-manager
   delivery_repo_names:
   - openshift4/ose-vsphere-cloud-controller-manager-rhel9
 for_payload: true

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -17,8 +17,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vsphere-cluster-api-controllers-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-vsphere-cluster-api-controllers
   delivery_repo_names:
   - openshift4/ose-vsphere-cluster-api-controllers-rhel9
 for_payload: true

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -19,8 +19,6 @@ distgit:
   component: ovn-kubernetes-microshift-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ovn-kubernetes-microshift
   delivery_repo_names:
   - openshift4/ose-ovn-kubernetes-microshift-rhel9
 for_payload: true

--- a/images/pf-status-relay-operator.yml
+++ b/images/pf-status-relay-operator.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: pf-status-relay-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: pf-status-relay-operator
   bundle_delivery_repo_name: openshift4/pf-status-relay-operator-bundle
   delivery_repo_names:
   - openshift4/pf-status-relay-rhel9-operator

--- a/images/pf-status-relay.yml
+++ b/images/pf-status-relay.yml
@@ -16,8 +16,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: pf-status-relay-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: pf-status-relay
   delivery_repo_names:
   - openshift4/pf-status-relay-rhel9
 for_payload: false

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: prom-label-proxy-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-prom-label-proxy
   delivery_repo_names:
   - openshift4/ose-prom-label-proxy-rhel9
 enabled_repos:

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: prometheus-config-reloader-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-prometheus-config-reloader
   delivery_repo_names:
   - openshift4/ose-prometheus-config-reloader-rhel9
 for_payload: true

--- a/images/prometheus-operator-admission-webhook.yml
+++ b/images/prometheus-operator-admission-webhook.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: prometheus-operator-admission-webhook-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-prometheus-operator-admission-webhook
   delivery_repo_names:
   - openshift4/ose-prometheus-operator-admission-webhook-rhel9
 for_payload: true

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -22,8 +22,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: prometheus-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-prometheus-operator
   delivery_repo_names:
   - openshift4/ose-prometheus-rhel9-operator
 for_payload: true

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ptp-operator-must-gather-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ptp-must-gather
   delivery_repo_names:
   - openshift4/ptp-must-gather-rhel9
 for_payload: false

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -20,8 +20,6 @@ distgit:
   component: ose-ptp-operator-container
   bundle_component: ose-ptp-operator-metadata-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-ptp-operator
   bundle_delivery_repo_name: openshift4/ose-ptp-operator-bundle
   delivery_repo_names:
   - openshift4/ose-ptp-rhel9-operator

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-cni-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: sriov-cni
   delivery_repo_names:
   - openshift4/sriov-cni-rhel9
 dependents:

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-dp-admission-controller-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-sriov-dp-admission-controller
   delivery_repo_names:
   - openshift4/ose-sriov-dp-admission-controller-rhel9
 for_payload: false

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-network-config-daemon-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-sriov-network-config-daemon
   delivery_repo_names:
   - openshift4/ose-sriov-network-config-daemon-rhel9
 enabled_repos:

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-network-device-plugin-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-sriov-network-device-plugin
   delivery_repo_names:
   - openshift4/ose-sriov-network-device-plugin-rhel9
 enabled_repos:

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -19,8 +19,6 @@ distgit:
   bundle_component: sriov-network-operator-metadata-container
   component: sriov-network-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-sriov-network-operator
   bundle_delivery_repo_name: openshift4/ose-sriov-network-operator-bundle
   delivery_repo_names:
   - openshift4/ose-sriov-network-rhel9-operator

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: sriov-network-webhook-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-sriov-network-webhook
   delivery_repo_names:
   - openshift4/ose-sriov-network-webhook-rhel9
 for_payload: false

--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: telemeter-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-telemeter
   delivery_repo_names:
   - openshift4/ose-telemeter-rhel9
 for_payload: true

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -21,8 +21,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-thanos-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-thanos
   delivery_repo_names:
   - openshift4/ose-thanos-rhel9
 enabled_repos:

--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -15,8 +15,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vertical-pod-autoscaler-operator-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-vertical-pod-autoscaler-operator
   bundle_delivery_repo_name: openshift4/ose-vertical-pod-autoscaler-operator-bundle
   delivery_repo_names:
   - openshift4/ose-vertical-pod-autoscaler-rhel9-operator

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -18,8 +18,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vertical-pod-autoscaler-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-vertical-pod-autoscaler
   delivery_repo_names:
   - openshift4/ose-vertical-pod-autoscaler-rhel9
 for_payload: false

--- a/images/vmware-vsphere-syncer.yml
+++ b/images/vmware-vsphere-syncer.yml
@@ -20,8 +20,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: vmware-vsphere-syncer-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-vsphere-csi-driver-syncer
   delivery_repo_names:
   - openshift4/ose-vsphere-csi-driver-syncer-rhel9
 for_payload: true

--- a/images/vsphere-problem-detector.yml
+++ b/images/vsphere-problem-detector.yml
@@ -19,8 +19,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-vsphere-problem-detector-container
 delivery:
-  # Maps to honeybadger repo_name
-  repo_name: ose-vsphere-problem-detector
   delivery_repo_names:
   - openshift4/ose-vsphere-problem-detector-rhel9
 for_payload: true


### PR DESCRIPTION
This PR removes the `delivery.repo_name` attribute from all image YAML files.

The `delivery.repo_name` attribute is no longer needed and should be removed from the image definitions.

## Changes
- Removed `delivery.repo_name` from all image YAML files under the `images/` directory

## Testing
- Verified that only the `repo_name` lines under the `delivery:` section were removed
- No other configuration changes were made