### PR TITLE
Revert mta-ui enabled_repos to rhel-9 repos [mta-8.2]

### DIFF
--- a/images/mta-ui.yml
+++ b/images/mta-ui.yml
@@ -25,8 +25,8 @@ delivery:
   - mta/mta-ui-rhel9
 for_payload: false
 enabled_repos:
-- rhel-98-appstream-rpms
-- rhel-98-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-baseos-rpms
 from:
   builder:
     - stream: rhel-9-nodejs-22


### PR DESCRIPTION
## Summary
- Reverts mta-ui `enabled_repos` from `rhel-98-*` back to `rhel-9-*`
- mta-ui still uses `stream: rhel-9-nodejs-22` (UBI9 base image), not `member: base-rhel9`, so [rhel-98](https://redhat.atlassian.net/browse/rhel-98) repos are incorrect
- Fixes hermetic build failure where dnf tries to resolve `cdn-ubi.redhat.com` via the base image's default `ubi-9-baseos-rpms` repo

## Root Cause
PR #11596 changed `enabled_repos` for all MTA images to `rhel-98-*`, but mta-ui was not migrated to the new `base-rhel9` member image — it still uses `stream: rhel-9-nodejs-22`. The lockfile was generated against wrong repos, causing the hermetic build to fail.

Made with [Cursor](https://cursor.com)