### PR TITLE
Set Golang builder distgit overrides

### DIFF
--- a/images/openshift-golang-builder-1-19.rhel8.yml
+++ b/images/openshift-golang-builder-1-19.rhel8.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
+
 enabled_repos:
 - rhel-8-golang-rpms
 - rhel-8-6-baseos-rpms

--- a/images/openshift-golang-builder-1-19.rhel9.yml
+++ b/images/openshift-golang-builder-1-19.rhel9.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+
 enabled_repos:
 - rhel-9-golang-rpms
 - rhel-9-0-baseos-rpms

--- a/images/openshift-golang-builder-1-20.rhel8.yml
+++ b/images/openshift-golang-builder-1-20.rhel8.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
+
 enabled_repos:
 - rhel-8-golang-rpms
 - rhel-8-6-baseos-rpms

--- a/images/openshift-golang-builder-1-20.rhel9.yml
+++ b/images/openshift-golang-builder-1-20.rhel9.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+
 enabled_repos:
 - rhel-9-golang-rpms
 - rhel-9-0-baseos-rpms

--- a/images/openshift-golang-builder-1-21.rhel8.yml
+++ b/images/openshift-golang-builder-1-21.rhel8.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
+
 enabled_repos:
 - rhel-8-golang-rpms
 - rhel-8-6-baseos-rpms

--- a/images/openshift-golang-builder-1-21.rhel9.yml
+++ b/images/openshift-golang-builder-1-21.rhel9.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+
 enabled_repos:
 - rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms

--- a/images/openshift-golang-builder-1-22.rhel8.yml
+++ b/images/openshift-golang-builder-1-22.rhel8.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
+
 enabled_repos:
 - rhel-8-golang-rpms
 - rhel-8-10-baseos-rpms

--- a/images/openshift-golang-builder-1-22.rhel9.yml
+++ b/images/openshift-golang-builder-1-22.rhel9.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+
 enabled_repos:
 - rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms

--- a/images/openshift-golang-builder-1-23.rhel8.yml
+++ b/images/openshift-golang-builder-1-23.rhel8.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
+
 enabled_repos:
 - rhel-8-golang-rpms
 - rhel-8-10-baseos-rpms

--- a/images/openshift-golang-builder-1-23.rhel9.yml
+++ b/images/openshift-golang-builder-1-23.rhel9.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+
 enabled_repos:
 - rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms

--- a/images/openshift-golang-builder-1-24.rhel8.yml
+++ b/images/openshift-golang-builder-1-24.rhel8.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
+
 enabled_repos:
 - rhel-8-golang-rpms
 - rhel-8-10-baseos-rpms

--- a/images/openshift-golang-builder-1-24.rhel9.yml
+++ b/images/openshift-golang-builder-1-24.rhel9.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+
 enabled_repos:
 - rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms

--- a/images/openshift-golang-builder-1-25.rhel8.yml
+++ b/images/openshift-golang-builder-1-25.rhel8.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
+
 enabled_repos:
 - rhel-8-golang-rpms
 - rhel-8-10-baseos-rpms

--- a/images/openshift-golang-builder-1-25.rhel9-4.yml
+++ b/images/openshift-golang-builder-1-25.rhel9-4.yml
@@ -13,6 +13,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+
 enabled_repos:
 - rhel-9-4-baseos-rpms
 - rhel-9-golang-rpms

--- a/images/openshift-golang-builder-1-25.rhel9-6.yml
+++ b/images/openshift-golang-builder-1-25.rhel9-6.yml
@@ -15,6 +15,15 @@ content:
       doozer_source: golang_builder_FIPS_wrapper.sh
       path: go_wrapper.sh
       overwriting: true
+
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
+
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+
 enabled_repos:
 - rhel-9-6-baseos-rpms
 - rhel-9-golang-rpms

--- a/images/openshift-golang-builder-1-26.rhel10.yml
+++ b/images/openshift-golang-builder-1-26.rhel10.yml
@@ -16,6 +16,8 @@ content:
 
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-10
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
 
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-10-hotfix

--- a/images/openshift-golang-builder-1-26.rhel8.yml
+++ b/images/openshift-golang-builder-1-26.rhel8.yml
@@ -16,6 +16,8 @@ content:
 
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
 
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix

--- a/images/openshift-golang-builder-1-26.rhel9.yml
+++ b/images/openshift-golang-builder-1-26.rhel9.yml
@@ -16,6 +16,8 @@ content:
 
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: openshift-golang-builder-container
+  name: openshift-golang-builder
 
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix


### PR DESCRIPTION
## What

- point every versioned Golang builder image at
  `containers/openshift-golang-builder`
- set the shared Brew component explicitly
- set per-image RHEL 8, RHEL 9, and RHEL 10 distgit branches and hotfix targets

## Why

The `golang` monobranch intentionally uses versioned YAML keys such as
`openshift-golang-builder-1-26.rhel8`, but the backing distgit repository is
not versioned. Without an explicit override, Doozer derives and tries to clone
`containers/openshift-golang-builder-1-26`, which does not exist and produces
the misleading access-denied/authentication failure.

This applies the existing `distgit.name` convention explicitly to all 18 real
Golang builder definitions and avoids relying on the group-level RHEL 9
branch/target for RHEL 8 and RHEL 10 variants.

Requires: https://github.com/openshift-eng/art-tools/pull/3206

## Verification

- parsed all 18 changed files with `yq`
- asserted each file has the expected distgit name, component, RHEL branch,
  and hotfix target
- `git diff --check`

The generic schema validator is not usable as a clean gate for this legacy
branch: it rejects pre-existing fields including `doozer_source` and the
already-present 1.26 `targets` entries.

