### PR TITLE
Introduce base-rhel9 image and replace ubi-minimal references [mce-2.11]

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -66,6 +66,8 @@ public_upstreams:
   public:  "https://github.com/openshift/image-based-install-operator"
 - private: "https://github.com/openshift-priv/cluster-api-provider-agent"
   public:  "https://github.com/openshift/cluster-api-provider-agent"
+- private: "https://github.com/openshift-priv/ocp-build-data"
+  public: "https://github.com/openshift-eng/ocp-build-data"
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub

--- a/images/addon-manager.yml
+++ b/images/addon-manager.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/addon-manager-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/azure-service-operator.yml
+++ b/images/azure-service-operator.yml
@@ -35,7 +35,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/azure-service-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/backplane-must-gather.yml
+++ b/images/backplane-must-gather.yml
@@ -21,7 +21,7 @@ enabled_repos:
 from:
   builder:
     - stream: ose-cli-rhel9
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/backplane-must-gather-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -21,7 +21,7 @@ from:
   builder:
     - stream: rhel9
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/backplane-operator-rhel9
 update-csv:
   name: multicluster-engine

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -1,0 +1,22 @@
+base_only: true
+content:
+  source:
+    git:
+      branch:
+        target: openshift-base-rhel9
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+distgit:
+  component: base-rhel9-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+for_payload: false
+for_release: false
+from:
+  stream: rhel9
+name: art-core/base-rhel9
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false

--- a/images/capoa-bootstrap.yml
+++ b/images/capoa-bootstrap.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/capoa-bootstrap-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/capoa-control-plane.yml
+++ b/images/capoa-control-plane.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/capoa-control-plane-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-api-provider-agent.yml
+++ b/images/cluster-api-provider-agent.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/cluster-api-provider-agent-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-api-provider-aws.yml
+++ b/images/cluster-api-provider-aws.yml
@@ -28,7 +28,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/cluster-api-provider-aws-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-api-provider-azure.yml
+++ b/images/cluster-api-provider-azure.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/cluster-api-provider-azure-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-api-provider-kubevirt.yml
+++ b/images/cluster-api-provider-kubevirt.yml
@@ -28,7 +28,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/cluster-api-provider-kubevirt-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-api-webhook-config.yml
+++ b/images/cluster-api-webhook-config.yml
@@ -27,7 +27,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/cluster-api-webhook-config-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-curator-controller.yml
+++ b/images/cluster-curator-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/cluster-curator-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-image-set-controller.yml
+++ b/images/cluster-image-set-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/cluster-image-set-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/cluster-proxy.yml
+++ b/images/cluster-proxy.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/cluster-proxy-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/clusterclaims-controller.yml
+++ b/images/clusterclaims-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/clusterclaims-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/clusterlifecycle-state-metrics.yml
+++ b/images/clusterlifecycle-state-metrics.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/clusterlifecycle-state-metrics-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/discovery-operator.yml
+++ b/images/discovery-operator.yml
@@ -21,7 +21,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/discovery-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/hive.yml
+++ b/images/hive.yml
@@ -31,7 +31,7 @@ from:
   builder:
     - stream: rhel-8-golang-1.25
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/hive-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/hypershift-addon-operator.yml
+++ b/images/hypershift-addon-operator.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/hypershift-addon-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/hypershift-cli.yml
+++ b/images/hypershift-cli.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/hypershift-cli-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/hypershift-release.yml
+++ b/images/hypershift-release.yml
@@ -22,7 +22,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/hypershift-release-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/image-based-install-operator.yml
+++ b/images/image-based-install-operator.yml
@@ -26,7 +26,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/image-based-install-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -21,7 +21,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/kube-rbac-proxy-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/managed-serviceaccount.yml
+++ b/images/managed-serviceaccount.yml
@@ -21,7 +21,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang-1.25
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/managed-serviceaccount-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/managedcluster-import-controller-addon.yml
+++ b/images/managedcluster-import-controller-addon.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/managedcluster-import-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/multicloud-manager.yml
+++ b/images/multicloud-manager.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/multicloud-manager-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/placement.yml
+++ b/images/placement.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/placement-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/provider-credential-controller.yml
+++ b/images/provider-credential-controller.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/provider-credential-controller-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/registration-operator.yml
+++ b/images/registration-operator.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/registration-operator-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/registration.yml
+++ b/images/registration.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/registration-rhel9
 owners:
 - acm-cicd@redhat.com

--- a/images/work.yml
+++ b/images/work.yml
@@ -18,7 +18,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
-  stream: rhel9
+  member: base-rhel9
 name: multicluster-engine/work-rhel9
 owners:
 - acm-cicd@redhat.com


### PR DESCRIPTION
## Summary

Add a managed `base-rhel9` image (layered on ubi-minimal) so MCE images receive timely RPM updates without waiting for RHEL releases. Replace all runtime `stream: rhel9` references with `member: base-rhel9` across 31 component configs.

Same pattern as Brian's ACM 2.16 PR #11642 and the MTA 8.1 PR #11595.

### Changes

- **New**: `images/base-rhel9.yml` — managed base image layered on ubi-minimal
- **Modified**: 31 image configs — runtime `stream: rhel9` → `member: base-rhel9`
- **Modified**: `group.yml` — added `ocp-build-data` public_upstreams entry (required for base-rhel9 source)
- **Unchanged**: `console-mce.yml` (uses `rhel-9-nodejs-24` as runtime base, not `rhel9`)

Ref: [HYPBLD-854](https://redhat.atlassian.net/browse/HYPBLD-854)

Made with [Cursor](https://cursor.com)