### PR TITLE
Bump volsync-addon-controller golang builder to 1.26

### DIFF
--- a/images/volsync-addon-controller.yml
+++ b/images/volsync-addon-controller.yml
@@ -17,7 +17,7 @@ dependents:
 - multiclusterhub-operator
 from:
   builder:
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang-1.26
   stream: rhel9
 name: rhacm2/volsync-addon-controller-rhel9
 owners:


### PR DESCRIPTION
## Summary
- `acm-volsync-addon-controller-container` builds are failing:
  ```
  go: go.mod requires go >= 1.26.0 (running go 1.25.9; GOTOOLCHAIN=local)
  ```
- Upstream `stolostron/volsync-addon-controller` (`release-2.16`) bumped its `go.mod` to `go 1.26`.
- `images/volsync-addon-controller.yml` was using the `rhel-9-golang` alias, which resolves to Go 1.25.9 on this branch (`GO_LATEST: "1.25"` in `group.yml`).
- Switches the builder stream to `rhel-9-golang-1.26` (already defined in `streams.yml`), matching the pattern already used by sibling ACM images on this branch (`cert-policy-controller`, `acm-cli`, `config-policy-controller`, `governance-policy-addon-controller`, `governance-policy-framework-addon`, `governance-policy-propagator`, `mtv-integrations`).

## Test plan
- [ ] Rebuild `acm-volsync-addon-controller-container` and confirm the `go mod download` / compliance shim step no longer fails with the toolchain version mismatch.

Made with [Cursor](https://cursor.com)