### PR TITLE
[mta-8.2] Enable base_image_release for remaining intermediary member images

### DIFF
--- a/images/mta-analyzer-lsp.yml
+++ b/images/mta-analyzer-lsp.yml
@@ -1,3 +1,5 @@
+base_image_release:
+  force: true
 cachito:
   packages:
     gomod:

--- a/images/mta-java-external-provider.yml
+++ b/images/mta-java-external-provider.yml
@@ -1,3 +1,5 @@
+base_image_release:
+  force: true
 cachito:
   packages:
     gomod:

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -1,3 +1,5 @@
+base_image_release:
+  force: true
 content:
   source:
     dockerfile: konflux.Dockerfile


### PR DESCRIPTION
## Summary
- Adds `base_image_release: force: true` to `mta-analyzer-lsp`, `mta-java-external-provider`, and `mta-jdtls-server-base`
- These images are used as `from.member` by other MTA images and need to be released to `art-images-base` so dependent images reference the official registry

## Context
Follow-up to #11703 which covered `mta-static-report`, `mta-go-external-provider`, `mta-nodejs-external-provider`, and `mta-python-external-provider`. These 3 additional images were also being pulled from `quay.io/redhat-user-workloads` instead of `art-images-base`.

## Member reference chain
- `mta-jdtls-server-base` → used by `mta-java-external-provider`
- `mta-java-external-provider` → used by `mta-cli`
- `mta-analyzer-lsp` → used by `mta-analyzer-addon`


Made with [Cursor](https://cursor.com)