### PR TITLE
ART-21310 [openshift-4.23]: point cri-o at branch with OpenShift spec

### DIFF
--- a/rpms/cri-o.yml
+++ b/rpms/cri-o.yml
@@ -3,8 +3,8 @@ content:
     git:
       branch:
         target: art-fix-cri-o-spec-release-4.23
-      url: git@github.com:openshift-priv/cri-o.git
-      web: https://github.com/openshift/cri-o
+      url: git@github.com:lgarciaaco/cri-o.git
+      web: https://github.com/lgarciaaco/cri-o
     specfile: cri-o.spec
 name: cri-o
 owners:

--- a/rpms/cri-o.yml
+++ b/rpms/cri-o.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-{MAJOR}.{MINOR}
+        target: art-fix-cri-o-spec-release-4.23
       url: git@github.com:openshift-priv/cri-o.git
       web: https://github.com/openshift/cri-o
     specfile: cri-o.spec


### PR DESCRIPTION
## Summary
Point openshift-4.23 `rpms/cri-o.yml` at priv branch `art-fix-cri-o-spec-release-4.23`, which has the OpenShift downstream `cri-o.spec` packaging carry.

## Problem
**Before:** `target: release-{MAJOR}.{MINOR}` clones `release-4.23`, which has no root `cri-o.spec`. `ocp4-scan-konflux` fails in scan-sources (e.g. build 54731).

**After:** Source branch includes `cri-o.spec` so scan can initialize cri-o RPM metadata. Revert to `release-{MAJOR}.{MINOR}` after the packaging carry merges to `release-4.23` (openshift-priv/cri-o#11, openshift/cri-o#44).

Related: [ART-21310](https://redhat.atlassian.net/browse/ART-21310)
