### PR TITLE
[mta-8.1] Switch mta-ui base image to nodejs-22

### DIFF
--- a/images/mta-ui.yml
+++ b/images/mta-ui.yml
@@ -27,6 +27,8 @@ for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms
+# ubi9/nodejs-20 is deprecated in Red Hat Catalog (deprecated-image-check).
+# Switched to nodejs-22 to align with mta-8.2 and clear Conforma failures.
 from:
   builder:
     - stream: rhel-9-nodejs-22

--- a/images/mta-ui.yml
+++ b/images/mta-ui.yml
@@ -29,8 +29,8 @@ enabled_repos:
 - rhel-9-baseos-rpms
 from:
   builder:
-    - stream: rhel-9-nodejs-20
-  stream: rhel-9-nodejs-20
+    - stream: rhel-9-nodejs-22
+  stream: rhel-9-nodejs-22
 name: mta/mta-ui-rhel9
 owners:
 - mta-devs@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -7,9 +7,8 @@ rhel-9-golang:
 rhel-9-nodejs-18:
   image: registry.redhat.io/ubi9/nodejs-18:latest
 
-rhel-9-nodejs-20:
-  image: registry.redhat.io/ubi9/nodejs-20:latest
-
+# rhel-9-nodejs-20 removed: ubi9/nodejs-20 is deprecated in Red Hat Catalog
+# (causes deprecated-image-check Conforma failures). Use rhel-9-nodejs-22.
 rhel-9-nodejs-22:
   image: registry.redhat.io/ubi9/nodejs-22:latest
 

--- a/streams.yml
+++ b/streams.yml
@@ -8,7 +8,7 @@ rhel-9-nodejs-18:
   image: registry.redhat.io/ubi9/nodejs-18:latest
 
 rhel-9-nodejs-20:
-  image: registry.redhat.io/ubi9/nodejs-20:9.7-1768870189
+  image: registry.redhat.io/ubi9/nodejs-20:latest
 
 # See OCP to upstream SDK alignment in this repo:
 # https://github.com/openshift/ocp-release-operator-sdk/tree/main

--- a/streams.yml
+++ b/streams.yml
@@ -10,6 +10,9 @@ rhel-9-nodejs-18:
 rhel-9-nodejs-20:
   image: registry.redhat.io/ubi9/nodejs-20:latest
 
+rhel-9-nodejs-22:
+  image: registry.redhat.io/ubi9/nodejs-22:latest
+
 # See OCP to upstream SDK alignment in this repo:
 # https://github.com/openshift/ocp-release-operator-sdk/tree/main
 rhel-9-ansible-operator:


### PR DESCRIPTION
## Summary

* Switch `mta-ui` from deprecated `rhel-9-nodejs-20` to `rhel-9-nodejs-22` (aligned with mta-8.2)
* Add `rhel-9-nodejs-22` stream and remove unused `rhel-9-nodejs-20` from `streams.yml`
* Document the change in `images/mta-ui.yml` (Red Hat Catalog deprecation → `deprecated-image-check` Conforma failures)

## Validation

Jenkins `layered-products` with this fork config built `mta-ui` on `nodejs-22`. Stage Conforma dropped mta-ui violations from 3 to **0**. Remaining advisory failure is unrelated: `mta-solution-server` `kernel-headers` arch mismatch.

## Test plan

- [x] Rebuild mta-ui via layered-products with this branch
- [x] Confirm Dockerfile `FROM` uses `ubi9/nodejs-22:latest`
- [x] Confirm stage Conforma has no mta-ui `deprecated-image-check` violations
- [ ] After merge: rebuild from upstream `mta-8.1` so assembly branch stops rewriting to nodejs-20
- [ ] Follow-up: rebuild mta-solution-server for `kernel-headers` unique_version