### PR TITLE
ART-21515: 4.16 back to rpm-lockfile-prototype

### DIFF
--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -6,6 +6,10 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/containernetworking-plugins.git
       web: https://github.com/openshift/containernetworking-plugins
+    modifications:
+    - action: replace
+      match: "RUN yum install -y dos2unix"
+      replacement: "RUN rpm -q dos2unix || yum install -y dos2unix"
     ci_alignment:
       streams_prs:
         # Label so that this PR automatically merges if tests pass.
@@ -33,10 +37,6 @@ from:
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-container-networking-plugins-rhel9
 payload_name: container-networking-plugins
-konflux:
-  cachi2:
-    lockfile:
-      backend: art-internal
 owners:
 - nfvpe-container@redhat.com
 - dosmith@redhat.com


### PR DESCRIPTION
[ose-containernetworking-plugins](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-containernetworking-plugins-pd7fk)

follows https://github.com/openshift-eng/art-tools/pull/3124 & https://github.com/openshift-eng/art-tools/pull/3126