### PR TITLE
no-jira: Add commit_prefix for ART reconciliation PRs in aws-karpenter-provider-aws

### DIFF
--- a/images/aws-karpenter-provider-aws.yml
+++ b/images/aws-karpenter-provider-aws.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/aws-karpenter-provider-aws
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
 distgit:


### PR DESCRIPTION
Add commit_prefix: "UPSTREAM: <carry>: " under
content.source.ci_alignment.streams_prs so ART reconciliation PRs use the correct carry commit prefix.