### PR TITLE
HYPBLD-847 - Use floating tag for rhel9 stream (ubi-minimal:9.7)

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -17,4 +17,4 @@ ose-cli:
   image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21
 
 rhel9:
-  image: registry.redhat.io/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00
+  image: registry.redhat.io/ubi9/ubi-minimal:9.7


### PR DESCRIPTION
Replace the pinned SHA digest with the floating :9.7 tag so the base image automatically picks up security patches without manual digest updates.

Ref: [HYPBLD-847](https://redhat.atlassian.net/browse/HYPBLD-847)