### PR TITLE
[5.0] images: add rpm-lockfile-prototype backend for hyperkube and must-gather

### DIFF
--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -40,5 +40,9 @@ labels:
   io.openshift.tags: openshift,hyperkube
 name: openshift/ose-hyperkube-rhel9
 payload_name: hyperkube
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype
 owners:
 - aos-master@redhat.com

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -33,5 +33,9 @@ from:
 canonical_builders_from_upstream: false
 name: openshift/ose-must-gather-rhel9
 payload_name: must-gather
+konflux:
+  cachi2:
+    lockfile:
+      backend: rpm-lockfile-prototype
 owners:
 - aos-master@redhat.com


### PR DESCRIPTION
## Summary

Enable `konflux.cachi2.lockfile.backend: rpm-lockfile-prototype` for:
- `openshift-enterprise-hyperkube`
- `ose-must-gather`

## Why

The default `art-internal` lockfile backend seeds RPM lists from a prior successful build's `installed_rpms` in the Konflux DB for the same assembly. For first builds under a fresh `test` assembly, this list is empty, lockfile generation is skipped, and Konflux still tries to prefetch `rpms.lock.yaml` — causing `prefetch-dependencies` failures.

Observed in Jenkins build `aos-cd-builds/build/ocp4-konflux #40318`:
```
Empty RPM list to install for openshift-enterprise-hyperkube; all required RPMs may be inherited? Skipping lockfile generation.
```

The `rpm-lockfile-prototype` backend resolves RPMs directly from Dockerfile `dnf`/`yum` commands at rebase time, independent of prior build history. This matches the pattern already used by ~20 other images in `openshift-5.0` (e.g. `openshift-enterprise-base-rhel9`, `ose-frr`).

## Validation

`validate-ocp-build-data` passed for both changed files.

Made with [Cursor](https://cursor.com)