### PR TITLE
logging-6.6: Switch operators to release branches

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: Dockerfile.art
     git:
       branch:
-        target: master
+        target: release-6.6
       url: git@github.com:openshift-priv/cluster-logging-operator.git
       web: https://github.com/openshift/cluster-logging-operator
 distgit:

--- a/images/loki-operator.yml
+++ b/images/loki-operator.yml
@@ -4,7 +4,7 @@ content:
     path: operator
     git:
       branch:
-        target: main
+        target: release-6.6
       url: git@github.com:openshift-priv/loki.git
       web: https://github.com/openshift/loki
 distgit:


### PR DESCRIPTION
Once both branches are created we can switch the 6.6 release to use the release branches instead of master/main. This does not need to happen before the 6.6.0 release, so I'll keep it on hold.

- [x] create branch for cluster-logging-operator
- [x] create branch for loki-operator

/label tide/merge-method-squash
/hold wait until branches are created & 6.6.0 is released
