### PR TITLE
ART-21515: 4.17 back to rpm-lockfile-prototype

### DIFF
--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -33,10 +33,6 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-container-networking-plugins-rhel9
 payload_name: container-networking-plugins
-konflux:
-  cachi2:
-    lockfile:
-      backend: art-internal
 owners:
 - nfvpe-container@redhat.com
 - dosmith@redhat.com


### PR DESCRIPTION
[ose-containernetworking-plugins](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-17/pipelineruns/ose-4-17-ose-containernetworking-plugins-n5x9p)

follows https://github.com/openshift-eng/art-tools/pull/3124 & https://github.com/openshift-eng/art-tools/pull/3126