### PR TITLE
Disable symlink check for images with broken upstream symlinks [openshift-4.13]

### DIFF
--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -31,3 +31,5 @@ delivery:
   delivery_repo_names:
   - openshift4/ose-csi-driver-nfs-rhel8
 payload_name: csi-driver-nfs
+konflux:
+  enable_symlink_check: false


### PR DESCRIPTION
Disable the symlink check for images that have broken upstream symlinks.