### PR TITLE
Add oadp-cli-binaries build config for oadp-1.3

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -71,6 +71,8 @@ public_upstreams:
   public:  "https://github.com/migtools/kopia"
 - private: "https://github.com/openshift-priv/migtools-oadp-non-admin"
   public:  "https://github.com/migtools/oadp-non-admin"
+- private: "https://github.com/openshift-priv/migtools-oadp-cli"
+  public:  "https://github.com/migtools/oadp-cli"
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub

--- a/images/oadp-cli-binaries.yml
+++ b/images/oadp-cli-binaries.yml
@@ -1,0 +1,46 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: konflux.Dockerfile
+    git:
+      branch:
+        target: oadp-1.3
+      url: git@github.com:openshift-priv/migtools-oadp-cli.git
+      web: https://github.com/migtools/oadp-cli
+    modifications:
+      - action: replace
+        match: "dnf -y"
+        replacement: "microdnf -y"
+      - action: replace
+        match: "dnf clean all"
+        replacement: "microdnf clean all"
+distgit:
+  component: oadp-cli-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+delivery:
+  delivery_repo_names:
+    - oadp/oadp-cli-binaries-rhel9
+for_payload: false
+enabled_repos:
+  - rhel-9-appstream-rpms
+  - rhel-9-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: oadp/oadp-cli-binaries-rhel9
+owners:
+  - oadp-maintainers@redhat.com
+dependents:
+  - oadp-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+        - tzdata
+jira:
+  project: OADP
+  component: oadp-cli-container


### PR DESCRIPTION
## Why the changes were made
OADP 1.3 is missing downstream Konflux build config for the CLI download server image (oadp/oadp-cli-binaries-rhel9). Pyxis already lists the product repo, but ocp-build-data on oadp-1.3 has no image definition.

This adds the missing image config so Konflux can build and deliver registry.redhat.io/oadp/oadp-cli-binaries-rhel9 from openshift-priv/migtools-oadp-cli @ oadp-1.3. Also adds migtools-oadp-cli to public_upstreams in group.yml

## How to test the changes made
After merge, run release metadata check (if available):

./release-sources oadp-1.3
oadp/oadp-cli-binaries-rhel9 is expected to show OBD and Delivery with green checkmarks