### PR TITLE
[mta-8.2] Enable base_image_release for intermediary member images

### DIFF
--- a/images/mta-go-external-provider.yml
+++ b/images/mta-go-external-provider.yml
@@ -1,3 +1,5 @@
+base_image_release:
+  force: true
 cachito:
   packages:
     gomod:

--- a/images/mta-nodejs-external-provider.yml
+++ b/images/mta-nodejs-external-provider.yml
@@ -1,3 +1,5 @@
+base_image_release:
+  force: true
 cachito:
   packages:
     gomod:

--- a/images/mta-python-external-provider.yml
+++ b/images/mta-python-external-provider.yml
@@ -1,3 +1,5 @@
+base_image_release:
+  force: true
 cachito:
   packages:
     gomod:

--- a/images/mta-static-report.yml
+++ b/images/mta-static-report.yml
@@ -1,3 +1,5 @@
+base_image_release:
+  force: true
 cachito:
   packages:
     gomod:


### PR DESCRIPTION
## Summary
- Adds `base_image_release: force: true` to `mta-static-report`, `mta-go-external-provider`, `mta-nodejs-external-provider`, and `mta-python-external-provider`
- These images are used as `from.member` by other MTA images (mta-cli, mta-hub, mta-operator) and need to be released to `art-images-base` so dependent images reference the official registry rather than the temporary quay.io build location

## Why
Without this flag, doozer does not trigger the Konflux base image release for these intermediary images. Dependent child images end up with `quay.io/redhat-user-workloads/...` references instead of `registry.redhat.io/openshift/art-images-base`.


Made with [Cursor](https://cursor.com)