### PR TITLE
Update MTA 8.2 image build targets from main to release-0.10

### DIFF
--- a/images/mta-analyzer-addon.yml
+++ b/images/mta-analyzer-addon.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-tackle2-addon-analyzer.git
       web: https://github.com/migtools/mta-tackle2-addon-analyzer
 jira:

--- a/images/mta-analyzer-lsp.yml
+++ b/images/mta-analyzer-lsp.yml
@@ -9,7 +9,7 @@ content:
     dockerfile: konflux.analyzer-lsp.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
 jira:

--- a/images/mta-analyzer-rpc.yml
+++ b/images/mta-analyzer-rpc.yml
@@ -9,7 +9,7 @@ content:
     dockerfile: konflux.analyzer-rpc.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-kai.git
       web: https://github.com/migtools/mta-kai
 jira:

--- a/images/mta-cli.yml
+++ b/images/mta-cli.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-kantra.git
       web: https://github.com/migtools/mta-kantra
 jira:

--- a/images/mta-discovery-addon.yml
+++ b/images/mta-discovery-addon.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-tackle2-addon-discovery.git
       web: https://github.com/migtools/mta-tackle2-addon-discovery
 jira:

--- a/images/mta-dotnet-external-provider.yml
+++ b/images/mta-dotnet-external-provider.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
 #      url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       url: git@github.com:openshift-priv/migtools-mta-c-sharp-analyzer-provider.git
 #      web: https://github.com/migtools/mta-analyzer-lsp

--- a/images/mta-go-external-provider.yml
+++ b/images/mta-go-external-provider.yml
@@ -11,7 +11,7 @@ content:
     dockerfile: konflux.go-external-provider.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
 jira:

--- a/images/mta-hub.yml
+++ b/images/mta-hub.yml
@@ -9,7 +9,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-tackle2-hub.git
       web: https://github.com/migtools/mta-tackle2-hub
     pkg_managers:

--- a/images/mta-java-external-provider.yml
+++ b/images/mta-java-external-provider.yml
@@ -10,7 +10,7 @@ content:
     dockerfile: konflux.java-external-provider.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
 jira:

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-java-analyzer-bundle.git
       web: https://github.com/migtools/mta-java-analyzer-bundle
 jira:

--- a/images/mta-nodejs-external-provider.yml
+++ b/images/mta-nodejs-external-provider.yml
@@ -10,7 +10,7 @@ content:
     dockerfile: konflux.nodejs-external-provider.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
 jira:

--- a/images/mta-operator.yml
+++ b/images/mta-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-operator.git
       web: https://github.com/migtools/mta-operator
       allow_unprotected_branch: true

--- a/images/mta-platform-addon.yml
+++ b/images/mta-platform-addon.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-tackle2-addon-platform.git
       web: https://github.com/migtools/mta-tackle2-addon-platform
 jira:

--- a/images/mta-python-external-provider.yml
+++ b/images/mta-python-external-provider.yml
@@ -16,7 +16,7 @@ content:
     dockerfile: konflux.python-external-provider.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
     pkg_managers:

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: konflux.solution-server.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-kai.git
       web: https://github.com/migtools/mta-kai
 jira:

--- a/images/mta-static-report.yml
+++ b/images/mta-static-report.yml
@@ -14,7 +14,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-static-report.git
       web: https://github.com/migtools/mta-static-report
 jira:

--- a/images/mta-ui.yml
+++ b/images/mta-ui.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: main
+        target: release-0.10
       url: git@github.com:openshift-priv/migtools-mta-tackle2-ui.git
       web: https://github.com/migtools/mta-tackle2-ui
     modifications:


### PR DESCRIPTION
Moves MTA 8.2 image builds to `release-0.10` branch