### PR TITLE
Bump repos to RHEL 9.7, use floating tag, add Go 1.26 stream [mce-2.11]

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -79,30 +79,30 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/baseos/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/baseos/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/baseos/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/baseos/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
     content_set:
-      default: rhel-9-for-x86_64-baseos-e4s-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-baseos-e4s-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-baseos-e4s-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-baseos-e4s-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-baseos-rpms
+      aarch64: rhel-9-for-aarch64-baseos-rpms
+      ppc64le: rhel-9-for-ppc64le-baseos-rpms
+      s390x: rhel-9-for-s390x-baseos-rpms
     reposync:
       enabled: false
 
   rhel-9-appstream-rpms:
     conf:
       baseurl:
-        aarch64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/aarch64/appstream/os/
-        ppc64le: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/ppc64le/appstream/os/
-        s390x: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/s390x/appstream/os/
-        x86_64: https://rhsm-pulp.corp.redhat.com/content/e4s/rhel9/9.6/x86_64/appstream/os/
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
     content_set:
-      default: rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_6
-      aarch64: rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_6
-      ppc64le: rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_6
-      s390x: rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_6
+      default: rhel-9-for-x86_64-appstream-rpms
+      aarch64: rhel-9-for-aarch64-appstream-rpms
+      ppc64le: rhel-9-for-ppc64le-appstream-rpms
+      s390x: rhel-9-for-s390x-appstream-rpms
     reposync:
       enabled: false
 

--- a/images/discovery-operator.yml
+++ b/images/discovery-operator.yml
@@ -20,7 +20,7 @@ enabled_repos:
 - rhel-9-appstream-rpms
 from:
   builder:
-    - stream: rhel-9-golang-1.25
+    - stream: rhel-9-golang-1.26
   member: base-rhel9
 name: multicluster-engine/discovery-operator-rhel9
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -8,6 +8,9 @@ rhel-9-golang-1.25:
 rhel-8-golang-1.25:
   image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.g2aa6a05.el8
 
+rhel-9-golang-1.26:
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9
+
 rhel-9-nodejs-24:
   image: registry.redhat.io/ubi9/nodejs-24-minimal@sha256:920a22bf794c1e3806b1279a26337ba02d18af7370df18045f5ffd5bf5d54dbc
 
@@ -18,4 +21,4 @@ ose-cli-rhel9:
   image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21
 
 rhel9:
-  image: registry.redhat.io/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00
+  image: registry.redhat.io/ubi9/ubi-minimal:9.7


### PR DESCRIPTION
## Summary

Three fixes for MCE 2.11, mirroring Brian's ACM 2.16 PRs (#11876, #11879):

1. **RHEL 9.7 repos** (`group.yml`): Update from 9.6 E4S to 9.7 to match the base UBI image. Fixes RPM depsolve failures (openssl-libs version conflict).

2. **Floating tag** (`streams.yml`): Replace pinned SHA digest with `ubi-minimal:9.7` so the base image picks up security patches without manual digest updates.

3. **Go 1.26 stream** (`streams.yml` + `images/discovery-operator.yml`): Add `rhel-9-golang-1.26` and update discovery-operator to use it. Upstream `go.mod` requires Go 1.26.3 which isn't available in the 1.25 builder.

Ref: [HYPBLD-854](https://redhat.atlassian.net/browse/HYPBLD-854)

Made with [Cursor](https://cursor.com)