### PR TITLE
Add cri-o RPM config for ART automation

### DIFF
--- a/rpms/cri-o.yml
+++ b/rpms/cri-o.yml
@@ -3,7 +3,7 @@ content:
     git:
       branch:
         target: add-openshift-spec-v2
-      url: git@github.com:bitoku/cri-o.git
+      url: git@github.com:openshift-priv/cri-o.git
       web: https://github.com/openshift/cri-o
     specfile: cri-o.spec
 name: cri-o

--- a/rpms/cri-o.yml
+++ b/rpms/cri-o.yml
@@ -3,8 +3,7 @@ content:
     git:
       branch:
         target: add-openshift-spec-v2
-      url: git@github.com:openshift-priv/cri-o.git
-      url_pull: git@github.com:bitoku/cri-o.git # TODO: remove once openshift/cri-o#31 merges
+      url: git@github.com:bitoku/cri-o.git
       web: https://github.com/openshift/cri-o
     specfile: cri-o.spec
 name: cri-o

--- a/rpms/cri-o.yml
+++ b/rpms/cri-o.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    git:
+      branch:
+        target: add-openshift-spec-v2
+      url: git@github.com:openshift-priv/cri-o.git
+      url_pull: git@github.com:bitoku/cri-o.git # TODO: remove once openshift/cri-o#31 merges
+      web: https://github.com/openshift/cri-o
+    specfile: cri-o.spec
+name: cri-o
+owners:
+- sgrunert@redhat.com
+- qiwan@redhat.com
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+- rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+- rhaos-{MAJOR}.{MINOR}-rhel-10-hotfix

--- a/rpms/cri-o.yml
+++ b/rpms/cri-o.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: add-openshift-spec-v2
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cri-o.git
       web: https://github.com/openshift/cri-o
     specfile: cri-o.spec


### PR DESCRIPTION
## Summary
- Onboard the cri-o RPM build to ART's standard automation ([ART-21310](https://redhat.atlassian.net/browse/ART-21310))
- Adds `rpms/cri-o.yml` targeting RHEL 9 and RHEL 10 for OCP 4.23
- Uses `url_pull` to point at the fork branch (`bitoku/cri-o:add-openshift-spec-v2`) while [openshift/cri-o#31](https://github.com/openshift/cri-o/pull/31) is still open

## Test plan
- [ ] Validate test assembly build succeeds
- [ ] Run test assembly plashet
- [ ] Run stream assembly plashet
- [ ] Remove `url_pull` and update `target` branch after openshift/cri-o#31 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)