### PR TITLE
ART-21503: [4.19] hyperkube on rhel98

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -572,6 +572,24 @@ repos:
       s390x: rhel-9-for-s390x-highavailability-e4s-rpms__9_DOT_6
     reposync:
       enabled: false
+
+  rhel-98-baseos:
+    conf:
+      baseurl:
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/s390x/baseos/os/
+      extra_options:
+        gpgcheck: "1"
+    content_set:
+      default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_8
+      aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_8
+      ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_8
+      s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_8
+    reposync:
+      enabled: false
+
   rhel-100-baseos:
     conf:
       baseurl:

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -10,6 +10,9 @@ content:
     - action: replace
       match: "COPY . ."
       replacement: "COPY . .\nRUN rm -rf unpacked_remote_sources"    # FIXME: Workaround for CLOUDBLD-8974
+    - action: replace
+      match: "RUN yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False iproute && yum clean all"
+      replacement: "RUN yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False iproute && yum clean all\nRUN yum upgrade -y openssl openssl-libs openssl-fips-provider openssl-fips-provider-so && yum clean all"
     ci_alignment:
       streams_prs:
         ci_build_root:

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -25,7 +25,7 @@ delivery:
   - openshift4/ose-hyperkube-rhel9
 enabled_repos:
 - rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
+- rhel-98-baseos
 for_payload: true
 base_image_release:
   force: true


### PR DESCRIPTION
Ref. [ART-21503](https://redhat.atlassian.net/browse/ART-21503)

## Test
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/39633/ ran from a patched art-tools to run ITS for `test` assembly.

[openshift-enterprise-hyperkube-container-v4.19.0-202607021328.p2.g63adf01.assembly.test.el9](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/build?nvr=openshift-enterprise-hyperkube-container-v4.19.0-202607021328.p2.g63adf01.assembly.test.el9&record_id=a12bd080-b1ed-4d83-b0ed-f48c6555c9aa&group=openshift-4.19&outcome=success&type=image) shows
```
openssl-3.5.5-4.el9_8
openssl-fips-provider-3.0.7-11.el9_8
openssl-fips-provider-so-3.0.7-11.el9_8
openssl-libs-3.5.5-4.el9_8
```