### PR TITLE
4.19: switch to ocp-priv

### DIFF
--- a/images/ci-openshift-golang-builder-latest.rhel8.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel8.yml
@@ -17,7 +17,7 @@ content:
       mirror_manifest_list: true
       upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
       upstream_image_mirror:
-      - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
+      - registry.ci.openshift.org/ocp-priv/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
     modifications:
     - action: replace
       match: "ENV CI_RPM_SVC=base-MAJOR-MINOR-rhelX.ocp.svc"

--- a/images/ci-openshift-golang-builder-latest.rhel9.yml
+++ b/images/ci-openshift-golang-builder-latest.rhel9.yml
@@ -17,7 +17,7 @@ content:
       mirror_manifest_list: true
       upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
       upstream_image_mirror:
-      - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
+      - registry.ci.openshift.org/ocp-priv/builder:rhel-9-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
     modifications:
     - action: replace
       match: "ENV CI_RPM_SVC=base-MAJOR-MINOR-rhelX.ocp.svc"


### PR DESCRIPTION
## Summary

The private CI mirror destination for the golang builder images (`ci_alignment.upstream_image_mirror`) still pointed at the old `ocp-private/builder-priv` imagestream, which no longer exists. It has moved to `ocp-priv/builder`.

This was causing `doozer images:streams mirror` (via the `sync-ci-images` pipeline) to fail with:

```
Error from server (NotFound): imagestreams.image.openshift.io "builder-priv" not found
```

Mirrors the fix from PR #11981 (openshift-5.0) and PR #11987 (openshift-4.22).

## Changes

- `images/ci-openshift-golang-builder-latest.rhel8.yml`
- `images/ci-openshift-golang-builder-latest.rhel9.yml`

`ocp-private/builder-priv` → `ocp-priv/builder`

🤖 Generated with [Claude Code](https://claude.com/claude-code)