### PR TITLE
Enable OKD for ose-haproxy-router-haproxy28

### DIFF
--- a/images/ose-haproxy-router-haproxy28.yml
+++ b/images/ose-haproxy-router-haproxy28.yml
@@ -28,3 +28,8 @@ konflux:
   cachi2:
     lockfile:
       backend: rpm-lockfile-prototype
+okd:
+  distgit:
+    branch: rhaos-5.0-rhel-9
+  enabled_repos:
+  - rhel-9-server-ose-rpms


### PR DESCRIPTION
## Summary
- Adds an `okd:` override to `images/ose-haproxy-router-haproxy28.yml`, matching the existing pattern used by its siblings `openshift-enterprise-haproxy-router.yml` and `ose-haproxy-router-base.yml`.
- Pins the OKD distgit branch to `rhaos-5.0-rhel-9` instead of inheriting the group-level OKD branch (`rhaos-5.0-rhel-10`), since this image builds from RHEL 9 content.
- Swaps `enabled_repos` to the public `rhel-9-server-ose-rpms` instead of the embargoed variant for OKD builds.

## Why
`ose-haproxy-router-haproxy28.yml` was added in #11561 without an `okd:` block, so it was never routed through the OKD-specific config merge (`get_okd_image_config` in `images_okd.py`), and would inherit the wrong (rhel-10) OKD branch and keep the embargoed repo.

Made with [Cursor](https://cursor.com)