### PR TITLE
Use centralized validation workflow from main

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,54 +11,5 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: "0"
+    uses: openshift-eng/ocp-build-data/.github/workflows/validate-reusable.yaml@main
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libkrb5-dev
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: Clone art-tools
-        run: |
-          git clone https://github.com/openshift-eng/art-tools
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "0.9.18"
-          enable-cache: true
-          cache-dependency-glob: "**/uv.lock"
-
-      - name: Install validator
-        run: |
-          cd art-tools
-          ./install.sh
-
-      - name: Get all relevant files that have changed
-        id: changed-files
-        uses: tj-actions/changed-files@v37
-        with:
-          files_yaml: |
-            config:
-              - 'streams.yml'
-              - 'group.yml'
-              - 'releases.yml'
-              - 'bug.yml'
-              - 'rpms/**.yml'
-              - 'images/**.yml'
-
-      - name: Run validator
-
-        if: steps.changed-files.outputs.config_any_changed == 'true'
-        run: |
-          uv run --project ./art-tools validate-ocp-build-data \
-          --images-dir images ${{ steps.changed-files.outputs.config_all_changed_files }}


### PR DESCRIPTION
## Summary
- Replaces the full validation workflow with a thin caller that invokes the reusable workflow from `main`
- Depends on https://github.com/openshift-eng/ocp-build-data/pull/11884 being merged first

## Motivation
Centralizes CI logic so future changes only need to update `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)