### PR TITLE
Disable symlink check for images with broken upstream symlinks [openshift-4.16]

### DIFF
--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -36,3 +36,5 @@ name: openshift/ose-csi-driver-nfs-rhel9
 payload_name: csi-driver-nfs
 owners:
 - shiftstack-team@redhat.com
+konflux:
+  enable_symlink_check: false

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -43,3 +43,5 @@ alternative_upstream:
     - stream: golang
     member: openshift-enterprise-base
   name: openshift/ose-helm-operator
+konflux:
+  enable_symlink_check: false

--- a/images/openshift-enterprise-operator-sdk.yml
+++ b/images/openshift-enterprise-operator-sdk.yml
@@ -34,3 +34,5 @@ owners:
 - jlanford@redhat.com
 - fabian@redhat.com
 - cmacedo@redhat.com
+konflux:
+  enable_symlink_check: false


### PR DESCRIPTION
Disable the symlink check for images that have broken upstream symlinks.