### PR TITLE
remove rhel-102-baseos from dtk-9

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -30,7 +30,6 @@ enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
 - rhel-9-rt-rpms
-- rhel-102-baseos
 for_payload: true
 from:
   member: openshift-enterprise-base-rhel9


### PR DESCRIPTION
builds are failing ([example](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/ose-5-0-driver-toolkit-4ctxr)) due to
```
(microdnf:1928): libdnf-WARNING **: 02:07:05.053: failed to parse public key for /etc/pki/rpm-gpg/RPM-GPG-KEY-PQC-redhat-release
Running transaction test...
error: Error running transaction: libc.so.6(GLIBC_ABI_DT_RELR)(64bit) is needed by ncurses-libs-6.4-15.20240127.el10_1.x86_64
libc.so.6(GLIBC_ABI_DT_RELR)(64bit) is needed by ncurses-6.4-15.20240127.el10_1.x86_64
libc.so.6(GLIBC_ABI_DT_RELR)(64bit) is needed by kpartx-0.9.9-18.el10.x86_64
```

removing the rhel10 baseos, the [build](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-5-0/pipelineruns/ose-5-0-driver-toolkit-wrxbd) is green 