### PR TITLE
4.17: switch to ocp-priv

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -26,9 +26,9 @@ rhel-9-golang:
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-priv/builder.
   upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}
+    - registry.ci.openshift.org/ocp-priv/builder:rhel-9-golang-1.22-openshift-{MAJOR}.{MINOR}
 
 rhel-8-golang:
   aliases:
@@ -39,9 +39,9 @@ rhel-8-golang:
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-priv/builder.
   upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}
+    - registry.ci.openshift.org/ocp-priv/builder:rhel-8-golang-1.22-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.23:
   aliases:
@@ -52,9 +52,9 @@ rhel-9-golang-1.23:
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-priv/builder.
   upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.23-openshift-{MAJOR}.{MINOR}
+    - registry.ci.openshift.org/ocp-priv/builder:rhel-9-golang-1.23-openshift-{MAJOR}.{MINOR}
 
 rhel-8-golang-1.23:
   aliases:
@@ -65,9 +65,9 @@ rhel-8-golang-1.23:
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-priv/builder.
   upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
+    - registry.ci.openshift.org/ocp-priv/builder:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
 
 ibm-rhel-9-golang-1.22:
   # Mirror non-embargoed golang builders for IBM


### PR DESCRIPTION
## Summary

Mirrors the fix from #11981 (openshift-5.0) and #11987 (openshift-4.22) to `openshift-4.17`.

The private CI mirror destination for the golang builder images still pointed at the old `ocp-private/builder-priv` imagestream, which no longer exists. It has moved to `ocp-priv/builder`. This was causing `doozer images:streams mirror` (via the `sync-ci-images` pipeline) to fail with:

```
Error from server (NotFound): imagestreams.image.openshift.io "builder-priv" not found
```

## Changes

- `streams.yml`: `ocp-private/builder-priv` → `ocp-priv/builder` (URLs and comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)