### PR TITLE
[mta-8.1] Enable base_image_release for intermediary member images

### DIFF
--- a/images/mta-generic-external-provider.yml
+++ b/images/mta-generic-external-provider.yml
@@ -22,6 +22,8 @@ delivery:
   delivery_repo_names:
   - mta/mta-generic-external-provider-rhel9
 for_payload: false
+base_image_release:
+  force: true
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-golang-dependency-provider.yml
+++ b/images/mta-golang-dependency-provider.yml
@@ -21,6 +21,8 @@ delivery:
   delivery_repo_names:
   - mta/mta-golang-dependency-provider-rhel9
 for_payload: false
+base_image_release:
+  force: true
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-static-report.yml
+++ b/images/mta-static-report.yml
@@ -24,6 +24,8 @@ delivery:
   delivery_repo_names:
   - mta/mta-static-report-rhel9
 for_payload: false
+base_image_release:
+  force: true
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms


### PR DESCRIPTION
## Summary
- Adds `base_image_release: force: true` to `mta-static-report`, `mta-generic-external-provider`, and `mta-golang-dependency-provider`
- These images are used as `from.member` by other MTA images and need to be released to `art-images-base` so dependent images reference them from the official registry instead of `quay.io/redhat-user-workloads`

Should merge alongside https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/20085

## Context
Mirrors the same fix already applied on mta-8.2 (#11703, #11708).

`mta-analyzer-lsp`, `mta-java-external-provider`, and `mta-jdtls-server-base` already had `base_image_release.force: true` set on mta-8.1.

## Member reference chain
- `mta-static-report` → used by `mta-cli`, `mta-hub`
- `mta-generic-external-provider` → used by `mta-cli`
- `mta-golang-dependency-provider` → used by `mta-generic-external-provider`

## Verification
Cross-checked every `from.member` reference across all mta-8.1 image configs against `base_image_release` settings. The only image consumed as a member without this flag is `base-rhel9`, which is intentionally excluded since it's `base_only: true` / `for_release: false` (same as on mta-8.2).

Made with [Cursor](https://cursor.com)
