### PR TITLE
Change architecture URLs to x86_64 in rhel-102-nfv.yml

### DIFF
--- a/repos/rhel-102-nfv.yml
+++ b/repos/rhel-102-nfv.yml
@@ -2,8 +2,8 @@
     baseurl:
       x86_64:  "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/nfv/os/"
       aarch64: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/aarch64/nfv/os/"
-      ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/ppc64le/nfv/os/"
-      s390x:   "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/s390x/nfv/os/"
+      ppc64le: "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/nfv/os/"
+      s390x:   "https://rhsm-pulp.corp.redhat.com/content/e4s/rhel10/10.2/x86_64/nfv/os/"
     extra_options:
       gpgcheck: '1'
   content_set:


### PR DESCRIPTION
Updated architecture URLs to point to x86_64 for ppc64le, and s390x.