### PR TITLE
oadp-mustgather: remove stale ose-cli builder stage

### DIFF
--- a/images/oadp-mustgather.yml
+++ b/images/oadp-mustgather.yml
@@ -30,7 +30,6 @@ enabled_repos:
   - rhel-98-baseos-rpms
 from:
   builder:
-    - stream: ose-cli
     - stream: rhel-9-golang
   member: base-rhel9
 name: oadp/oadp-mustgather-rhel9

--- a/streams.yml
+++ b/streams.yml
@@ -1,7 +1,4 @@
 ---
-ose-cli:
-  image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21
-
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}


### PR DESCRIPTION
Removes the unused ose-cli stream reference from oadp-mustgather image config and streams.yml.

Companion PR: https://github.com/openshift/oadp-must-gather/pull/142

Made with [Cursor](https://cursor.com)