### PR TITLE
Disable symlink check for images with broken upstream symlinks [openshift-4.20]

### DIFF
--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -35,6 +35,7 @@ from:
 name: openshift/ose-csi-driver-nfs-rhel9
 payload_name: csi-driver-nfs
 konflux:
+  enable_symlink_check: false
   cachi2:
     lockfile:
       rpms:

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -31,3 +31,5 @@ owners:
 - jlanford@redhat.com
 - fabian@redhat.com
 - cmacedo@redhat.com
+konflux:
+  enable_symlink_check: false

--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -30,3 +30,5 @@ name: openshift/ose-baremetal-cluster-api-controllers-rhel9
 payload_name: baremetal-cluster-api-controllers
 owners:
 - metal-platform@redhat.com
+konflux:
+  enable_symlink_check: false


### PR DESCRIPTION
Disable the symlink check for images that have broken upstream symlinks.