### PR TITLE
Add url_pull for oc-mirror on oc-mirror-2.0 branch

### DIFF
--- a/images/oc-mirror.yml
+++ b/images/oc-mirror.yml
@@ -13,6 +13,7 @@ content:
         # TODO(ART-21250): confirm git.branch.target (main vs release-2.0)
         target: main
       url: git@github.com:openshift-priv/oc-mirror.git
+      url_pull: git@github.com:ashwindasr/oc-mirror.git
       web: https://github.com/openshift/oc-mirror
 distgit:
   branch: oc-mirror-{MAJOR}.{MINOR}-rhel-9


### PR DESCRIPTION
This PR adds the url_pull configuration for oc-mirror in images/oc-mirror.yml.