### PR TITLE
ART-21663: images: add ose-kube-vip payload member

### DIFF
--- a/images/ose-kube-vip.yml
+++ b/images/ose-kube-vip.yml
@@ -1,0 +1,33 @@
+content:
+  source:
+    dockerfile: Dockerfile.openshift
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/kube-vip.git
+      web: https://github.com/openshift/kube-vip
+    ci_alignment:
+      streams_prs:
+        ci_build_root:
+          member: ci-openshift-build-root-latest.rhel9
+    pkg_managers:
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ose-kube-vip-container
+delivery:
+  repo_name: ose-kube-vip
+  delivery_repo_names:
+  - openshift5/ose-kube-vip-rhel9
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+for_payload: true
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/ose-kube-vip-rhel9
+payload_name: kube-vip
+owners:
+- mko@redhat.com


### PR DESCRIPTION
kube-vip provides BGP-based VIP management for on-prem platforms (OPNET-595, DevPreviewNoUpgrade feature gate BGPBasedVIPManagement). The machine-config-operator references the new kube-vip payload tag in its image-references; this config must merge before that MCO change so nightly payload assembly can resolve the tag.

Source: github.com/openshift/kube-vip (fork of kube-vip/kube-vip), Dockerfile.openshift, static Go binary on base-rhel9.

Supersedes https://github.com/openshift-eng/ocp-build-data/pull/11837