### PR TITLE
Enable per-arch recovery for ose-baremetal-installer lockfile generation

### DIFF
--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -42,6 +42,9 @@ payload_name: baremetal-installer
 owners:
 - kni-devel-deployment@redhat.com
 konflux:
+  cachi2:
+    lockfile:
+      recover_per_arch: true
   vm_override:
     x86_64: linux-c4xlarge/amd64
     aarch64: linux-c4xlarge/arm64


### PR DESCRIPTION
## Summary

- Adds konflux.cachi2.lockfile.recover_per_arch: true to ose-baremetal-installer image config
- This enables the lockfile generator per-arch package recovery for install stages (not just update-only stages)

## Problem

ose-baremetal-installer fails during rebase because nmstate pulls in dmidecode as a transitive dependency, and dmidecode only exists for x86_64/aarch64 (not s390x/ppc64le). The existing _recover_stripped_per_arch recovery in the lockfile generator is gated behind is_update_only, so it never fires for images that use dnf install.

## Fix

The recover_per_arch flag (implemented in art-tools) relaxes the guard so that arch-specific transitive dependencies can be resolved per-arch and merged back into the lockfile.

## Test plan

- [ ] Verify ose-baremetal-installer lockfile generation succeeds with the art-tools changes applied
- [ ] Confirm no regressions on other images

Made with [Cursor](https://cursor.com)