### PR TITLE
ART-21676: Update Golang cross bundle source

### DIFF
--- a/Dockerfiles/SOURCES.md
+++ b/Dockerfiles/SOURCES.md
@@ -1,0 +1,5 @@
+# External sources
+
+`cross.tar.gz` is published on `ocp-artifacts` and uploaded to Brew lookaside
+for Brew builds. Konflux downloads the archive directly from `ocp-artifacts`
+and does not use the `sources` file.

--- a/Dockerfiles/sources
+++ b/Dockerfiles/sources
@@ -1,0 +1,1 @@
+SHA512 (cross.tar.gz) = 7f88be5ff323fbdb0ba1bd2743f5acfaa00ba7816d94d2d573a7ab4ebb35c8675f3a695edc1726904bf1ae0dc7d4920ce3ff0e4c73d7301dfcc3cd2079cf28f1


### PR DESCRIPTION
## Summary

- add the Brew lookaside entry for the rebuilt `cross.tar.gz` to the shared Dockerfile source context
- ensure Golang builder rebases carry the current cross bundle source into Dist-Git
- document that Brew uses lookaside while Konflux downloads the archive directly from ocp-artifacts

## Validation

- source entry generated by `rhpkg new-sources`
- source entry parsed with the installed `rhpkg` library
- `git diff --check`
- global pre-commit and commit-message hooks
