### PR TITLE
fix: revert ose-baremetal-installer to art-internal lockfile backend

### DIFF
--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -42,6 +42,9 @@ payload_name: baremetal-installer
 owners:
 - kni-devel-deployment@redhat.com
 konflux:
+  cachi2:
+    lockfile:
+      backend: art-internal
   vm_override:
     x86_64: linux-c4xlarge/amd64
     aarch64: linux-c4xlarge/arm64


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/openshift-eng/ocp-build-data/pull/11640.

The `rpm-lockfile-prototype` backend (enabled group-wide on June 30) breaks ose-baremetal-installer because `dmidecode` is only available on x86_64/aarch64 but not s390x/ppc64le. The backend resolves all arches in a single invocation, so any arch-missing package fails the entire resolve.

There is a per-arch recovery mechanism (`_recover_stripped_per_arch`) that handles this for **update-only** stages (bare `dnf upgrade`), but ose-baremetal-installer explicitly installs dmidecode via `dnf install`, so recovery is skipped and the rebase fails:

```
Failed to rebase ose-baremetal-installer: rpm-lockfile-prototype failed (exit code 1):
ERROR:dnf:No match for argument: dmidecode
```

Failed build: [#39653](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/39653/)

Switch to `art-internal` backend until `rpm-lockfile-prototype` extends per-arch recovery to non-update-only stages.

Slack thread: https://redhat-internal.slack.com/archives/C07RAB68T5G/p1783011121044829?thread_ts=1783002333.738549&cid=C07RAB68T5G

## Test plan

- [ ] Verify ose-baremetal-installer builds successfully in the next ocp4-konflux run for 4.19