### PR TITLE
fix: revert lockfile backend to art-internal for ironic-agent and ose-containernetworking-plugins

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -44,6 +44,7 @@ enabled_repos:
 konflux:
   cachi2:
     lockfile:
+      backend: art-internal
       cross_arch: true
       rpms:
       - binutils

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -32,6 +32,10 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-container-networking-plugins-rhel9
 payload_name: container-networking-plugins
+konflux:
+  cachi2:
+    lockfile:
+      backend: art-internal
 owners:
 - nfvpe-container@redhat.com
 - dosmith@redhat.com


### PR DESCRIPTION
## Summary

The `rpm-lockfile-prototype` backend was enabled group-wide for openshift-4.19 on June 30 ([c3d19473](https://github.com/openshift-eng/ocp-build-data/commit/c3d19473)). Two images have been failing since:

- **ironic-agent**: The prototype strips bare `dnf upgrade -y` commands but fails to resolve `python3-setuptools-67.6.1` from the ironic plashet repo during lockfile generation. The lockfile pins the base image version (53.0.0) which does not satisfy the `>= 64.0.0` constraint in `prepare-image.sh`. The last successful build ([vk9nj, June 30](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ironic-agent-vk9nj)) used the old backend.

- **ose-containernetworking-plugins**: Multi-stage Dockerfile mixes rhel-9-golang and rhel-8-golang builder images. The prototype resolves all stages against el9 repos only, producing a lockfile with el9 glibc that conflicts with the el8 builder's system glibc at build time (`cannot install both glibc-2.34 and glibc-2.28`).

This PR switches both images to the `art-internal` (legacy) lockfile backend until `rpm-lockfile-prototype` handles these cases.

Slack thread: https://redhat-internal.slack.com/archives/C07RAB68T5G/p1783011121044829?thread_ts=1783002333.738549&cid=C07RAB68T5G

## Test plan

- [ ] Verify ironic-agent builds successfully in the next ocp4-konflux run for 4.19
- [ ] Verify ose-containernetworking-plugins builds successfully in the next ocp4-konflux run for 4.19