### PR TITLE
ART-14750: Switch golang-builder to plashet + signed RPMs (rhel-9-golang-1.19)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -10,6 +10,8 @@ vars:
   MAJOR: 4
   MINOR: 13
 
+sign_golang_rpm: true
+
 konflux:
   network_mode: hermetic
   build_attempts: 1
@@ -45,12 +47,12 @@ repos:
       extra_options:
         module_hotfixes: 1
         # this repo provides complete RHEL 9 build env; we just want the go-toolset content
-        includepkgs: module-build-macros golang* goversioninfo
+        includepkgs: golang* goversioninfo
       baseurl:
-        aarch64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/aarch64/
-        ppc64le: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/ppc64le/
-        s390x: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/s390x/
-        x86_64: https://download.devel.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-9-build/latest/x86_64/
+        aarch64: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el9/latest/aarch64/os/
+        ppc64le: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el9/latest/ppc64le/os/
+        s390x: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el9/latest/s390x/os/
+        x86_64: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/stream/golang-el9/latest/x86_64/os/
     # These content sets are not used, so just putting something here
     content_set:
       default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms


### PR DESCRIPTION
## Summary
- Switch `rhel-9-golang-rpms` repo from brewroot URLs to plashet URLs (signed RPMs)
- Remove `module-build-macros` from `includepkgs`
- Add `sign_golang_rpm: true` (sustaining golang — auto-signed via brew tags)