### PR TITLE
fix(acm-2.16): correct delivery_repo_names for multiclusterhub-operator

### DIFF
--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -11,7 +11,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/multiclusterhub-operator-rhel9
+  - rhacm2/multiclusterhub-rhel9
   bundle_delivery_repo_name: rhacm2/acm-operator-bundle
 for_payload: false
 enabled_repos:


### PR DESCRIPTION
The actual registry repo is rhacm2/multiclusterhub-rhel9, not rhacm2/multiclusterhub-operator-rhel9. PR #11536 fixed the name field but missed delivery_repo_names.