### PR TITLE
Pin corrected RHEL 10 driver-toolkit build for 5.0 ec.5

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -61,10 +61,10 @@ releases:
         rpms: []
         images:
           - distgit_key: driver-toolkit-rhel10
-            why: Query from assembly basis event failed to replicate referenced nightly content exactly. Pinning to replicate.
+            why: Pin post-component-collision-fix build with kernel content matching the referenced nightly.
             metadata:
               is:
-                nvr: driver-toolkit-container-v5.0.0-202607231141.p2.g7ec03cb.assembly.stream.el10
+                nvr: driver-toolkit-rhel10-container-v5.0.0-202607270839.p2.g7ec03cb.assembly.stream.el10
   ec.4:
     assembly:
       type: preview


### PR DESCRIPTION
## Summary

- replace the OCP 5.0 `ec.5` RHEL 10 driver-toolkit pin with the post-component-collision-fix build
- update the pin rationale to describe the corrected build and matching nightly kernel content

## Why

The previously pinned EL10 build predates the `driver-toolkit-rhel10-container` component-name fix. Its NVR uses `driver-toolkit-container`, which collides with the EL9 NVR during Elliott snapshot preparation even though the builds have distinct Konflux components.

The replacement is a successful stream build with the corrected component name. It uses the same upstream commit, supports the same four architectures, and contains the same kernel and RT kernel version (`6.12.0-211.39.1.el10_2`) as the prior pin.

The replacement is not bit-for-bit identical because it uses a newer base image and omits eight incidental non-kernel RPMs; no RPMs are added and the DTK kernel content is unchanged.

## Impact

Shipment snapshot preparation can include both the EL9 `driver-toolkit` and EL10 `driver-toolkit-10` builds without Elliott treating their NVRs as duplicate components.

## Validation

- confirmed the replacement build is successful in the Konflux build database
- compared source commit, architectures, parent image, installed RPMs, and kernel RPMs against the previous build
- `UV_CACHE_DIR=/tmp/art-tools-uv-cache uv run --project /home/sid/Projects/art/art-tools validate-ocp-build-data --images-dir images releases.yml`
- `git diff --check`
- Red Hat pre-commit and commit-message hooks passed
