### PR TITLE
ironic-agent: add okd from override for single-FROM Dockerfile.okd

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -205,3 +205,5 @@ okd:
   content:
     source:
       dockerfile: Dockerfile.okd
+  from:
+    stream: centos_stream9


### PR DESCRIPTION
## Problem

The OKD build of ironic-agent fails during rebase:

> Build metadata for ironic-agent expected 2 parent images, but found 1 in Dockerfile (1 total FROM directives, 0 are stage references)

## Root Cause

The base from: config expects 2 parent images (1 builder + 1 base) matching Dockerfile.ocp, but the okd: section only overrides the Dockerfile path to Dockerfile.okd without overriding from:.

The upstream [Dockerfile.okd](https://github.com/openshift/ironic-agent-image/blob/release-5.0/Dockerfile.okd) has a single FROM directive (FROM quay.io/centos/centos:stream9) -- no multi-stage build -- so the rebaser parent count check fails (2 != 1).

## Fix

Add from: stream: centos_stream9 under the okd: section so the metadata expects 1 parent image, matching Dockerfile.okd.

This follows the established pattern used by okd-only-upi-installer, openshift-enterprise-ansible-operator, and ose-haproxy-router-base on this branch.

Made with [Cursor](https://cursor.com)