### PR TITLE
Revert "Exclude ose-haproxy-router-haproxy28 from ec.4 assembly"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -86,10 +86,6 @@ releases:
                   git:
                     url: git@github.com:openshift-priv/gcp-pd-csi-driver-operator.git
                     web: https://github.com/openshift/gcp-pd-csi-driver-operator
-          - distgit_key: ose-haproxy-router-haproxy28
-            why: Image first built after assembly basis time (June 30 vs June 29)
-            metadata:
-              mode: disabled
   ec.3:
     assembly:
       type: preview


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#11647