### PR TITLE
Add RHCOS kernel CVE(s) to 4.20.30 assembly issues.include

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -36,6 +36,11 @@ releases:
             aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:63d2acc6d2f7f6b2eca9dca96cd6a2d3bedad91ab4196bf9de46d18d2b30aba9
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2793205e006b88926087fa5b23b6a0004d076cdd2d2001aa97410fd6d83ca8c7
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b87632368e7b0d484e8678b963350b756dd45e216bd9ff8cfe652e6b260dc32d
+      issues:
+        include:
+          - id: OCPBUGS-98237
+          - id: OCPBUGS-98391
+          - id: OCPBUGS-98243
       members:
         rpms: []
         images: []


### PR DESCRIPTION
Include post-cutoff verified CVE tracker bugs for sweep pickup:
- OCPBUGS-98237 (CVE-2026-53359)
- OCPBUGS-98391 (CVE-2026-46242)