### PR TITLE
Disable symlink check for images with broken upstream symlinks [openshift-4.15]

### DIFF
--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -36,3 +36,5 @@ name: openshift/ose-csi-driver-nfs-rhel9
 payload_name: csi-driver-nfs
 owners:
 - shiftstack-team@redhat.com
+konflux:
+  enable_symlink_check: false


### PR DESCRIPTION
Disable the symlink check for images that have broken upstream symlinks.