### PR TITLE
Test rebuilt Golang cross toolchain in 4.22

### DIFF
--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -21,7 +21,7 @@ delivery:
 for_payload: true
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-new
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-operator-registry-rhel9
 payload_name: operator-registry

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -23,7 +23,7 @@ for_payload: true
 from:
   builder:
   - stream: rhel-8-golang
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-new
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-operator-framework-tools-rhel9
 payload_name: operator-framework-tools

--- a/streams.yml
+++ b/streams.yml
@@ -26,6 +26,10 @@ rhel-9-golang:
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
 
+rhel-9-golang-new:
+  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.11-202607161637.p2.g6245b3b.el9
+  mirror: false
+
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}


### PR DESCRIPTION
Testing https://github.com/openshift-eng/ocp-build-data/pull/11873 

## Summary

- add a `rhel-9-golang-new` stream pointing to the rebuilt Go 1.25.11 Konflux builder
- use the new stream for the RHEL 9 builder stages of `operator-registry` and `ose-operator-framework-tools`

## Purpose

This allows an `ocp4-konflux` test-assembly build of the two OLM images to verify that their `make cross` steps succeed with the rebuilt macOS cross-compilation toolchain.

Builder pullspec:

```text
quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.11-202607161637.p2.g6245b3b.el9
```

## Validation

- parsed all three changed YAML files with `yq`
- resolved the builder's Linux/amd64 manifest with `oc image info`
- `git diff --check`
- repository pre-commit and commit-message hooks
