### PR TITLE
Fix OKD build for haproxy-router-haproxy28: pin to CentOS Stream 9 base

### DIFF
--- a/images/ose-haproxy-router-haproxy28.yml
+++ b/images/ose-haproxy-router-haproxy28.yml
@@ -31,5 +31,7 @@ konflux:
 okd:
   distgit:
     branch: rhaos-5.0-rhel-9
+  from:
+    stream: centos_stream9
   enabled_repos:
   - rhel-9-server-ose-rpms


### PR DESCRIPTION
## Problem

The OKD Konflux build for `haproxy-router-haproxy28` was failing with:

```
Problem: cannot install the best candidate for the job
  - nothing provides libpcre.so.1()(64bit) needed by haproxy28-2.8.18-2.rhaos4.23.el9.x86_64
  - nothing provides libpcreposix.so.0()(64bit) needed by haproxy28-2.8.18-2.rhaos4.23.el9.x86_64
```

This caused `origin/scos-5.0:haproxy-router-haproxy28` to never be promoted, blocking the `okd-scos-images` CI check on openshift/cluster-ingress-operator#1499.

## Root Cause

The image's `from.member: openshift-enterprise-base-rhel9` resolves for OKD builds through that image's own `okd.distgit.branch: rhaos-5.0-rhel-10` override, yielding a **CentOS Stream 10** base image. The `haproxy28` RPM from `rhel-9-server-ose-rpms` is an el9 package that links against PCRE1 (`libpcre.so.1`), which was removed in CentOS/RHEL 10 (replaced by PCRE2 only).

## Fix

Add `okd.from.stream: centos_stream9` to mirror the pattern already used by the sibling images `ose-haproxy-router-base` and `openshift-enterprise-haproxy-router`, which build successfully for OKD using a CentOS Stream 9 base where el9 RPM dependencies are satisfied.

Made with [Cursor](https://cursor.com)