### PR TITLE
Use floating tags for rhel8/rhel9 base images

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -120,18 +120,12 @@ rhel-9-golang-1.23-ci-build-root:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-{MAJOR}.{MINOR}
 
 rhel8:
-  # the most recent release at present. since we yum update this, it does not need to float.
-  # it is important that we not build from unreleased builds and publish them.
-  # ubi8-container-8.10-901.1717584420
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8@sha256:143123d85045df426c5bbafc6863659880ebe276eb02c77ee868b88d08dbd05d
+  image: registry.redhat.io/ubi8/ubi:8.10
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 
 rhel9:
-  # the most recent release at present. since we yum update this, it does not need to float.
-  # it is important that we not build from unreleased builds and publish them.
-  # rhel-els-container-9.4-847.1719484506
-  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:0a4a4ab60ce8abac3edab51cacdbed25cd012a3e4169895bce2d18ed74364e08
+  image: registry.redhat.io/rhel9-4-els/rhel:latest
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
## Summary
- Switch rhel8 and rhel9 base images from sha-pinned references on `registry-proxy.engineering.redhat.com` to floating tags on `registry.redhat.io`
- rhel8: `registry.redhat.io/ubi8/ubi:8.10`
- rhel9: `registry.redhat.io/rhel9-4-els/rhel:latest`

Consistent with what was done for 4.23 in #10791 and #10795.

## Test plan
- [ ] Verify base image builds pull correctly from registry.redhat.io


🤖 Generated with [Claude Code](https://claude.com/claude-code)