### PR TITLE
ART-21453: fix ose-haproxy-router-haproxy28 delivery_repo_names to use -rhel9 suffix

### DIFF
--- a/images/ose-haproxy-router-haproxy28.yml
+++ b/images/ose-haproxy-router-haproxy28.yml
@@ -12,7 +12,7 @@ distgit:
 delivery:
   repo_name: ose-haproxy-router-haproxy28
   delivery_repo_names:
-  - openshift5/ose-haproxy-router-haproxy28
+  - openshift5/ose-haproxy-router-haproxy28-rhel9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms


### PR DESCRIPTION
## Summary

Fixes `delivery_repo_names` for `ose-haproxy-router-haproxy28` to include the `-rhel9` suffix.

## Why

The Pyxis delivery repo is registered as `openshift5/ose-haproxy-router-haproxy28-rhel9` (see [pyxis-repo-configs](https://gitlab.cee.redhat.com/releng/pyxis-repo-configs/-/blob/main/products/ocp/ocp5-managed.yaml)), not `openshift5/ose-haproxy-router-haproxy28`. `delivery_repo_names` was set without the suffix when the image was added in #11561, which doesn't match the actual registered Pyxis repo.

The corresponding advisory RPA repository urls in konflux-release-data are also being corrected to match: [MR !20075](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/20075).

Same fix applied to the new `ose-haproxy-router-haproxy32` component in #11725.

Jira: [ART-21453](https://redhat.atlassian.net/browse/ART-21453)
