### PR TITLE
Set bundle_name_override for backplane-operator and fix product name

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,7 +1,7 @@
 freeze_automation: false
 name: mce-2.11
 csv_namespace: multicluster-engine
-product: mce
+product: multicluster-engine
 version: 2.11.4
 
 vars:

--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -23,6 +23,7 @@ from:
     - stream: rhel-9-golang-1.26
   member: base-rhel9
 name: multicluster-engine/backplane-rhel9-operator
+bundle_name_override: mce-operator-bundle
 update-csv:
   name: multicluster-engine
   manifests-dir: bundle


### PR DESCRIPTION
## Summary

- Sets `bundle_name_override: mce-operator-bundle` on `images/backplane-operator.yml` so the operator's OLM bundle short name is `mce-operator-bundle` instead of the default `backplane-operator-bundle`. This matches the existing `bundle_delivery_repo_name: multicluster-engine/mce-operator-bundle` delivery naming convention already configured for this image.
- Fixes `group.yml` `product` field from `mce` to `multicluster-engine`.

**Note:** `bundle_name_override` is a new top-level config field being added to doozer/ocp-build-data-validator in [openshift-eng/art-tools#3214](https://github.com/openshift-eng/art-tools/pull/3214). This PR should not be merged until that lands (otherwise schema validation will reject the new field).

Alongside https://github.com/openshift-eng/art-tools/pull/3214
