### PR TITLE
Bump MTA version to 8.2.1

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -2,7 +2,7 @@ freeze_automation: false
 name: mta-8.2
 csv_namespace: mta
 product: mta
-version: 8.2.0
+version: 8.2.1
 
 vars:
   # The go versions used by the various CI builder images.


### PR DESCRIPTION
## Summary
- Bumps `version` in `group.yml` from `8.2.0` to `8.2.1` now that 8.2.0 has been released

## Test plan
- [ ] Verify `group.yml` shows `version: 8.2.1`
- [ ] Confirm builds pick up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)