### PR TITLE
4.14: switch to ocp-priv

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -26,9 +26,9 @@ golang:
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-priv/builder.
   upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
+    - registry.ci.openshift.org/ocp-priv/builder:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
   aliases:
@@ -39,9 +39,9 @@ rhel-9-golang:
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-priv/builder.
   upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
+    - registry.ci.openshift.org/ocp-priv/builder:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
 
 # Go 1.19 on RHEL 9 (pinned); matches openshift-4.12 rhel-9-golang art-images-base image.
 rhel-9-golang-1.19:
@@ -51,9 +51,9 @@ rhel-9-golang-1.19:
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-private/builder-priv.
+  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-priv/builder.
   upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-private/builder-priv:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
+    - registry.ci.openshift.org/ocp-priv/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 # This image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on


### PR DESCRIPTION
## Summary

Mirrors the fix from #11981 (openshift-5.0) and #11987 (openshift-4.22) to `openshift-4.14`.

The private CI mirror destination for the golang builder images still pointed at the old `ocp-private/builder-priv` imagestream, which no longer exists. It has moved to `ocp-priv/builder`. This was causing `doozer images:streams mirror` (via the `sync-ci-images` pipeline) to fail with:

```
Error from server (NotFound): imagestreams.image.openshift.io "builder-priv" not found
```

## Changes

- `streams.yml`: `ocp-private/builder-priv` → `ocp-priv/builder` (URLs and comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)