### PR TITLE
logging-6.6: Update Go builder to 1.26.4

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606191459.p2.g0edc4e2.el8
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.4-202607091539.p2.g48af02f.el9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:


### PR DESCRIPTION
/label tide/merge-method-squash