### PR TITLE
oadp-1.5: switch base-rhel9 images to RHEL 9.8 e4s repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -126,3 +126,33 @@ repos:
       s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_6
     reposync:
       enabled: false
+
+  rhel-98-baseos-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/baseos/os/
+    content_set:
+      default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_8
+      aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_8
+      ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_8
+      s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_8
+    reposync:
+      enabled: false
+
+  rhel-98-appstream-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.8/x86_64/appstream/os/
+    content_set:
+      default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_8
+      aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_8
+      ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_8
+      s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_8
+    reposync:
+      enabled: false

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -10,8 +10,8 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: base-rhel9-container
 enabled_repos:
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
+- rhel-98-baseos-rpms
+- rhel-98-appstream-rpms
 for_payload: false
 for_release: false
 from:

--- a/images/oadp-cli-binaries.yml
+++ b/images/oadp-cli-binaries.yml
@@ -25,8 +25,8 @@ delivery:
     - oadp/oadp-cli-binaries-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-hypershift-velero-plugin.yml
+++ b/images/oadp-hypershift-velero-plugin.yml
@@ -26,8 +26,8 @@ delivery:
     - oadp/oadp-hypershift-velero-plugin-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-kubevirt-velero-plugin.yml
+++ b/images/oadp-kubevirt-velero-plugin.yml
@@ -26,8 +26,8 @@ delivery:
     - oadp/oadp-kubevirt-velero-plugin-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-mustgather.yml
+++ b/images/oadp-mustgather.yml
@@ -26,8 +26,8 @@ delivery:
     - oadp/oadp-mustgather-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: ose-cli

--- a/images/oadp-non-admin.yml
+++ b/images/oadp-non-admin.yml
@@ -18,8 +18,8 @@ delivery:
     - oadp/oadp-non-admin-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -29,8 +29,8 @@ delivery:
     - oadp/oadp-rhel9-operator
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-velero-plugin-for-aws.yml
+++ b/images/oadp-velero-plugin-for-aws.yml
@@ -26,8 +26,8 @@ delivery:
     - oadp/oadp-velero-plugin-for-aws-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-velero-plugin-for-gcp.yml
+++ b/images/oadp-velero-plugin-for-gcp.yml
@@ -26,8 +26,8 @@ delivery:
     - oadp/oadp-velero-plugin-for-gcp-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-velero-plugin-for-legacy-aws.yml
+++ b/images/oadp-velero-plugin-for-legacy-aws.yml
@@ -26,8 +26,8 @@ delivery:
     - oadp/oadp-velero-plugin-for-legacy-aws-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-velero-plugin-for-microsoft-azure.yml
+++ b/images/oadp-velero-plugin-for-microsoft-azure.yml
@@ -26,8 +26,8 @@ delivery:
     - oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-velero-plugin.yml
+++ b/images/oadp-velero-plugin.yml
@@ -26,8 +26,8 @@ delivery:
     - oadp/oadp-velero-plugin-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/oadp-velero.yml
+++ b/images/oadp-velero.yml
@@ -29,8 +29,8 @@ delivery:
     - oadp/oadp-velero-rhel9
 for_payload: false
 enabled_repos:
-  - rhel-9-appstream-rpms
-  - rhel-9-baseos-rpms
+  - rhel-98-appstream-rpms
+  - rhel-98-baseos-rpms
 from:
   builder:
     - stream: rhel-9-golang


### PR DESCRIPTION
## Summary

`rhel9` stream in `oadp-1.5` points to `registry.redhat.io/ubi9/ubi-minimal:latest`, which resolves to a RHEL 9.8-based image. `base-rhel9` and every image built from it (`from.member: base-rhel9` / `from.stream: rhel9`) still had `enabled_repos` pinned to the RHEL 9.6 EUS `baseos`/`appstream` repos.

This causes a microdnf depsolve failure during Konflux builds, e.g.:

```
Problem: cannot install both openssl-libs-1:3.2.2-7.el9_6.2.x86_64 from rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6 and openssl-libs-1:3.5.5-4.el9_8.x86_64 from @System
 - package openssl-1:3.2.2-7.el9_6.2.x86_64 from rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6 requires openssl-libs(x86-64) = 1:3.2.2-7.el9_6.2, but none of the providers can be installed
 - package libcurl-minimal-7.76.1-40.el9.x86_64 from @System requires openssl-libs(x86-64) >= 1:3.5.1, but none of the providers can be installed
```

The base image already ships `openssl-libs 3.5.5` (RHEL 9.8), but the group's only enabled repos top out at `openssl-libs 3.2.2` (RHEL 9.6 EUS) -- an unresolvable downgrade conflict.

This is the same issue found and fixed in oadp-1.6 (openshift-eng/ocp-build-data#11704); this PR applies the identical fix to oadp-1.5, which shares the same `rhel9` stream definition and repo setup.

- Added `rhel-98-baseos-rpms` / `rhel-98-appstream-rpms` (RHEL 9.8 e4s content) to `group.yml`, covering all of oadp's arches (x86_64, aarch64, ppc64le, s390x).
- Updated `enabled_repos` in `base-rhel9.yml` and all 12 images that build from it to use the new `rhel-98-*` repos instead of the stale `rhel-9-*` (9.6 EUS) ones.
- Left the old `rhel-9-baseos-rpms` / `rhel-9-appstream-rpms` / `rhel-9-codeready-builder-rpms` repo definitions in place (unused now, but harmless) -- this mirrors the pattern already established in `mta-8.2` and `oadp-1.6`.

## Test plan

- [x] YAML validated locally (`yaml.safe_load` on all changed files)
- [x] Confirmed all affected images have `from.member: base-rhel9` (or are `base-rhel9` itself)
- [ ] Kick off an oadp-1.5 Konflux rebase/build to confirm the depsolve conflict is resolved
