### PR TITLE
4.16 add memory to ose-baremetal-installer

### DIFF
--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -39,4 +39,4 @@ konflux:
   vm_override:
     # https://konflux.pages.redhat.com/docs/users/getting-started/multi-platform-builds.html#amd64-2
     x86_64: linux-d160-c4xlarge/amd64
-    aarch64: linux-c4xlarge/arm64
+    aarch64: linux-d160-c4xlarge/arm64


### PR DESCRIPTION
`/usr/lib/golang/pkg/tool/linux_arm64/link: mapping output file failed: no space left on device`

https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-baremetal-installer-2tpcs