### PR TITLE
Library updates to MTC now require golang 1.25

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -23,7 +23,7 @@ ose-must-gather:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202603271447.p2.gcb9763d.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.g2aa6a05.el8
 
 rhel-8-builder:
   image: registry.redhat.io/ubi8/ubi:latest


### PR DESCRIPTION
Updated the builder to point at golang 1.25.