### PR TITLE
Sync to old branch

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -234,30 +234,30 @@ repos:
       extra_options:
         excludepkgs: golang*
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
     content_set:
-      default: rhel-9-for-x86_64-appstream-rpms
-      aarch64: rhel-9-for-aarch64-appstream-rpms
-      ppc64le: rhel-9-for-ppc64le-appstream-rpms
-      s390x: rhel-9-for-s390x-appstream-rpms
+      default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_6
+      aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_6
+      ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_6
+      s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
     reposync:
       enabled: false
 
   rhel-9-6-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/codeready-builder/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/ppc64le/codeready-builder/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/s390x/codeready-builder/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/x86_64/codeready-builder/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/aarch64/codeready-builder/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/ppc64le/codeready-builder/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/s390x/codeready-builder/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.6/x86_64/codeready-builder/os/
     content_set:
-      default: codeready-builder-for-rhel-9-x86_64-rpms__9_DOT_6
-      aarch64: codeready-builder-for-rhel-9-aarch64-rpms__9_DOT_6
-      ppc64le: codeready-builder-for-rhel-9-ppc64le-rpms__9_DOT_6
-      s390x: codeready-builder-for-rhel-9-s390x-rpms__9_DOT_6
+      default: codeready-builder-for-rhel-9-x86_64-eus-rpms__9_DOT_6
+      aarch64: codeready-builder-for-rhel-9-aarch64-eus-rpms__9_DOT_6
+      ppc64le: codeready-builder-for-rhel-9-ppc64le-eus-rpms__9_DOT_6
+      s390x: codeready-builder-for-rhel-9-s390x-eus-rpms__9_DOT_6
     reposync:
       enabled: false
 

--- a/group.yml
+++ b/group.yml
@@ -217,15 +217,15 @@ repos:
   rhel-9-6-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
     content_set:
-      default: rhel-9-for-x86_64-baseos-rpms
-      aarch64: rhel-9-for-aarch64-baseos-rpms
-      ppc64le: rhel-9-for-ppc64le-baseos-rpms
-      s390x: rhel-9-for-s390x-baseos-rpms
+      default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6
+      aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_6
+      ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_6
+      s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_6
     reposync:
       enabled: false
 


### PR DESCRIPTION
Update rhel-9-6-baseos-rpms

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED