### PR TITLE
ART-21515: 4.16 add modifications to ose-machine-config-operator

### DIFF
--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -6,6 +6,10 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-config-operator.git
       web: https://github.com/openshift/machine-config-operator
+    modifications:
+    - action: replace
+      match: "RUN --mount=type=cache,target=/var/cache/dnf,z"
+      replacement: "RUN"
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
fixes
`
[2026-07-06T10:21:23.152Z] 2026-07-06 10:21:22,894 doozerlib.lockfile_prototype.shell_parser WARNING bashlex failed to parse RUN body, skipping: unexpected token 'then' (position 74)
`


[successful build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-16/pipelineruns/ose-4-16-ose-machine-config-operator-w6lv2)