### PR TITLE
Bump default Go builder to 1.26 for ACM 2.16

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -5,8 +5,8 @@ product: acm
 version: 2.16.3
 
 vars:
-  GO_LATEST: "1.25"
-  GO_EXTRA: "1.25"
+  GO_LATEST: "1.26"
+  GO_EXTRA: "1.26"
   MAJOR: 4
   MINOR: 21
 

--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9
 
 rhel-9-golang-1.26:
   image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9


### PR DESCRIPTION
Update GO_LATEST and GO_EXTRA vars to 1.26, and point the rhel-9-golang stream to the 1.26.3 builder image.

Ref: [HYPBLD-847](https://redhat.atlassian.net/browse/HYPBLD-847)