### PR TITLE
Fix backplane-operator delivery name to match Pyxis [mce-2.11]

### DIFF
--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -11,7 +11,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - multicluster-engine/backplane-operator-rhel9
+  - multicluster-engine/backplane-rhel9-operator
   bundle_delivery_repo_name: multicluster-engine/mce-operator-bundle
 for_payload: false
 enabled_repos:

--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -22,7 +22,7 @@ from:
     - stream: rhel9
     - stream: rhel-9-golang-1.26
   member: base-rhel9
-name: multicluster-engine/backplane-operator-rhel9
+name: multicluster-engine/backplane-rhel9-operator
 update-csv:
   name: multicluster-engine
   manifests-dir: bundle


### PR DESCRIPTION
## Summary

Fix `name` field from `multicluster-engine/backplane-operator-rhel9` to `multicluster-engine/backplane-rhel9-operator` to match the actual Pyxis/registry delivery name.

Release pipeline fails with:
```
LabelValidationError: Component 'mce-2-11-backplane-operator' name label
('multicluster-engine/backplane-operator-rhel9') does not match expected
name ('multicluster-engine/backplane-rhel9-operator')
```

Ref: [HYPBLD-854](https://redhat.atlassian.net/browse/HYPBLD-854)

Made with [Cursor](https://cursor.com)