### PR TITLE
Add RHCOS kernel CVE(s) to 4.22.6 assembly issues.include

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -48,6 +48,14 @@ releases:
             aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:58a751029e8d5a758471e2189e37554f732b42c8ff429bd2c57d5d9b9dfe37c0
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1afddb375c230aece97a643c60f30b33d4077ae70dfb6752726e73aa4e5f994e
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9ef2e0df88ee6dc0dde46b23bc40ddddecb1f0ba9373acace3bdbc5850736df3
+      issues:
+        include:
+          - id: OCPBUGS-98234
+          - id: OCPBUGS-98250
+          - id: OCPBUGS-98395
+          - id: OCPBUGS-93783
+          - id: OCPBUGS-90700
+          - id: OCPBUGS-88152
       members:
         rpms: []
         images: []


### PR DESCRIPTION
Include post-cutoff verified CVE tracker bugs for sweep pickup:
- OCPBUGS-98234 (CVE-2026-53359)