### PR TITLE
Add go1.21 builder for azure-file-csi-driver (4.15)

### DIFF
--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -31,7 +31,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.21
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-azure-file-csi-driver-rhel9
 payload_name: azure-file-csi-driver

--- a/streams.yml
+++ b/streams.yml
@@ -108,6 +108,19 @@ nodejs:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true
 
+rhel-9-golang-1.21:
+  aliases:
+    - rhel-9-golang-1.21
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21.13-202606092245.p2.gce417c9.el9
+  mirror: true
+  transform: rhel-9/golang
+  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}.art
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  upstream_image_mirror:
+    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
+
 rhel-9-golang-1-22:
   aliases:
     - rhel-9-golang-1.22


### PR DESCRIPTION
## Summary
- Re-add `rhel-9-golang-1.21` stream to `streams.yml` using the current go 1.21.13 builder image from 4.16
- Switch `azure-file-csi-driver` to build with `rhel-9-golang-1.21` instead of `rhel-9-golang` (go 1.20)

## Test plan
- [ ] Verify azure-file-csi-driver builds successfully with the go 1.21 builder
- [ ] Confirm the stream image resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)