### PR TITLE
Remove ec.4 microshift RPM pin to allow rebuild with updated spec

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -65,12 +65,7 @@ releases:
         - code: MISMATCHED_SIBLINGS
           component: ose-gcp-pd-csi-driver-operator
       members:
-        rpms:
-          - distgit_key: microshift
-            why: Pin microshift to assembly
-            metadata:
-              is:
-                el9: microshift-5.0.0~ec.4-202607091104.p0.g3b84391.assembly.ec.4.el9
+        rpms: []
         images:
           - distgit_key: oc-mirror-plugin
             why: Pin oc-mirror-plugin to payload and assembly NVR


### PR DESCRIPTION
The current ec.4 microshift RPM pin points to a build using commit 3b84391, which predates https://github.com/openshift/microshift/pull/7014. That PR fixes the cri-o/cri-tools version requirements in the spec file (bumping from `<1.36.0` to `>=1.36.0`,`<1.37.0`), which is needed to unblock the microshift-bootc build for ec.4.

Removing the pin so build-microshift can rebuild from the current `release-5.0` HEAD which includes the fix.