### PR TITLE
oadp-mustgather: remove stale ose-cli builder stage

### DIFF
--- a/images/oadp-mustgather.yml
+++ b/images/oadp-mustgather.yml
@@ -33,7 +33,6 @@ enabled_repos:
   - rhel-98-baseos-rpms
 from:
   builder:
-    - stream: ose-cli
     - stream: rhel-9-golang
   member: base-rhel9
 name: oadp/oadp-mustgather-rhel9

--- a/streams.yml
+++ b/streams.yml
@@ -1,7 +1,4 @@
 ---
-ose-cli:
-  image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.22
-
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}


### PR DESCRIPTION
## Summary

`doozer` konflux rebase for `oadp-mustgather` (group `oadp-1.3`) is failing:

```
ValueError: Build metadata for oadp-mustgather expected 3 parent images, but found 2 in Dockerfile (2 total FROM directives, 0 are stage references)
```

The `oc` CLI builder stage was removed from `konflux.Dockerfile` upstream in [openshift/oadp-must-gather@6e6c8e4](https://github.com/openshift/oadp-must-gather/commit/6e6c8e403927ad40c6c448f167132ec13159b61b) ("remove oc cli from konflux build"), dropping the Dockerfile from 3 `FROM` directives to 2. This repo's `images/oadp-mustgather.yml` still listed the stale `ose-cli` entry under `from.builder`, causing the parent-image count mismatch and failing the rebase (seen in [`build/layered-products` #8950](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/8950/console)).

- Removes the stale `ose-cli` builder stream from `images/oadp-mustgather.yml`, leaving `rhel-9-golang` (builder) + `base-rhel9` (member) to match the current 2-stage Dockerfile.
- Removes the now-unused `ose-cli` stream definition from `streams.yml` (confirmed via `git grep ose-cli` across the whole `oadp-1.3` branch that no other image config references it).

## Test plan

- [ ] Re-run `build/layered-products` for group `oadp-1.3` and confirm `oadp-mustgather` rebases successfully
