### PR TITLE
ART-21676: Update Golang cross bundle source

### DIFF
--- a/images/sources
+++ b/images/sources
@@ -1,1 +1,1 @@
-aa3375e0864e7232488c548ffaa806e1  cross.tar.gz
+SHA512 (cross.tar.gz) = 7f88be5ff323fbdb0ba1bd2743f5acfaa00ba7816d94d2d573a7ab4ebb35c8675f3a695edc1726904bf1ae0dc7d4920ce3ff0e4c73d7301dfcc3cd2079cf28f1


### PR DESCRIPTION
## Summary

- update `images/sources` to reference the rebuilt `cross.tar.gz` in Brew lookaside
- ensure Golang builder rebases retain the current cross bundle source

## Validation

- source entry generated by `rhpkg new-sources`
- `git diff --check`
- global pre-commit and commit-message hooks
