### PR TITLE
ART-21453: Add image config for ose-haproxy-router-haproxy32

### DIFF
--- a/images/ose-haproxy-router-haproxy32.yml
+++ b/images/ose-haproxy-router-haproxy32.yml
@@ -1,0 +1,35 @@
+content:
+  source:
+    dockerfile: images/router/haproxy32/Dockerfile.ocp
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/router.git
+      web: https://github.com/openshift/router
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ose-haproxy-router-haproxy32-container
+delivery:
+  repo_name: ose-haproxy-router-haproxy32
+  delivery_repo_names:
+  - openshift5/ose-haproxy-router-haproxy32
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
+for_payload: true
+from:
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-haproxy-router-haproxy32
+payload_name: haproxy-router-haproxy32
+owners:
+- aos-network-edge-staff@redhat.com
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype
+okd:
+  distgit:
+    branch: rhaos-5.0-rhel-9
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/ose-haproxy-router-haproxy32.yml
+++ b/images/ose-haproxy-router-haproxy32.yml
@@ -12,7 +12,7 @@ distgit:
 delivery:
   repo_name: ose-haproxy-router-haproxy32
   delivery_repo_names:
-  - openshift5/ose-haproxy-router-haproxy32
+  - openshift5/ose-haproxy-router-haproxy32-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ose-haproxy-router-haproxy32.yml
+++ b/images/ose-haproxy-router-haproxy32.yml
@@ -31,5 +31,7 @@ konflux:
 okd:
   distgit:
     branch: rhaos-5.0-rhel-9
+  from:
+    stream: centos_stream9
   enabled_repos:
   - rhel-9-server-ose-rpms


### PR DESCRIPTION
## Summary

Add new image configuration for `ose-haproxy-router-haproxy32` to the OCP 5.0 build data.

HAProxy 3.2 is being deployed as a sidecar of the router pod as part of OCPSTRAT-2943, mirroring the `ose-haproxy-router-haproxy28` config added in [ART-21452](https://redhat.atlassian.net/browse/ART-21452) (#11561, #11643).

## Details

- **Component**: `containers/haproxy-router-haproxy32`
- **Payload name**: `haproxy-router-haproxy32`
- **Image type**: CVO payload (`for_payload: true`)
- **Source**: `openshift/router` — `/images/router/haproxy32/Dockerfile.ocp`
- **Delivery repo**: `openshift5/ose-haproxy-router-haproxy32-rhel9`
- **Bug component**: Networking / router
- **Approval**: [NE-2218](https://redhat.atlassian.net/browse/NE-2218) comment
- **Jira**: [ART-21453](https://redhat.atlassian.net/browse/ART-21453)

Includes the `okd:` block from the start (haproxy28 needed a follow-up PR #11643 for this).

`delivery_repo_names` uses the `-rhel9` suffix to match how the delivery repo is actually registered in Pyxis (see [pyxis-repo-configs MR !1117](https://gitlab.cee.redhat.com/releng/pyxis-repo-configs/-/merge_requests/1117)). The equivalent fix for `haproxy28` is in #11726.
