### PR TITLE
Document Brew cross bundle publishing

### DIFF
--- a/cross/README.md
+++ b/cross/README.md
@@ -175,35 +175,20 @@ Set **Doozer data Git ref** to the source branch of the test PR and set
 resulting Konflux build downloads the candidate archive and completes the
 cross-toolchain steps successfully.
 
-## Upload and test the archive in Brew
+## Upload the archive to Brew
 
-Brew obtains `cross.tar.gz` from its lookaside cache. After promoting the
-archive on `ocp-artifacts`, use the helper to verify the published SHA-256 and
-upload the archive:
+After promoting the archive on `ocp-artifacts`, use the helper to upload it to
+Brew lookaside:
 
 ```console
-$ ./cross/update-brew-cross-sources.sh --dry-run
 $ ./cross/update-brew-cross-sources.sh
 ```
 
-The real upload requires `rhpkg`, a valid Red Hat Kerberos ticket, and access
-to the Brew distgit repository. The script uses a temporary distgit clone only
-to provide the repository context required by `rhpkg new-sources`. It never
-commits or pushes to distgit. Repeated runs are safe: `rhpkg` detects when the
-same archive is already present in lookaside. `--dry-run` generates the source
-entry offline and performs no upload.
-
-Copy the generated `sources` entry into the source-context `sources` file,
-typically `images/sources`, in every relevant ocp-build-data branch and open a
-PR for those changes. This is the durable source of truth: doozer copies the
-source context during rebase and will overwrite a `sources` file changed only
-in Brew distgit.
-
-In Jenkins, run the Golang builder job with **Build system** set to `brew`.
-Confirm that the resulting Brew task builds from a distgit commit containing
-the new `sources` digest and that the macOS cross-toolchain compilation
-completes successfully. Updating the Konflux artifact URL or release policy
-does not change which lookaside object a Brew build consumes.
+The script prints the generated `sources` entry. Copy that entry into the
+source-context `sources` file, typically `images/sources`, in every relevant
+ocp-build-data branch and open a PR for each branch. See
+[ocp-build-data PR #11914](https://github.com/openshift-eng/ocp-build-data/pull/11914)
+for an example.
 
 ## Promote the verified archive
 

--- a/cross/README.md
+++ b/cross/README.md
@@ -182,10 +182,15 @@ repository stores `cross.tar.gz` in its lookaside cache, and each distgit
 branch selects the archive through its committed `sources` file.
 
 After promoting the archive on `ocp-artifacts`, run the update script with
-every Brew distgit branch that should consume it. A valid Red Hat Kerberos
-ticket and permission to push to the distgit repository are required:
+every Brew distgit branch that should consume it. The real update requires
+`rhpkg`, a valid Red Hat Kerberos ticket, and permission to push to the distgit
+repository; dry-run uses the read-only HTTPS Git endpoint:
 
 ```console
+$ ./cross/update-brew-cross-sources.sh --dry-run \
+    rhaos-4.22-rhel-9 \
+    rhaos-4.22-rhel-8
+
 $ ./cross/update-brew-cross-sources.sh \
     rhaos-4.22-rhel-9 \
     rhaos-4.22-rhel-8
@@ -197,9 +202,11 @@ lookaside cache once. It then commits the generated `sources` file to each
 specified branch and pushes without force. Branches that already reference the
 archive are identified before the lookaside step and skipped; if all specified
 branches are current, the script exits without uploading, committing, or
-pushing. Because `sources` is versioned independently, every active Brew
-distgit branch whose Dockerfile uses `COPY cross.tar.gz` must be passed to the
-script. Branches that do not install the cross toolchain need no update.
+pushing. The `--dry-run` option performs the download, verification, clone,
+branch validation, and comparison without modifying the lookaside cache or
+distgit branches. Because `sources` is versioned independently, every active
+Brew distgit branch whose Dockerfile uses `COPY cross.tar.gz` must be passed to
+the script. Branches that do not install the cross toolchain need no update.
 
 In Jenkins, run the Golang builder job with **Build system** set to `brew`.
 Confirm that the resulting Brew task builds from a distgit commit containing

--- a/cross/README.md
+++ b/cross/README.md
@@ -177,45 +177,29 @@ cross-toolchain steps successfully.
 
 ## Update and test the archive in Brew
 
-Brew does not download the archive from the OCP artifacts URL. The Brew
-distgit repository stores `cross.tar.gz` in its lookaside cache, and each
-distgit branch selects the archive through its committed `sources` file.
+Brew does not download the archive during the image build. The Brew distgit
+repository stores `cross.tar.gz` in its lookaside cache, and each distgit
+branch selects the archive through its committed `sources` file.
 
-Use `rhpkg new-sources` from one target distgit branch to upload the verified
-candidate and update that branch's `sources` file:
-
-```console
-$ distgit_branch=rhaos-4.22-rhel-9
-$ rhpkg clone -b "$distgit_branch" containers/openshift-golang-builder
-$ cd openshift-golang-builder
-$ cp /path/to/cross-new.tar.gz cross.tar.gz
-$ md5sum cross.tar.gz
-$ rhpkg new-sources cross.tar.gz
-$ cat sources
-$ cp sources /tmp/openshift-golang-builder-cross.sources
-$ git add sources
-$ git commit -m "Update cross.tar.gz"
-$ git push origin HEAD
-```
-
-Confirm that the digest written to `sources` matches the local archive. The
-lookaside object is content-addressed and only needs to be uploaded once, but
-`sources` is versioned independently on every distgit branch. To update another
-active branch, reuse the generated file and commit it on that branch:
+After promoting the archive on `ocp-artifacts`, run the update script with
+every Brew distgit branch that should consume it. A valid Red Hat Kerberos
+ticket and permission to push to the distgit repository are required:
 
 ```console
-$ next_branch=rhaos-4.22-rhel-8
-$ git fetch origin "$next_branch"
-$ git switch --create "$next_branch" --track "origin/$next_branch"
-$ cp /tmp/openshift-golang-builder-cross.sources sources
-$ git add sources
-$ git commit -m "Update cross.tar.gz"
-$ git push origin HEAD
+$ ./cross/update-brew-cross-sources.sh \
+    rhaos-4.22-rhel-9 \
+    rhaos-4.22-rhel-8
 ```
 
-Repeat the branch update for every active Brew distgit branch whose Dockerfile
-uses `COPY cross.tar.gz`. Branches that do not install the cross toolchain do
-not need the source entry.
+The script downloads `cross.tar.gz` and `sha256sum.txt`, verifies the published
+SHA-256 checksum, and uses `rhpkg new-sources` to upload the archive to the
+lookaside cache once. It then commits the generated `sources` file to each
+specified branch and pushes without force. Branches that already reference the
+archive are identified before the lookaside step and skipped; if all specified
+branches are current, the script exits without uploading, committing, or
+pushing. Because `sources` is versioned independently, every active Brew
+distgit branch whose Dockerfile uses `COPY cross.tar.gz` must be passed to the
+script. Branches that do not install the cross toolchain need no update.
 
 In Jenkins, run the Golang builder job with **Build system** set to `brew`.
 Confirm that the resulting Brew task builds from a distgit commit containing

--- a/cross/README.md
+++ b/cross/README.md
@@ -193,10 +193,6 @@ commits or pushes to distgit. Repeated runs are safe: `rhpkg` detects when the
 same archive is already present in lookaside. `--dry-run` generates the source
 entry offline and performs no upload.
 
-The default context branch is `rhaos-4.22-rhel-9`. Use `--branch` or set
-`BREW_DISTGIT_BRANCH` if that branch is unavailable. The selected branch is
-not modified.
-
 Copy the generated `sources` entry into the source-context `sources` file,
 typically `images/sources`, in every relevant ocp-build-data branch and open a
 PR for those changes. This is the durable source of truth: doozer copies the

--- a/cross/README.md
+++ b/cross/README.md
@@ -175,6 +175,54 @@ Set **Doozer data Git ref** to the source branch of the test PR and set
 resulting Konflux build downloads the candidate archive and completes the
 cross-toolchain steps successfully.
 
+## Update and test the archive in Brew
+
+Brew does not download the archive from the OCP artifacts URL. The Brew
+distgit repository stores `cross.tar.gz` in its lookaside cache, and each
+distgit branch selects the archive through its committed `sources` file.
+
+Use `rhpkg new-sources` from one target distgit branch to upload the verified
+candidate and update that branch's `sources` file:
+
+```console
+$ distgit_branch=rhaos-4.22-rhel-9
+$ rhpkg clone -b "$distgit_branch" containers/openshift-golang-builder
+$ cd openshift-golang-builder
+$ cp /path/to/cross-new.tar.gz cross.tar.gz
+$ md5sum cross.tar.gz
+$ rhpkg new-sources cross.tar.gz
+$ cat sources
+$ cp sources /tmp/openshift-golang-builder-cross.sources
+$ git add sources
+$ git commit -m "Update cross.tar.gz"
+$ git push origin HEAD
+```
+
+Confirm that the digest written to `sources` matches the local archive. The
+lookaside object is content-addressed and only needs to be uploaded once, but
+`sources` is versioned independently on every distgit branch. To update another
+active branch, reuse the generated file and commit it on that branch:
+
+```console
+$ next_branch=rhaos-4.22-rhel-8
+$ git fetch origin "$next_branch"
+$ git switch --create "$next_branch" --track "origin/$next_branch"
+$ cp /tmp/openshift-golang-builder-cross.sources sources
+$ git add sources
+$ git commit -m "Update cross.tar.gz"
+$ git push origin HEAD
+```
+
+Repeat the branch update for every active Brew distgit branch whose Dockerfile
+uses `COPY cross.tar.gz`. Branches that do not install the cross toolchain do
+not need the source entry.
+
+In Jenkins, run the Golang builder job with **Build system** set to `brew`.
+Confirm that the resulting Brew task builds from a distgit commit containing
+the new `sources` digest and that the macOS cross-toolchain compilation
+completes successfully. Updating the Konflux artifact URL or release policy
+does not change which lookaside object a Brew build consumes.
+
 ## Promote the verified archive
 
 After the test PR produces a green build and the result has been verified,
@@ -204,8 +252,10 @@ The Konflux release policy has an `sbom_spdx.allowed_package_sources`
 exception for this archive. After promoting a new `cross.tar.gz`, update the
 embedded SHA-256 digest in the relevant policy file in
 [`konflux-release-data`](https://gitlab.cee.redhat.com/releng/konflux-release-data).
-For the OCP ART production policy, the exception is in
-`config/kflux-ocp-p01.7ayg.p1/product/EnterpriseContractPolicy/registry-ocp-art-base-prod.yaml`.
+The archive URL and its SHA-256 digest may appear in multiple policy files.
+Search the repository for `cross.tar.gz` or the previously published SHA-256
+digest to find every active reference, then replace each matching digest with
+the checksum of the promoted archive.
 
 Open a merge request with the new digest. See
 [konflux-release-data MR #17453](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/17453)

--- a/cross/README.md
+++ b/cross/README.md
@@ -175,38 +175,33 @@ Set **Doozer data Git ref** to the source branch of the test PR and set
 resulting Konflux build downloads the candidate archive and completes the
 cross-toolchain steps successfully.
 
-## Update and test the archive in Brew
+## Upload and test the archive in Brew
 
-Brew does not download the archive during the image build. The Brew distgit
-repository stores `cross.tar.gz` in its lookaside cache, and each distgit
-branch selects the archive through its committed `sources` file.
-
-After promoting the archive on `ocp-artifacts`, run the update script with
-every Brew distgit branch that should consume it. The real update requires
-`rhpkg`, a valid Red Hat Kerberos ticket, and permission to push to the distgit
-repository; dry-run uses the read-only HTTPS Git endpoint:
+Brew obtains `cross.tar.gz` from its lookaside cache. After promoting the
+archive on `ocp-artifacts`, use the helper to verify the published SHA-256 and
+upload the archive:
 
 ```console
-$ ./cross/update-brew-cross-sources.sh --dry-run \
-    rhaos-4.22-rhel-9 \
-    rhaos-4.22-rhel-8
-
-$ ./cross/update-brew-cross-sources.sh \
-    rhaos-4.22-rhel-9 \
-    rhaos-4.22-rhel-8
+$ ./cross/update-brew-cross-sources.sh --dry-run
+$ ./cross/update-brew-cross-sources.sh
 ```
 
-The script downloads `cross.tar.gz` and `sha256sum.txt`, verifies the published
-SHA-256 checksum, and uses `rhpkg new-sources` to upload the archive to the
-lookaside cache once. It then commits the generated `sources` file to each
-specified branch and pushes without force. Branches that already reference the
-archive are identified before the lookaside step and skipped; if all specified
-branches are current, the script exits without uploading, committing, or
-pushing. The `--dry-run` option performs the download, verification, clone,
-branch validation, and comparison without modifying the lookaside cache or
-distgit branches. Because `sources` is versioned independently, every active
-Brew distgit branch whose Dockerfile uses `COPY cross.tar.gz` must be passed to
-the script. Branches that do not install the cross toolchain need no update.
+The real upload requires `rhpkg`, a valid Red Hat Kerberos ticket, and access
+to the Brew distgit repository. The script uses a temporary distgit clone only
+to provide the repository context required by `rhpkg new-sources`. It never
+commits or pushes to distgit. Repeated runs are safe: `rhpkg` detects when the
+same archive is already present in lookaside. `--dry-run` generates the source
+entry offline and performs no upload.
+
+The default context branch is `rhaos-4.22-rhel-9`. Use `--branch` or set
+`BREW_DISTGIT_BRANCH` if that branch is unavailable. The selected branch is
+not modified.
+
+Copy the generated `sources` entry into the source-context `sources` file,
+typically `images/sources`, in every relevant ocp-build-data branch and open a
+PR for those changes. This is the durable source of truth: doozer copies the
+source context during rebase and will overwrite a `sources` file changed only
+in Brew distgit.
 
 In Jenkins, run the Golang builder job with **Build system** set to `brew`.
 Confirm that the resulting Brew task builds from a distgit commit containing

--- a/cross/update-brew-cross-sources.sh
+++ b/cross/update-brew-cross-sources.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly DEFAULT_ARTIFACT_BASE_URL="https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder"
+readonly DEFAULT_DISTGIT_REPO="containers/openshift-golang-builder"
+readonly DEFAULT_COMMIT_MESSAGE="Update cross.tar.gz"
+
+artifact_base_url="${CROSS_ARTIFACT_BASE_URL:-$DEFAULT_ARTIFACT_BASE_URL}"
+distgit_repo="${BREW_DISTGIT_REPO:-$DEFAULT_DISTGIT_REPO}"
+commit_message="${CROSS_DISTGIT_COMMIT_MESSAGE:-$DEFAULT_COMMIT_MESSAGE}"
+branches=()
+branches_to_update=()
+updated_count=0
+declare -A seen_branches=()
+
+usage() {
+  cat <<'EOF'
+Usage: update-brew-cross-sources.sh BRANCH [BRANCH ...]
+
+Download and verify the published cross.tar.gz, upload it to the Brew
+lookaside cache, and update each specified openshift-golang-builder distgit
+branch to use it.
+
+Environment overrides:
+  CROSS_ARTIFACT_BASE_URL       Directory containing cross.tar.gz and sha256sum.txt
+  BREW_DISTGIT_REPO             Distgit repository (default: containers/openshift-golang-builder)
+  CROSS_DISTGIT_COMMIT_MESSAGE  Commit message (default: Update cross.tar.gz)
+
+The script commits and pushes directly to every specified distgit branch.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while (($#)); do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      die "unknown option: $1"
+      ;;
+    *)
+      if [[ ! ${seen_branches[$1]+set} ]]; then
+        branches+=("$1")
+        seen_branches[$1]=1
+      fi
+      shift
+      ;;
+  esac
+done
+
+((${#branches[@]} > 0)) || die "at least one distgit branch is required"
+
+for command in awk basename cmp curl git md5sum mktemp rhpkg sha256sum sha512sum; do
+  command -v "$command" >/dev/null || die "required command not found: $command"
+done
+
+for branch in "${branches[@]}"; do
+  git check-ref-format --branch "$branch" >/dev/null ||
+    die "invalid branch name: $branch"
+done
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/brew-cross-sources.XXXXXXXX")
+trap 'rm -rf "$work_dir"' EXIT
+
+artifact_dir="$work_dir/artifact"
+mkdir -p "$artifact_dir"
+artifact_base_url=${artifact_base_url%/}
+
+printf 'Downloading cross.tar.gz and sha256sum.txt\n'
+curl --fail --location --retry 3 \
+  --output "$artifact_dir/cross.tar.gz" \
+  "$artifact_base_url/cross.tar.gz"
+curl --fail --location --retry 3 \
+  --output "$artifact_dir/sha256sum.txt" \
+  "$artifact_base_url/sha256sum.txt"
+
+(
+  cd "$artifact_dir"
+  sha256sum --check --strict sha256sum.txt
+)
+
+archive_sha256=$(sha256sum "$artifact_dir/cross.tar.gz" | awk '{print $1}')
+archive_md5=$(md5sum "$artifact_dir/cross.tar.gz" | awk '{print $1}')
+archive_sha512=$(sha512sum "$artifact_dir/cross.tar.gz" | awk '{print $1}')
+printf 'Verified SHA-256: %s\n' "$archive_sha256"
+printf 'Archive MD5: %s\n' "$archive_md5"
+
+first_branch=${branches[0]}
+(
+  cd "$work_dir"
+  rhpkg clone -b "$first_branch" "$distgit_repo"
+)
+
+distgit_dir="$work_dir/$(basename "$distgit_repo")"
+[[ -d "$distgit_dir/.git" ]] || die "rhpkg did not create $distgit_dir"
+
+git -C "$distgit_dir" fetch origin
+for branch in "${branches[@]}"; do
+  git -C "$distgit_dir" show-ref --verify --quiet "refs/remotes/origin/$branch" ||
+    die "distgit branch not found: $branch"
+done
+
+sources_matches_archive() {
+  local sources_file=$1
+
+  awk \
+    -v md5="$archive_md5" \
+    -v sha256="$archive_sha256" \
+    -v sha512="$archive_sha512" '
+      ($1 == md5 || $1 == sha256 || $1 == sha512) &&
+          ($2 == "cross.tar.gz" || $2 == "*cross.tar.gz") { found = 1 }
+      $1 == "SHA256" && $2 == "(cross.tar.gz)" && $3 == "=" && $4 == sha256 { found = 1 }
+      $1 == "SHA512" && $2 == "(cross.tar.gz)" && $3 == "=" && $4 == sha512 { found = 1 }
+      END { exit !found }
+    ' "$sources_file"
+}
+
+branch_index=0
+for branch in "${branches[@]}"; do
+  branch_sources="$work_dir/branch-sources-$branch_index"
+  ((branch_index += 1))
+
+  if git -C "$distgit_dir" show "origin/$branch:sources" >"$branch_sources" 2>/dev/null &&
+    sources_matches_archive "$branch_sources"; then
+    printf '%s already references the published archive; skipping\n' "$branch"
+  else
+    branches_to_update+=("$branch")
+  fi
+done
+
+if ((${#branches_to_update[@]} == 0)); then
+  printf 'All %s distgit branch(es) already reference the published archive.\n' \
+    "${#branches[@]}"
+  exit 0
+fi
+
+cp "$artifact_dir/cross.tar.gz" "$distgit_dir/cross.tar.gz"
+(
+  cd "$distgit_dir"
+  rhpkg new-sources cross.tar.gz
+)
+
+generated_sources="$work_dir/sources"
+[[ -s "$distgit_dir/sources" ]] || die "rhpkg did not generate a sources file"
+cp "$distgit_dir/sources" "$generated_sources"
+printf 'Generated sources entry:\n'
+cat "$generated_sources"
+
+if git -C "$distgit_dir" ls-files --error-unmatch sources >/dev/null 2>&1; then
+  git -C "$distgit_dir" restore --staged --worktree -- sources
+else
+  rm -f "$distgit_dir/sources"
+fi
+rm -f "$distgit_dir/cross.tar.gz"
+
+for branch in "${branches_to_update[@]}"; do
+  printf '\nUpdating %s\n' "$branch"
+  git -C "$distgit_dir" checkout --detach "origin/$branch"
+
+  if [[ -f "$distgit_dir/sources" ]] &&
+    cmp --silent "$generated_sources" "$distgit_dir/sources"; then
+    printf '%s already references this archive; skipping\n' "$branch"
+    continue
+  fi
+
+  cp "$generated_sources" "$distgit_dir/sources"
+  git -C "$distgit_dir" add -- sources
+  git -C "$distgit_dir" commit -m "$commit_message" -- sources
+  git -C "$distgit_dir" push origin "HEAD:refs/heads/$branch"
+  ((updated_count += 1))
+done
+
+printf '\nUpdated %s distgit branch(es); %s already current.\n' \
+  "$updated_count" "$(( ${#branches[@]} - updated_count ))"

--- a/cross/update-brew-cross-sources.sh
+++ b/cross/update-brew-cross-sources.sh
@@ -4,11 +4,14 @@ set -euo pipefail
 
 readonly DEFAULT_ARTIFACT_BASE_URL="https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder"
 readonly DEFAULT_DISTGIT_REPO="containers/openshift-golang-builder"
+readonly DEFAULT_DISTGIT_GIT_URL="https://pkgs.devel.redhat.com/git/containers/openshift-golang-builder"
 readonly DEFAULT_COMMIT_MESSAGE="Update cross.tar.gz"
 
 artifact_base_url="${CROSS_ARTIFACT_BASE_URL:-$DEFAULT_ARTIFACT_BASE_URL}"
 distgit_repo="${BREW_DISTGIT_REPO:-$DEFAULT_DISTGIT_REPO}"
+distgit_git_url="${BREW_DISTGIT_GIT_URL:-$DEFAULT_DISTGIT_GIT_URL}"
 commit_message="${CROSS_DISTGIT_COMMIT_MESSAGE:-$DEFAULT_COMMIT_MESSAGE}"
+dry_run=false
 branches=()
 branches_to_update=()
 updated_count=0
@@ -16,7 +19,7 @@ declare -A seen_branches=()
 
 usage() {
   cat <<'EOF'
-Usage: update-brew-cross-sources.sh BRANCH [BRANCH ...]
+Usage: update-brew-cross-sources.sh [--dry-run] BRANCH [BRANCH ...]
 
 Download and verify the published cross.tar.gz, upload it to the Brew
 lookaside cache, and update each specified openshift-golang-builder distgit
@@ -25,7 +28,12 @@ branch to use it.
 Environment overrides:
   CROSS_ARTIFACT_BASE_URL       Directory containing cross.tar.gz and sha256sum.txt
   BREW_DISTGIT_REPO             Distgit repository (default: containers/openshift-golang-builder)
+  BREW_DISTGIT_GIT_URL          Read-only distgit URL used by --dry-run
   CROSS_DISTGIT_COMMIT_MESSAGE  Commit message (default: Update cross.tar.gz)
+
+Options:
+  --dry-run  Verify and compare the archive without uploading, committing, or pushing
+  -h, --help  Show this help
 
 The script commits and pushes directly to every specified distgit branch.
 EOF
@@ -38,6 +46,10 @@ die() {
 
 while (($#)); do
   case "$1" in
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -57,9 +69,12 @@ done
 
 ((${#branches[@]} > 0)) || die "at least one distgit branch is required"
 
-for command in awk basename cmp curl git md5sum mktemp rhpkg sha256sum sha512sum; do
+for command in awk basename cmp curl git md5sum mktemp sha256sum sha512sum; do
   command -v "$command" >/dev/null || die "required command not found: $command"
 done
+if [[ $dry_run == false ]]; then
+  command -v rhpkg >/dev/null || die "required command not found: rhpkg"
+fi
 
 for branch in "${branches[@]}"; do
   git check-ref-format --branch "$branch" >/dev/null ||
@@ -74,10 +89,10 @@ mkdir -p "$artifact_dir"
 artifact_base_url=${artifact_base_url%/}
 
 printf 'Downloading cross.tar.gz and sha256sum.txt\n'
-curl --fail --location --retry 3 \
+curl --fail --silent --show-error --location --retry 3 \
   --output "$artifact_dir/cross.tar.gz" \
   "$artifact_base_url/cross.tar.gz"
-curl --fail --location --retry 3 \
+curl --fail --silent --show-error --location --retry 3 \
   --output "$artifact_dir/sha256sum.txt" \
   "$artifact_base_url/sha256sum.txt"
 
@@ -93,13 +108,18 @@ printf 'Verified SHA-256: %s\n' "$archive_sha256"
 printf 'Archive MD5: %s\n' "$archive_md5"
 
 first_branch=${branches[0]}
-(
-  cd "$work_dir"
-  rhpkg clone -b "$first_branch" "$distgit_repo"
-)
+if [[ $dry_run == true ]]; then
+  git clone --branch "$first_branch" "$distgit_git_url" \
+    "$work_dir/$(basename "$distgit_repo")"
+else
+  (
+    cd "$work_dir"
+    rhpkg clone -b "$first_branch" "$distgit_repo"
+  )
+fi
 
 distgit_dir="$work_dir/$(basename "$distgit_repo")"
-[[ -d "$distgit_dir/.git" ]] || die "rhpkg did not create $distgit_dir"
+[[ -d "$distgit_dir/.git" ]] || die "distgit clone did not create $distgit_dir"
 
 git -C "$distgit_dir" fetch origin
 for branch in "${branches[@]}"; do
@@ -138,6 +158,16 @@ done
 if ((${#branches_to_update[@]} == 0)); then
   printf 'All %s distgit branch(es) already reference the published archive.\n' \
     "${#branches[@]}"
+  exit 0
+fi
+
+if [[ $dry_run == true ]]; then
+  printf 'Dry run: would upload cross.tar.gz with MD5 %s to Brew lookaside.\n' \
+    "$archive_md5"
+  for branch in "${branches_to_update[@]}"; do
+    printf 'Dry run: would update %s.\n' "$branch"
+  done
+  printf 'Dry run: no lookaside upload, commit, or push was performed.\n'
   exit 0
 fi
 

--- a/cross/update-brew-cross-sources.sh
+++ b/cross/update-brew-cross-sources.sh
@@ -4,38 +4,36 @@ set -euo pipefail
 
 readonly DEFAULT_ARTIFACT_BASE_URL="https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder"
 readonly DEFAULT_DISTGIT_REPO="containers/openshift-golang-builder"
+readonly DEFAULT_DISTGIT_BRANCH="rhaos-4.22-rhel-9"
 readonly DEFAULT_DISTGIT_GIT_URL="https://pkgs.devel.redhat.com/git/containers/openshift-golang-builder"
-readonly DEFAULT_COMMIT_MESSAGE="Update cross.tar.gz"
 
 artifact_base_url="${CROSS_ARTIFACT_BASE_URL:-$DEFAULT_ARTIFACT_BASE_URL}"
 distgit_repo="${BREW_DISTGIT_REPO:-$DEFAULT_DISTGIT_REPO}"
+distgit_branch="${BREW_DISTGIT_BRANCH:-$DEFAULT_DISTGIT_BRANCH}"
 distgit_git_url="${BREW_DISTGIT_GIT_URL:-$DEFAULT_DISTGIT_GIT_URL}"
-commit_message="${CROSS_DISTGIT_COMMIT_MESSAGE:-$DEFAULT_COMMIT_MESSAGE}"
 dry_run=false
-branches=()
-branches_to_update=()
-updated_count=0
-declare -A seen_branches=()
 
 usage() {
   cat <<'EOF'
-Usage: update-brew-cross-sources.sh [--dry-run] BRANCH [BRANCH ...]
+Usage: update-brew-cross-sources.sh [--dry-run] [--branch DISTGIT_BRANCH]
 
-Download and verify the published cross.tar.gz, upload it to the Brew
-lookaside cache, and update each specified openshift-golang-builder distgit
-branch to use it.
+Download and verify the published cross.tar.gz, then upload it to the Brew
+lookaside cache. The distgit clone is temporary; this script never commits or
+pushes to a distgit branch.
 
 Environment overrides:
-  CROSS_ARTIFACT_BASE_URL       Directory containing cross.tar.gz and sha256sum.txt
-  BREW_DISTGIT_REPO             Distgit repository (default: containers/openshift-golang-builder)
-  BREW_DISTGIT_GIT_URL          Read-only distgit URL used by --dry-run
-  CROSS_DISTGIT_COMMIT_MESSAGE  Commit message (default: Update cross.tar.gz)
+  CROSS_ARTIFACT_BASE_URL  Directory containing cross.tar.gz and sha256sum.txt
+  BREW_DISTGIT_REPO        Distgit repository (default: containers/openshift-golang-builder)
+  BREW_DISTGIT_BRANCH      Branch used only to establish an rhpkg context
+  BREW_DISTGIT_GIT_URL     Read-only distgit URL used by --dry-run
 
 Options:
-  --dry-run  Verify and compare the archive without uploading, committing, or pushing
-  -h, --help  Show this help
+  --branch BRANCH  Branch used only to establish an rhpkg context
+  --dry-run        Generate the sources entry offline without uploading
+  -h, --help       Show this help
 
-The script commits and pushes directly to every specified distgit branch.
+Copy the generated sources entry into the source-context sources file in each
+relevant ocp-build-data branch.
 EOF
 }
 
@@ -46,6 +44,11 @@ die() {
 
 while (($#)); do
   case "$1" in
+    --branch)
+      (($# >= 2)) || die "--branch requires a value"
+      distgit_branch=$2
+      shift 2
+      ;;
     --dry-run)
       dry_run=true
       shift
@@ -54,34 +57,19 @@ while (($#)); do
       usage
       exit 0
       ;;
-    -*)
-      die "unknown option: $1"
-      ;;
     *)
-      if [[ ! ${seen_branches[$1]+set} ]]; then
-        branches+=("$1")
-        seen_branches[$1]=1
-      fi
-      shift
+      die "unknown argument: $1"
       ;;
   esac
 done
 
-((${#branches[@]} > 0)) || die "at least one distgit branch is required"
-
-for command in awk basename cmp curl git md5sum mktemp sha256sum sha512sum; do
+for command in awk basename curl git mktemp rhpkg sha256sum; do
   command -v "$command" >/dev/null || die "required command not found: $command"
 done
-if [[ $dry_run == false ]]; then
-  command -v rhpkg >/dev/null || die "required command not found: rhpkg"
-fi
+git check-ref-format --branch "$distgit_branch" >/dev/null ||
+  die "invalid branch name: $distgit_branch"
 
-for branch in "${branches[@]}"; do
-  git check-ref-format --branch "$branch" >/dev/null ||
-    die "invalid branch name: $branch"
-done
-
-work_dir=$(mktemp -d "${TMPDIR:-/tmp}/brew-cross-sources.XXXXXXXX")
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/brew-cross-lookaside.XXXXXXXX")
 trap 'rm -rf "$work_dir"' EXIT
 
 artifact_dir="$work_dir/artifact"
@@ -102,110 +90,37 @@ curl --fail --silent --show-error --location --retry 3 \
 )
 
 archive_sha256=$(sha256sum "$artifact_dir/cross.tar.gz" | awk '{print $1}')
-archive_md5=$(md5sum "$artifact_dir/cross.tar.gz" | awk '{print $1}')
-archive_sha512=$(sha512sum "$artifact_dir/cross.tar.gz" | awk '{print $1}')
 printf 'Verified SHA-256: %s\n' "$archive_sha256"
-printf 'Archive MD5: %s\n' "$archive_md5"
 
-first_branch=${branches[0]}
 if [[ $dry_run == true ]]; then
-  git clone --branch "$first_branch" "$distgit_git_url" \
+  git clone --branch "$distgit_branch" "$distgit_git_url" \
     "$work_dir/$(basename "$distgit_repo")"
 else
   (
     cd "$work_dir"
-    rhpkg clone -b "$first_branch" "$distgit_repo"
+    rhpkg clone -b "$distgit_branch" "$distgit_repo"
   )
 fi
 
 distgit_dir="$work_dir/$(basename "$distgit_repo")"
 [[ -d "$distgit_dir/.git" ]] || die "distgit clone did not create $distgit_dir"
 
-git -C "$distgit_dir" fetch origin
-for branch in "${branches[@]}"; do
-  git -C "$distgit_dir" show-ref --verify --quiet "refs/remotes/origin/$branch" ||
-    die "distgit branch not found: $branch"
-done
-
-sources_matches_archive() {
-  local sources_file=$1
-
-  awk \
-    -v md5="$archive_md5" \
-    -v sha256="$archive_sha256" \
-    -v sha512="$archive_sha512" '
-      ($1 == md5 || $1 == sha256 || $1 == sha512) &&
-          ($2 == "cross.tar.gz" || $2 == "*cross.tar.gz") { found = 1 }
-      $1 == "SHA256" && $2 == "(cross.tar.gz)" && $3 == "=" && $4 == sha256 { found = 1 }
-      $1 == "SHA512" && $2 == "(cross.tar.gz)" && $3 == "=" && $4 == sha512 { found = 1 }
-      END { exit !found }
-    ' "$sources_file"
-}
-
-branch_index=0
-for branch in "${branches[@]}"; do
-  branch_sources="$work_dir/branch-sources-$branch_index"
-  ((branch_index += 1))
-
-  if git -C "$distgit_dir" show "origin/$branch:sources" >"$branch_sources" 2>/dev/null &&
-    sources_matches_archive "$branch_sources"; then
-    printf '%s already references the published archive; skipping\n' "$branch"
-  else
-    branches_to_update+=("$branch")
-  fi
-done
-
-if ((${#branches_to_update[@]} == 0)); then
-  printf 'All %s distgit branch(es) already reference the published archive.\n' \
-    "${#branches[@]}"
-  exit 0
-fi
-
-if [[ $dry_run == true ]]; then
-  printf 'Dry run: would upload cross.tar.gz with MD5 %s to Brew lookaside.\n' \
-    "$archive_md5"
-  for branch in "${branches_to_update[@]}"; do
-    printf 'Dry run: would update %s.\n' "$branch"
-  done
-  printf 'Dry run: no lookaside upload, commit, or push was performed.\n'
-  exit 0
-fi
-
 cp "$artifact_dir/cross.tar.gz" "$distgit_dir/cross.tar.gz"
 (
   cd "$distgit_dir"
-  rhpkg new-sources cross.tar.gz
+  if [[ $dry_run == true ]]; then
+    rhpkg new-sources --offline cross.tar.gz
+  else
+    rhpkg new-sources cross.tar.gz
+  fi
 )
 
-generated_sources="$work_dir/sources"
 [[ -s "$distgit_dir/sources" ]] || die "rhpkg did not generate a sources file"
-cp "$distgit_dir/sources" "$generated_sources"
 printf 'Generated sources entry:\n'
-cat "$generated_sources"
+cat "$distgit_dir/sources"
 
-if git -C "$distgit_dir" ls-files --error-unmatch sources >/dev/null 2>&1; then
-  git -C "$distgit_dir" restore --staged --worktree -- sources
+if [[ $dry_run == true ]]; then
+  printf 'Dry run complete; no lookaside upload was performed.\n'
 else
-  rm -f "$distgit_dir/sources"
+  printf 'Lookaside upload complete; no distgit commit or push was performed.\n'
 fi
-rm -f "$distgit_dir/cross.tar.gz"
-
-for branch in "${branches_to_update[@]}"; do
-  printf '\nUpdating %s\n' "$branch"
-  git -C "$distgit_dir" checkout --detach "origin/$branch"
-
-  if [[ -f "$distgit_dir/sources" ]] &&
-    cmp --silent "$generated_sources" "$distgit_dir/sources"; then
-    printf '%s already references this archive; skipping\n' "$branch"
-    continue
-  fi
-
-  cp "$generated_sources" "$distgit_dir/sources"
-  git -C "$distgit_dir" add -- sources
-  git -C "$distgit_dir" commit -m "$commit_message" -- sources
-  git -C "$distgit_dir" push origin "HEAD:refs/heads/$branch"
-  ((updated_count += 1))
-done
-
-printf '\nUpdated %s distgit branch(es); %s already current.\n' \
-  "$updated_count" "$(( ${#branches[@]} - updated_count ))"

--- a/cross/update-brew-cross-sources.sh
+++ b/cross/update-brew-cross-sources.sh
@@ -4,18 +4,16 @@ set -euo pipefail
 
 readonly DEFAULT_ARTIFACT_BASE_URL="https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-golang-builder"
 readonly DEFAULT_DISTGIT_REPO="containers/openshift-golang-builder"
-readonly DEFAULT_DISTGIT_BRANCH="rhaos-4.22-rhel-9"
 readonly DEFAULT_DISTGIT_GIT_URL="https://pkgs.devel.redhat.com/git/containers/openshift-golang-builder"
 
 artifact_base_url="${CROSS_ARTIFACT_BASE_URL:-$DEFAULT_ARTIFACT_BASE_URL}"
 distgit_repo="${BREW_DISTGIT_REPO:-$DEFAULT_DISTGIT_REPO}"
-distgit_branch="${BREW_DISTGIT_BRANCH:-$DEFAULT_DISTGIT_BRANCH}"
 distgit_git_url="${BREW_DISTGIT_GIT_URL:-$DEFAULT_DISTGIT_GIT_URL}"
 dry_run=false
 
 usage() {
   cat <<'EOF'
-Usage: update-brew-cross-sources.sh [--dry-run] [--branch DISTGIT_BRANCH]
+Usage: update-brew-cross-sources.sh [--dry-run]
 
 Download and verify the published cross.tar.gz, then upload it to the Brew
 lookaside cache. The distgit clone is temporary; this script never commits or
@@ -24,13 +22,11 @@ pushes to a distgit branch.
 Environment overrides:
   CROSS_ARTIFACT_BASE_URL  Directory containing cross.tar.gz and sha256sum.txt
   BREW_DISTGIT_REPO        Distgit repository (default: containers/openshift-golang-builder)
-  BREW_DISTGIT_BRANCH      Branch used only to establish an rhpkg context
   BREW_DISTGIT_GIT_URL     Read-only distgit URL used by --dry-run
 
 Options:
-  --branch BRANCH  Branch used only to establish an rhpkg context
-  --dry-run        Generate the sources entry offline without uploading
-  -h, --help       Show this help
+  --dry-run   Generate the sources entry offline without uploading
+  -h, --help  Show this help
 
 Copy the generated sources entry into the source-context sources file in each
 relevant ocp-build-data branch.
@@ -44,11 +40,6 @@ die() {
 
 while (($#)); do
   case "$1" in
-    --branch)
-      (($# >= 2)) || die "--branch requires a value"
-      distgit_branch=$2
-      shift 2
-      ;;
     --dry-run)
       dry_run=true
       shift
@@ -66,8 +57,6 @@ done
 for command in awk basename curl git mktemp rhpkg sha256sum; do
   command -v "$command" >/dev/null || die "required command not found: $command"
 done
-git check-ref-format --branch "$distgit_branch" >/dev/null ||
-  die "invalid branch name: $distgit_branch"
 
 work_dir=$(mktemp -d "${TMPDIR:-/tmp}/brew-cross-lookaside.XXXXXXXX")
 trap 'rm -rf "$work_dir"' EXIT
@@ -93,12 +82,12 @@ archive_sha256=$(sha256sum "$artifact_dir/cross.tar.gz" | awk '{print $1}')
 printf 'Verified SHA-256: %s\n' "$archive_sha256"
 
 if [[ $dry_run == true ]]; then
-  git clone --branch "$distgit_branch" "$distgit_git_url" \
+  git clone "$distgit_git_url" \
     "$work_dir/$(basename "$distgit_repo")"
 else
   (
     cd "$work_dir"
-    rhpkg clone -b "$distgit_branch" "$distgit_repo"
+    rhpkg clone "$distgit_repo"
   )
 fi
 


### PR DESCRIPTION
## Summary

- add an idempotent helper that verifies the published archive and uploads it to Brew lookaside
- print the generated SHA-512 `sources` entry after upload
- document updating the source-context `sources` file in each relevant ocp-build-data branch with an example PR
- document Konflux release-policy updates

## Validation

- `git diff --check`
- `bash -n cross/update-brew-cross-sources.sh`
- `shellcheck cross/update-brew-cross-sources.sh`
- global pre-commit and commit-message hooks
