### PR TITLE
Bump backplane-operator and hive to Go 1.26 builder [mce-2.11]

### DIFF
--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -20,7 +20,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel9
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang-1.26
   member: base-rhel9
 name: multicluster-engine/backplane-operator-rhel9
 update-csv:

--- a/images/hive.yml
+++ b/images/hive.yml
@@ -30,7 +30,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-8-golang-1.25
-    - stream: rhel-9-golang-1.25
+    - stream: rhel-9-golang-1.26
   member: base-rhel9
 name: multicluster-engine/hive-rhel9
 owners:


### PR DESCRIPTION
## Summary

Fix Go version build failures for backplane-operator and hive:

- **backplane-operator**: `go.mod` requires `>= 1.25.11`, builder has `1.25.8` → switch to `rhel-9-golang-1.26`
- **hive**: `go.mod` requires `>= 1.26.0`, builder has `1.25.9` → switch to `rhel-9-golang-1.26`

Build logs:
```
go: go.mod requires go >= 1.25.11 (running go 1.25.8; GOTOOLCHAIN=local)
go: go.mod requires go >= 1.26.0 (running go 1.25.9; GOTOOLCHAIN=local)
```

Ref: [HYPBLD-854](https://redhat.atlassian.net/browse/HYPBLD-854)

Made with [Cursor](https://cursor.com)