### PR TITLE
Fix backplane-must-gather delivery name to match Pyxis [mce-2.11]

### DIFF
--- a/images/backplane-must-gather.yml
+++ b/images/backplane-must-gather.yml
@@ -22,7 +22,7 @@ from:
   builder:
     - stream: ose-cli-rhel9
   member: base-rhel9
-name: multicluster-engine/backplane-must-gather-rhel9
+name: multicluster-engine/must-gather-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:


### PR DESCRIPTION
## Summary

Fix `name` field from `multicluster-engine/backplane-must-gather-rhel9` to `multicluster-engine/must-gather-rhel9` to match the actual Pyxis/registry delivery name.

Release pipeline fails with:
```
LabelValidationError: Component 'mce-2-11-backplane-must-gather' name label
('multicluster-engine/backplane-must-gather-rhel9') does not match expected
name ('multicluster-engine/must-gather-rhel9')
```

Ref: [HYPBLD-854](https://redhat.atlassian.net/browse/HYPBLD-854)

Made with [Cursor](https://cursor.com)