### PR TITLE
HYPBLD-847 - Introduce base-rhel9 image and replace ubi-minimal references

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -35,9 +35,9 @@ Created as part of JIRA ticket [HYPBLD-847](https://redhat.atlassian.net/browse/
 
 ## Git Source URLs
 
-- **Decision**: Use `git@github.com:stolostron/<repo>.git` directly (no openshift-priv mirrors)
-- **Rationale**: ACM repos are already public under `github.com/stolostron/`. No private mirrors exist. Verified: `grep -r "openshift-priv"` in KRD ACM tenant returns zero hits.
-- **Consequence**: `public_upstreams` section omitted from `group.yml`.
+- **Decision**: Use `git@github.com:openshift-priv/stolostron-<repo>.git` with `public_upstreams` mapping to `stolostron`
+- **Rationale**: ART builds use `openshift-priv` mirrors for hermetic source resolution. The `public_upstreams` section maps `openshift-priv` -> `stolostron` so ART can locate public sources for advisories and CVE tracking.
+- **Updated**: Originally omitted `public_upstreams`; added after enabling hermetic builds.
 
 ## Distgit Component Naming
 
@@ -80,3 +80,40 @@ Created as part of JIRA ticket [HYPBLD-847](https://redhat.atlassian.net/browse/
 
 - **Decision**: Omitted from `group.yml`
 - **Rationale**: Optional field. Many products (OCP, AAP, Serverless) don't use it. Can be added later if ACM wants QE/DOCS sign-off on FBC release MRs.
+
+## Base RHEL 9 Image (Part 5)
+
+- **Decision**: Introduce `images/base-rhel9.yml` as a layered base image on top of `ubi-minimal`
+- **Rationale**: RPMs available through ART's enabled repositories are shipped sooner than RHEL. Without a managed base image that runs `yum update`, ACM would be stuck in rebuild loops waiting for RHEL updates. This pattern is standard across all ART-managed layered products (OCP, logging-6.5, MTA 8.1, OADP 1.6).
+- **Source**: Developer request (Ashwin), reference PR openshift-eng/ocp-build-data#11595
+
+### base-rhel9 Image Name
+
+- **Decision**: `name: art-core/base-rhel9` (not `rhacm2/base-rhel9`)
+- **Rationale**: This is a shared ART infrastructure image, not an ACM product image. The `art-core/` namespace is used by all layered products for this same base image (logging-6.5, MTA 8.1). It is not shipped to customers and has `for_release: false`.
+
+### base-rhel9 Source Branch
+
+- **Decision**: Source from `openshift-base-rhel9` branch of `ocp-build-data` (shared across all products)
+- **Rationale**: The Dockerfile, `microdnf-wrapper.sh`, and `ubi.repo` on this branch are maintained by ART and shared by all layered products. No ACM-specific fork needed.
+
+### public_upstreams Override for ocp-build-data
+
+- **Decision**: Added specific `public_upstreams` entry mapping `openshift-priv/ocp-build-data` -> `openshift-eng/ocp-build-data`
+- **Rationale**: ACM's generic mapping (`openshift-priv` -> `stolostron`) does not apply to the `ocp-build-data` repo, which lives under `openshift-eng`. Without this override, ART's source resolver would look for a non-existent `stolostron/ocp-build-data`. Same issue addressed in MTA 8.1 PR#11595 (commit "Fix public_upstreams mapping").
+
+### Runtime Base Image Replacement
+
+- **Decision**: All 47 component configs changed from `from: stream: rhel9` to `from: member: base-rhel9`
+- **Rationale**: Per developer guidance (A3): "Any job that uses the existing ubi-minimal image should be replaced: stream: rhel9 -> member: base-rhel9." This ensures all ACM images layer on the managed base, receiving timely RPM updates. Builder entries using `stream: rhel9` (only `multiclusterhub-operator`) also changed.
+- **Exception**: `base-rhel9.yml` itself retains `from: stream: rhel9` since it IS the layer on top of ubi-minimal.
+
+### base-rhel9 Lockfile RPMs
+
+- **Decision**: `konflux.cachi2.lockfile.rpms: [findutils]` with `inspect_parent: false`
+- **Rationale**: Matches logging-6.5 configuration. The shared Dockerfile uses `find` implicitly, and `inspect_parent: false` is correct for a base image (no parent lockfile to inherit). The `findutils` RPM ensures hermetic builds can resolve this dependency.
+
+### base-rhel9 Ownership
+
+- **Decision**: `owners: [aos-team-art@redhat.com]` (ART team, not ACM team)
+- **Rationale**: This is an ART-maintained infrastructure image shared across products. Matches the pattern in logging-6.5 and other layered products.

--- a/group.yml
+++ b/group.yml
@@ -48,6 +48,8 @@ assemblies:
 public_upstreams:
 - private: "https://github.com/openshift-priv"
   public: "https://github.com/stolostron"
+- private: "https://github.com/openshift-priv/ocp-build-data"
+  public: "https://github.com/openshift-eng/ocp-build-data"
 
 branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 

--- a/images/acm-cli.yml
+++ b/images/acm-cli.yml
@@ -34,7 +34,7 @@ from:
   builder:
     - stream: rhel-9-golang-1.26
     - stream: rhel-8-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/acm-cli-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -20,9 +20,3 @@ name: art-core/base-rhel9
 owners:
 - aos-team-art@redhat.com
 canonical_builders_from_upstream: false
-konflux:
-  cachi2:
-    lockfile:
-      inspect_parent: false
-      rpms:
-      - findutils

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -1,0 +1,28 @@
+base_only: true
+content:
+  source:
+    git:
+      branch:
+        target: openshift-base-rhel9
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+distgit:
+  component: base-rhel9-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+for_payload: false
+for_release: false
+from:
+  stream: rhel9
+name: art-core/base-rhel9
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false
+konflux:
+  cachi2:
+    lockfile:
+      inspect_parent: false
+      rpms:
+      - findutils

--- a/images/cert-policy-controller.yml
+++ b/images/cert-policy-controller.yml
@@ -21,7 +21,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang-1.26
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/cert-policy-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-backup-controller.yml
+++ b/images/cluster-backup-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/cluster-backup-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-permission.yml
+++ b/images/cluster-permission.yml
@@ -21,7 +21,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/cluster-permission-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/config-policy-controller.yml
+++ b/images/config-policy-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.26
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/config-policy-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/console.yml
+++ b/images/console.yml
@@ -25,7 +25,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-nodejs-20
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/console-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/endpoint-monitoring-operator.yml
+++ b/images/endpoint-monitoring-operator.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/endpoint-monitoring-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/governance-policy-addon-controller.yml
+++ b/images/governance-policy-addon-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.26
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/governance-policy-addon-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/governance-policy-framework-addon.yml
+++ b/images/governance-policy-framework-addon.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.26
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/governance-policy-framework-addon-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/governance-policy-propagator.yml
+++ b/images/governance-policy-propagator.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.26
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/governance-policy-propagator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/grafana-dashboard-loader.yml
+++ b/images/grafana-dashboard-loader.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/grafana-dashboard-loader-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -25,7 +25,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/grafana-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/insights-client.yml
+++ b/images/insights-client.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/insights-client-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/insights-metrics.yml
+++ b/images/insights-metrics.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/insights-metrics-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/klusterlet-addon-controller.yml
+++ b/images/klusterlet-addon-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/klusterlet-addon-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/kube-rbac-proxy-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/kube-state-metrics-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/memcached-exporter.yml
+++ b/images/memcached-exporter.yml
@@ -24,7 +24,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/memcached-exporter-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/metrics-collector.yml
+++ b/images/metrics-collector.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/metrics-collector-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/mtv-integrations.yml
+++ b/images/mtv-integrations.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.26
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/mtv-integrations-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/multicloud-integrations.yml
+++ b/images/multicloud-integrations.yml
@@ -21,7 +21,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/multicloud-integrations-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/multicluster-observability-addon.yml
+++ b/images/multicluster-observability-addon.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/multicluster-observability-addon-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/multicluster-observability-operator.yml
+++ b/images/multicluster-observability-operator.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/multicluster-observability-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/multicluster-operators-application.yml
+++ b/images/multicluster-operators-application.yml
@@ -21,7 +21,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/multicluster-operators-application-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/multicluster-operators-channel.yml
+++ b/images/multicluster-operators-channel.yml
@@ -21,7 +21,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/multicluster-operators-channel-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/multicluster-operators-subscription.yml
+++ b/images/multicluster-operators-subscription.yml
@@ -29,7 +29,7 @@ from:
   builder:
     - stream: rhel-9-golang
     - stream: rhel-8-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/multicluster-operators-subscription-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/multicluster-role-assignment.yml
+++ b/images/multicluster-role-assignment.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/multicluster-role-assignment-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -19,9 +19,9 @@ enabled_repos:
 - rhel-9-appstream-rpms
 from:
   builder:
-    - stream: rhel9
+    - member: base-rhel9
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/multiclusterhub-operator
 update-csv:
   name: advanced-cluster-management

--- a/images/must-gather.yml
+++ b/images/must-gather.yml
@@ -31,7 +31,7 @@ from:
   builder:
     - stream: ose-cli
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/must-gather-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/node-exporter.yml
+++ b/images/node-exporter.yml
@@ -24,7 +24,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/node-exporter-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/obo-prometheus-operator.yml
+++ b/images/obo-prometheus-operator.yml
@@ -25,7 +25,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/obo-prometheus-rhel9-operator
 owners:
 - acm-cicd@redhat.com

--- a/images/observatorium-operator.yml
+++ b/images/observatorium-operator.yml
@@ -24,7 +24,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/observatorium-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/observatorium.yml
+++ b/images/observatorium.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/observatorium-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/prometheus-alertmanager.yml
+++ b/images/prometheus-alertmanager.yml
@@ -24,7 +24,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/prometheus-alertmanager-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/prometheus-config-reloader-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/prometheus-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/prometheus.yml
+++ b/images/prometheus.yml
@@ -24,7 +24,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/prometheus-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/rbac-query-proxy.yml
+++ b/images/rbac-query-proxy.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/rbac-query-proxy-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/search-collector.yml
+++ b/images/search-collector.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/search-collector-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/search-indexer.yml
+++ b/images/search-indexer.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/search-indexer-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/search-v2-api.yml
+++ b/images/search-v2-api.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/search-v2-api-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/search-v2-operator.yml
+++ b/images/search-v2-operator.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/search-v2-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/siteconfig.yml
+++ b/images/siteconfig.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/siteconfig-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/submariner-addon.yml
+++ b/images/submariner-addon.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/submariner-addon-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/thanos-receive-controller.yml
+++ b/images/thanos-receive-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/thanos-receive-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -24,7 +24,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/thanos-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/volsync-addon-controller.yml
+++ b/images/volsync-addon-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.26
-  stream: rhel9
+  member: base-rhel9
 name: rhacm2/volsync-addon-controller-rhel9
 owners:
 - acm-cicd@redhat.com


### PR DESCRIPTION
Add a managed base-rhel9 image (layered on ubi-minimal) so ACM images receive timely RPM updates without waiting for RHEL releases. Replace all stream: rhel9 references with member: base-rhel9 across 47 component configs to use the new managed base.

Ref: [HYPBLD-847](https://redhat.atlassian.net/browse/HYPBLD-847)