### PR TITLE
Add reusable validation workflow

### DIFF
--- a/.github/workflows/validate-reusable.yaml
+++ b/.github/workflows/validate-reusable.yaml
@@ -1,0 +1,57 @@
+name: Validate ocp-build-data (reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Clone art-tools
+        run: |
+          git clone https://github.com/openshift-eng/art-tools
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.18"
+          enable-cache: true
+          cache-dependency-glob: "**/uv.lock"
+
+      - name: Install validator
+        run: |
+          cd art-tools
+          ./install.sh
+
+      - name: Get all relevant files that have changed
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files_yaml: |
+            config:
+              - 'streams.yml'
+              - 'group.yml'
+              - 'releases.yml'
+              - 'bug.yml'
+              - 'rpms/**.yml'
+              - 'images/**.yml'
+
+      - name: Run validator
+        if: steps.changed-files.outputs.config_any_changed == 'true'
+        run: |
+          uv run --project ./art-tools validate-ocp-build-data \
+          --images-dir images ${{ steps.changed-files.outputs.config_all_changed_files }}

--- a/.github/workflows/validate-reusable.yaml
+++ b/.github/workflows/validate-reusable.yaml
@@ -3,13 +3,19 @@ name: Validate ocp-build-data (reusable)
 on:
   workflow_call:
 
+env:
+  PYTHON_VERSION: "3.11"
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v7
         with:
-          fetch-depth: "0"
+          fetch-depth: 0
+          set-safe-directory: ${{ env.GITHUB_WORKSPACE }}
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |
@@ -17,9 +23,9 @@ jobs:
           sudo apt-get install -y libkrb5-dev
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{env.PYTHON_VERSION}}
 
       - name: Clone art-tools
         run: |
@@ -28,7 +34,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version: "0.9.18"
+          version: "0.11.26"
+          python-version: ${{env.PYTHON_VERSION}}
           enable-cache: true
           cache-dependency-glob: "**/uv.lock"
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/validate-reusable.yaml` on `main` with `workflow_call` trigger
- Contains all validation steps (checkout, install deps, clone art-tools, run validator)
- Companion PRs will update each `openshift-*` branch to call this instead of maintaining their own copy

## Motivation
All 13 `openshift-*` branches carry identical copies of `validate.yaml`. Future changes (e.g. bumping `uv` version, adding steps) require updating every branch. This centralizes the logic so only `main` needs updating.

## Test plan
- [ ] Merge this PR first
- [ ] Then merge companion PRs on openshift-* branches
- [ ] Validate by opening a test PR touching a `.yml` file against an updated branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)