### PR TITLE
DRAFT: Revert "Remove oc-mirror from the payload"

### DIFF
--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -27,7 +27,7 @@ delivery:
   repo_name: oc-mirror-plugin
   delivery_repo_names:
   - openshift5/oc-mirror-plugin-rhel9
-for_payload: false
+for_payload: true
 from:
   builder:
   - stream: rhel-8-golang


### PR DESCRIPTION
DRAFT
Reverts openshift-eng/ocp-build-data#11231

This has been created in case we need to revert to get this back into the payload due to konflux pipeline timing. 