### PR TITLE
images/vector: exempt pinned RPM from scan-sources

### DIFF
--- a/images/vector.yml
+++ b/images/vector.yml
@@ -40,19 +40,17 @@ jira:
   component: vector-container
 scan_sources:
   exempt_rpms:
-    # Rust toolset (pinned at 1.84.1)
-    - rust*
     - cargo
-    - clippy
-    # LLVM/Clang toolchain (pinned at 19.1.7)
-    - llvm*
     - clang*
-    - lld*
+    - clippy
     - compiler-rt
     - git-clang-format
+    - libasan*
+    - liblsan*
+    - libomp*
+    - libtsan*
+    - lld*
+    - llvm*
     - python3-clang
     - python3-lldb
-    - libomp*
-    # GCC sanitizer libs (pinned at 14.2.1)
-    - libasan*
-    - libtsan*
+    - rust*


### PR DESCRIPTION
Follows https://github.com/openshift-eng/ocp-build-data/pull/11984 and https://github.com/openshift-eng/ocp-build-data/pull/11985

Originally ran against x86_64 RPMs, liblsan is apparently an s390x-only package dependency, so it was missed.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED