### PR TITLE
enable_symlink_check false in csi-driver-nfs

### DIFF
--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -30,3 +30,5 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-csi-driver-nfs-rhel8
 payload_name: csi-driver-nfs
+konflux:
+  enable_symlink_check: false


### PR DESCRIPTION
[failing](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-csi-driver-nfs-6rpgc) 

[success after this change](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-12/pipelineruns/ose-4-12-csi-driver-nfs-h9cwr)