### PR TITLE
Test new cross toolchain bundle in RHEL 9.6 Konflux

### DIFF
--- a/images/openshift-golang-builder-96.yml
+++ b/images/openshift-golang-builder-96.yml
@@ -47,7 +47,8 @@ konflux:
       - golang
     artifact_lockfile:
       resources:
-      - https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross.tar.gz
+      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder/cross-new.tar.gz
+        filename: cross.tar.gz
   content:
     source:
       modifications:


### PR DESCRIPTION
Test new toolchain bundle produced from https://github.com/openshift-eng/ocp-build-data/pull/11871

## Summary

- Point the RHEL 9.6 Golang builder's Konflux artifact dependency at `cross-new.tar.gz`.
- Expose the downloaded artifact as `cross.tar.gz` so the existing Dockerfile build path remains unchanged.

## Purpose

Exercise the newly generated cross-toolchain source bundle in a Konflux image build.

## Validation

- Parsed the updated image configuration as YAML and verified the artifact URL and filename mapping.
- Repository pre-commit and commit-message hooks passed.
