### PR TITLE
Disable alignment PRs for openshift-enterprise-pod on 5.0

### DIFF
--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -9,6 +9,9 @@ content:
       url: git@github.com:openshift-priv/kubernetes.git
       web: https://github.com/openshift/kubernetes
     path: build/pause
+    ci_alignment:
+      streams_prs:
+        enabled: false
     okd_alignment:
       context_dir: build/pause
       dockerfile: Dockerfile.Rhel


### PR DESCRIPTION
## Summary
- Sets `content.source.ci_alignment.streams_prs.enabled: false` on `images/openshift-enterprise-pod.yml` so ART's automated upstream-alignment PR bot (`doozer images streams prs open`) stops opening/updating reconciliation PRs against this image's upstream repo on the `openshift-5.0` branch.

On request from image owners ([slack thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1783615638240229))