### PR TITLE
Override COREOS_VERSIONS for OKD machine-os-images builds

### DIFF
--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -61,3 +61,15 @@ konflux:
         filename: coreos10-ppc64le.iso
       - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260423-0/s390x/rhcos-10.2.20260423-0-live-iso.s390x.iso
         filename: coreos10-s390x.iso
+okd:
+  content:
+    source:
+      modifications:
+      - action: replace
+        match: "ARG COREOS_VERSIONS=9,10"
+        replacement: "ARG COREOS_VERSIONS=10"
+      - action: replace
+        match: 'COPY fetch_image.sh /usr/local/bin/'
+        replacement: |
+          COPY fetch_image.sh /usr/local/bin/
+          RUN sed -i 's/echo "rhel-10"/echo "centos-10"/' /usr/local/bin/fetch_image.sh


### PR DESCRIPTION
OKD 5.0's openshift-install binary only supports centos-10 stream, not centos-9. By using a Dockerfile modification to change COREOS_VERSIONS from "9,10" to "10" for OKD builds, we ensure OKD builds only attempt to fetch the supported version.

This provides a cleaner alternative to error suppression in the fetch_image.sh script, addressing the concern raised in https://github.com/openshift/machine-os-images/pull/107 about using 2>/dev/null to hide errors.

Related: https://github.com/openshift/machine-os-images/pull/107

Test: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/okd-5-0/pipelineruns/okd-5-0-ose-machine-os-images-mkrr8