### PR TITLE
Bump default Go builder to 1.26 for MCE 2.11

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -5,8 +5,8 @@ product: mce
 version: 2.11.4
 
 vars:
-  GO_LATEST: "1.25"
-  GO_EXTRA: "1.25"
+  GO_LATEST: "1.26"
+  GO_EXTRA: "1.26"
   MAJOR: 4
   MINOR: 21
 

--- a/streams.yml
+++ b/streams.yml
@@ -1,6 +1,6 @@
 ---
 rhel-9-golang:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.8-202604211249.p2.g50071d5.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9
 
 rhel-9-golang-1.25:
   image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.gdf787b0.el9


### PR DESCRIPTION
## Summary

Update GO_LATEST and GO_EXTRA vars to 1.26, and point the rhel-9-golang stream to the 1.26.3 builder image.

Same change as Brian's ACM 2.16 PR #12001. This ensures all MCE components using the default `rhel-9-golang` stream get Go 1.26, fixing Go version build failures across the board.

Ref: [HYPBLD-854](https://redhat.atlassian.net/browse/HYPBLD-854)

Made with [Cursor](https://cursor.com)