### PR TITLE
Remove prefetch workarounds for tests and oc-mirror (KFLUXSPRT-8436)

### DIFF
--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -40,6 +40,3 @@ owners:
 - jpower@redhat.com
 - dmesser@redhat.com
 - aflom@redhat.com
-konflux:
-  cachito:
-    mode: removal

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -33,8 +33,6 @@ from:
   - stream: rhel-9-golang
   member: ose-tools
 canonical_builders_from_upstream: false
-konflux:
-  clone_git_tags: false
 labels:
   License: GPLv2+
   io.k8s.description: OpenShift is a platform for developing, building, and deploying containerized applications.


### PR DESCRIPTION
## Summary
- Remove `konflux.clone_git_tags: false` from `openshift-enterprise-tests.yml`
- Remove `konflux.cachito.mode: removal` from `oc-mirror-plugin.yml`

All go.mod dependencies for both images now resolve successfully on proxy.golang.org on the 5.0 branch. These workarounds are no longer needed.

## Test plan
- [ ] Verify Konflux builds of ose-5-0-openshift-enterprise-tests succeed with prefetch enabled
- [ ] Verify Konflux builds of ose-5-0-oc-mirror-plugin succeed with prefetch enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)