### PR TITLE
Add RHCOS kernel CVE(s) to 4.21.25 assembly issues.include

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -48,6 +48,11 @@ releases:
             aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0d5f03ccf278b46d72a72f07a34fb56b5430411c2f6a10fb070f150ec9c0bf1c
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0ac5368eaa3c899f88e6282fc24d22baf5cd9f59c76e1db56c011ddd7b8b58d0
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2f82918e4e280a26d7bffc54ddea4a93f975b568420ad8aa6a54efc228b1f4bc
+      issues:
+        include:
+          - id: OCPBUGS-98236
+          - id: OCPBUGS-98396
+          - id: OCPBUGS-98249
       members:
         rpms: []
         images: []


### PR DESCRIPTION
Include post-cutoff verified CVE tracker bugs for sweep pickup:
- OCPBUGS-98236 (CVE-2026-53359)
- OCPBUGS-98396 (CVE-2026-46242)