### PR TITLE
ART-20340: Replace hardcoded major version 4 with {MAJOR} placeholder in advisory templates

### DIFF
--- a/config/advisory_templates.yml
+++ b/config/advisory_templates.yml
@@ -8,23 +8,23 @@ boilerplates:
       # https://issues.redhat.com/browse/ART-8758
       # Do not leave a comment for a custom assembly type
       advisory_type_comment: True
-      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} bug fix and security update
+      synopsis: OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH} bug fix and security update
       topic: |
-        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs and add enhancements.
+        Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs and add enhancements.
 
-         This release includes a security update for Red Hat OpenShift Container Platform 4.{MINOR}.
+         This release includes a security update for Red Hat OpenShift Container Platform {MAJOR}.{MINOR}.
 
         Red Hat Product Security has rated this update as having a security impact of {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
       description: |
         Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
 
-        This advisory contains the container images for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the RPM packages for this release:
+        This advisory contains the container images for Red Hat OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH}. See the following advisory for the RPM packages for this release:
 
         https://access.redhat.com/errata/{RPM_ADVISORY}
 
         Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
 
         Security Fix(es):
 
@@ -32,11 +32,11 @@ boilerplates:
 
         For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
 
-        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        All OpenShift Container Platform {MAJOR}.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       solution: |
-        For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+        For OpenShift Container Platform {MAJOR}.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
 
         You may download the oc tool and use it to inspect release image metadata for x86_64, s390x, ppc64le, and aarch64 architectures. The image digests may be found at https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags.
 
@@ -54,7 +54,7 @@ boilerplates:
               (For aarch64 architecture)
               The image digest is {aarch64_DIGEST}
 
-        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        All OpenShift Container Platform {MAJOR}.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       security_reviewer: sfowler@redhat.com
     rhba:
       # This is to enable leaving legacy style comment when we create an advisory
@@ -64,24 +64,24 @@ boilerplates:
       # https://issues.redhat.com/browse/ART-8758
       # Do not leave a comment for a custom assembly type
       advisory_type_comment: True
-      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} bug fix update
+      synopsis: OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH} bug fix update
       topic: |
-        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+        Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
       description: |
         Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
 
-        This advisory contains the container images for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the RPM packages for this release:
+        This advisory contains the container images for Red Hat OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH}. See the following advisory for the RPM packages for this release:
 
         https://access.redhat.com/errata/{RPM_ADVISORY}
 
         Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
       solution: |
-        For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions
+        For OpenShift Container Platform {MAJOR}.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions
         on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
 
         You can download the oc tool and use it to inspect release image metadata
         for x86_64, s390x, ppc64le, and aarch64 architectures. The image digests
@@ -102,21 +102,21 @@ boilerplates:
         (For aarch64 architecture)
         The image digest is {aarch64_DIGEST}
 
-        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate
-        release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        All OpenShift Container Platform {MAJOR}.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate
+        release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
   rpm:
     rhsa:
-      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} packages and security update
+      synopsis: OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH} packages and security update
       topic: |
-        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs and add enhancements.
+        Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs and add enhancements.
 
-        This release includes a security update for Red Hat OpenShift Container Platform 4.{MINOR}.
+        This release includes a security update for Red Hat OpenShift Container Platform {MAJOR}.{MINOR}.
 
         Red Hat Product Security has rated this update as having a security impact of {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
       description: |
         Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
 
-        This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
+        This advisory contains the RPM packages for Red Hat OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
 
         https://access.redhat.com/errata/{IMAGE_ADVISORY}
 
@@ -126,44 +126,44 @@ boilerplates:
 
         For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
 
-        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        All OpenShift Container Platform {MAJOR}.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       solution: |
-        For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+        For OpenShift Container Platform {MAJOR}.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
       security_reviewer: sfowler@redhat.com
     rhba:
-      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} packages update
-      topic: Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+      synopsis: OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH} packages update
+      topic: Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
       description: |
         Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
 
-        This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
+        This advisory contains the RPM packages for Red Hat OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
 
         https://access.redhat.com/errata/{IMAGE_ADVISORY}
 
-        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at
+        All OpenShift Container Platform {MAJOR}.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       solution: |
         See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
 
-        Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
   extras:
     rhsa:
-      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} security and extras update
+      synopsis: OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH} security and extras update
       topic: |
-        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+        Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
 
-        This release includes a security update for Red Hat OpenShift Container Platform 4.{MINOR}.
+        This release includes a security update for Red Hat OpenShift Container Platform {MAJOR}.{MINOR}.
 
         Red Hat Product Security has rated this update as having a security impact of  {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
       description: |
         Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
 
-        This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
+        This advisory contains the RPM packages for Red Hat OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH}. See the following advisory for the container images for this release:
 
         https://access.redhat.com/errata/{IMAGE_ADVISORY}
 
@@ -173,38 +173,38 @@ boilerplates:
 
         For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.
 
-        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        All OpenShift Container Platform {MAJOR}.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       solution: |
-        For OpenShift Container Platform 4.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+        For OpenShift Container Platform {MAJOR}.{MINOR} see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
       security_reviewer: sfowler@redhat.com
     rhba:
-      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} extras update
-      topic: Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+      synopsis: OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH} extras update
+      topic: Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
       description: |
         Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
 
-        This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.{MINOR}.{PATCH}. See the following advisory for the container images for
+        This advisory contains the RPM packages for Red Hat OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH}. See the following advisory for the container images for
         this release:
 
         https://access.redhat.com/errata/{IMAGE_ADVISORY}
 
-        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate
+        All OpenShift Container Platform {MAJOR}.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate
         release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available
-        at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli
+        at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli
       solution: |
         See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
 
         Details on how to access this content are available at
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
   metadata:
     rhsa:
-      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} security update
+      synopsis: OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH} security update
       topic: |
-        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs and add enhancements.
+        Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs and add enhancements.
 
         Red Hat Product Security has rated this update as having a security impact of  {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
       description: |
@@ -218,14 +218,14 @@ boilerplates:
       solution: |
         See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
 
-        Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       security_reviewer: sfowler@redhat.com
     rhba:
-      synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} OLM Operators metadata update
+      synopsis: OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH} OLM Operators metadata update
       topic: |
-        Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+        Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
 
         This advisory will be used to release the corresponding Operator manifests by using new Operator metadata containers.
       description: |
@@ -233,24 +233,24 @@ boilerplates:
 
         This advisory will be used to release the corresponding Operator manifests via new Operator metadata containers.
 
-        All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
+        All OpenShift Container Platform {MAJOR}.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli.
       solution: |
         See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html/release_notes/
+        https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html/release_notes/
 
-        Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/4.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli
+        Details on how to access this content are available at https://docs.redhat.com/en/documentation/openshift_container_platform/{MAJOR}.{MINOR}/html-single/updating_clusters/index#updating-cluster-cli
   microshift:
     rhsa:
-      synopsis: Red Hat build of MicroShift 4.{MINOR}.{PATCH} security update
+      synopsis: Red Hat build of MicroShift {MAJOR}.{MINOR}.{PATCH} security update
       topic: |
-        Red Hat build of MicroShift release 4.{MINOR}.{PATCH} is now available with updates to packages and images that include a security update.
+        Red Hat build of MicroShift release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that include a security update.
 
         Red Hat Product Security has rated this update as having a security impact of {IMPACT}. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
       description: |
         Red Hat build of MicroShift is Red Hat's light-weight Kubernetes orchestration solution designed for edge device deployments and is built from the edge capabilities of Red Hat OpenShift Container Platform. MicroShift is an application that is deployed on top of Red Hat Enterprise Linux devices at the edge, providing an efficient way to operate single-node clusters in these low-resource environments.
 
-        This advisory contains the RPM packages for Red Hat build of MicroShift 4.{MINOR}.{PATCH}. Read the following advisory for the container images for this release:
+        This advisory contains the RPM packages for Red Hat build of MicroShift {MAJOR}.{MINOR}.{PATCH}. Read the following advisory for the container images for this release:
 
         https://access.redhat.com/errata/RHSA-XXXX:XXXX
 
@@ -258,79 +258,79 @@ boilerplates:
 
         {CVES}
 
-        All Red Hat build of MicroShift 4.{MINOR} users are advised to use these updated packages and images when they are available in the RPM repository.
+        All Red Hat build of MicroShift {MAJOR}.{MINOR} users are advised to use these updated packages and images when they are available in the RPM repository.
       solution: |
-        For MicroShift 4.{MINOR}, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
+        For MicroShift {MAJOR}.{MINOR}, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
+        https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{MAJOR}.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
       security_reviewer: sfowler@redhat.com
     rhba:
-      synopsis: Red Hat build of MicroShift 4.{MINOR}.{PATCH} bug fix and enhancement update
-      topic: Red Hat build of MicroShift release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+      synopsis: Red Hat build of MicroShift {MAJOR}.{MINOR}.{PATCH} bug fix and enhancement update
+      topic: Red Hat build of MicroShift release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
       description: |
         Red Hat build of MicroShift is Red Hat's light-weight Kubernetes orchestration solution designed for edge device deployments and is built from the edge capabilities of Red Hat OpenShift. MicroShift is an application that is deployed on top of Red Hat Enterprise Linux devices at the edge, providing an efficient way to operate single-node clusters in these low-resource environments.
 
-        This advisory contains the RPM packages for Red Hat build of MicroShift 4.{MINOR}.{PATCH}. Read the following advisory for the container images for this release:
+        This advisory contains the RPM packages for Red Hat build of MicroShift {MAJOR}.{MINOR}.{PATCH}. Read the following advisory for the container images for this release:
 
         https://access.redhat.com/errata/RHXX-XXXX:XXXX
 
         All of the bug fixes may not be documented in this advisory. Read the following release notes documentation for details about these changes:
 
-        https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
+        https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{MAJOR}.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
 
-        All Red Hat build of MicroShift 4.{MINOR} users are advised to use these updated packages and images when they are available in the RPM repository.
+        All Red Hat build of MicroShift {MAJOR}.{MINOR} users are advised to use these updated packages and images when they are available in the RPM repository.
 
       solution: |
-        For MicroShift 4.{MINOR}.{PATCH}, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
+        For MicroShift {MAJOR}.{MINOR}.{PATCH}, read the following documentation for important instructions on how to install the latest RPMs and fully apply this asynchronous errata update:
 
-        https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
+        https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{MAJOR}.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
   microshift-bootc:
-    synopsis: Red Hat build of MicroShift 4.{MINOR}, image mode for RHEL
-    topic: Red Hat build of MicroShift 4.{MINOR}, image mode for RHEL
+    synopsis: Red Hat build of MicroShift {MAJOR}.{MINOR}, image mode for RHEL
+    topic: Red Hat build of MicroShift {MAJOR}.{MINOR}, image mode for RHEL
     description: |
       Red Hat build of MicroShift is Red Hat's light-weight Kubernetes orchestration solution designed for edge device deployments and is built from Red Hat OpenShift. This microshift-bootc image can be used to boot and install MicroShift using image mode for Red Hat Enterprise Linux (RHEL). It can also be used as a base layer for customized solutions with MicroShift. For example, by layering applications and configurations on top of the base microshift-bootc image during image building.
     solution: |
-      For MicroShift 4.{MINOR}, read the following documentation for details on any important changes to this image: https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
+      For MicroShift {MAJOR}.{MINOR}, read the following documentation for details on any important changes to this image: https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{MAJOR}.{MINOR}/html/red_hat_build_of_microshift_release_notes/index
   bootimage:
-    synopsis: OpenShift Container Platform 4.{MINOR}.{PATCH} packages update
-    topic: Red Hat OpenShift Container Platform release 4.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
+    synopsis: OpenShift Container Platform {MAJOR}.{MINOR}.{PATCH} packages update
+    topic: Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.{PATCH} is now available with updates to packages and images that fix several bugs.
     description: |
       Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
-      This advisory contains extra RPM packages used in building the initial Red Hat OpenShift Container Platform 4.{MINOR} RHCOS boot-images. See the following advisory for the container images for this release:
+      This advisory contains extra RPM packages used in building the initial Red Hat OpenShift Container Platform {MAJOR}.{MINOR} RHCOS boot-images. See the following advisory for the container images for this release:
       <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
       There is no need for users to deploy these packages directly, as they are used only indirectly the first time a node is booted.
     solution: |
       See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
-      https://docs.openshift.com/container-platform/4.{MINOR}/release_notes/ocp-4-{MINOR}-release-notes.html
-      Details on how to access this content are available at https://docs.openshift.com/container-platform/4.{MINOR}/updating/updating-cluster-cli.html
+      https://docs.openshift.com/container-platform/{MAJOR}.{MINOR}/release_notes/ocp-{MAJOR}-{MINOR}-release-notes.html
+      Details on how to access this content are available at https://docs.openshift.com/container-platform/{MAJOR}.{MINOR}/updating/updating-cluster-cli.html
   prerelease:
-    synopsis: OpenShift Container Platform 4.{MINOR} OLM Operators pre-release
+    synopsis: OpenShift Container Platform {MAJOR}.{MINOR} OLM Operators pre-release
     topic: |
-      This advisory will be used to pre-release OCP 4.{MINOR} operator bundles and the
+      This advisory will be used to pre-release OCP {MAJOR}.{MINOR} operator bundles and the
       container image builds on which they depend.
     description: |
       Although named OCP product builds are made public for testing prior to release,
       optional operators cannot be provided in the same way, which is a gap for
       partners and customers following the latest developments.
     solution: |
-      This advisory will be used to pre-release OCP 4.{MINOR} operator bundles and the
+      This advisory will be used to pre-release OCP {MAJOR}.{MINOR} operator bundles and the
       container image builds on which they depend.
   advance:
     release: "RHOSE ASYNC"
-    synopsis: OpenShift Container Platform 4.{MINOR} OLM Operators advance release
+    synopsis: OpenShift Container Platform {MAJOR}.{MINOR} OLM Operators advance release
     topic: |
-      Red Hat OpenShift Container Platform release 4.{MINOR}.0 is now available with updates to packages and images.
+      Red Hat OpenShift Container Platform release {MAJOR}.{MINOR}.0 is now available with updates to packages and images.
       This advisory will be used to release Operator manifests via new Operator metadata containers, as well as container images that are dependencies for the Operators.
     description: |
       Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
       This advisory will be used to release Operator manifests via new Operator metadata containers, as well as container images that are dependencies for the Operators.
-      All OpenShift Container Platform 4.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.{MINOR}/updating/updating-cluster-cli.html
+      All OpenShift Container Platform {MAJOR}.{MINOR} users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/{MAJOR}.{MINOR}/updating/updating-cluster-cli.html
     solution: |
       See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-      https://docs.openshift.com/container-platform/4.{MINOR}/release_notes/ocp-4-{MINOR}-release-notes.html
+      https://docs.openshift.com/container-platform/{MAJOR}.{MINOR}/release_notes/ocp-{MAJOR}-{MINOR}-release-notes.html
 
-      Details on how to access this content are available at https://docs.openshift.com/container-platform/4.{MINOR}/updating/updating-cluster-cli.html
+      Details on how to access this content are available at https://docs.openshift.com/container-platform/{MAJOR}.{MINOR}/updating/updating-cluster-cli.html
   openshift-logging:
     synopsis: Logging for Red Hat OpenShift - {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}
     topic: Logging for Red Hat OpenShift - {PRODUCT_MAJOR}.{PRODUCT_MINOR}.{PRODUCT_PATCH}


### PR DESCRIPTION
All consuming code (elliott create, attach-cve-flaws, shipment, build-microshift, release-from-fbc) already passes MAJOR in replace_vars, so this is a no-op change in behavior while making the templates version-agnostic.
