### PR TITLE
ART-21515: 4.19 back to rpm-lockfile-prototype

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -44,7 +44,6 @@ enabled_repos:
 konflux:
   cachi2:
     lockfile:
-      backend: art-internal
       cross_arch: true
       rpms:
       - binutils

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -42,9 +42,6 @@ payload_name: baremetal-installer
 owners:
 - kni-devel-deployment@redhat.com
 konflux:
-  cachi2:
-    lockfile:
-      backend: art-internal
   vm_override:
     x86_64: linux-c4xlarge/amd64
     aarch64: linux-c4xlarge/arm64

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -32,10 +32,6 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-container-networking-plugins-rhel9
 payload_name: container-networking-plugins
-konflux:
-  cachi2:
-    lockfile:
-      backend: art-internal
 owners:
 - nfvpe-container@redhat.com
 - dosmith@redhat.com


### PR DESCRIPTION
[ironic-agent](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ironic-agent-jshx2)

[ose-baremetal-installer](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-baremetal-installer-6b2gh)

[ose-containernetworking-plugins](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-19/pipelineruns/ose-4-19-ose-containernetworking-plugins-rbgz2)

follows https://github.com/openshift-eng/art-tools/pull/3124 & https://github.com/openshift-eng/art-tools/pull/3126