### PR TITLE
Clean up golang streams in multus-cni.yml

### DIFF
--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -28,8 +28,6 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: rhel-9-golang
-  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 labels:
   io.k8s.description: This is a component of OpenShift Container Platform and provides a meta CNI plugin.


### PR DESCRIPTION
Removed duplicate and outdated golang streams from the builder section.

follows https://github.com/openshift/multus-cni/pull/285