### PR TITLE
HYPBLD-847 - Bump repos from RHEL 9.6 E4S to RHEL 9.7

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -62,29 +62,29 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/os/
     content_set:
-      default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-baseos-rpms
+      aarch64: rhel-9-for-aarch64-baseos-rpms
+      ppc64le: rhel-9-for-ppc64le-baseos-rpms
+      s390x: rhel-9-for-s390x-baseos-rpms
     reposync:
       enabled: false
 
   rhel-9-appstream-rpms:
     conf:
       baseurl:
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/os/
     content_set:
-      default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-appstream-rpms
+      aarch64: rhel-9-for-aarch64-appstream-rpms
+      ppc64le: rhel-9-for-ppc64le-appstream-rpms
+      s390x: rhel-9-for-s390x-appstream-rpms
     reposync:
       enabled: false


### PR DESCRIPTION
The base UBI image (ubi9/ubi-minimal:latest) contains RHEL 9.7 packages, causing depsolve failures when components try to install packages from the 9.6 E4S repos (openssl-libs version conflict).

Update repos to RHEL 9.7 (content/dist/rhel9/9.7) to match the base image version, consistent with logging-6.5 configuration.

Ref: [HYPBLD-847](https://redhat.atlassian.net/browse/HYPBLD-847)