### PR TITLE
Remove for_payload field from image configs

### DIFF
--- a/images/acm-cli.yml
+++ b/images/acm-cli.yml
@@ -24,7 +24,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/acm-cli-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 enabled_repos:

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -12,7 +12,6 @@ distgit:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-for_payload: false
 for_release: false
 from:
   stream: rhel9

--- a/images/cert-policy-controller.yml
+++ b/images/cert-policy-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/cert-policy-controller-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 enabled_repos:

--- a/images/cluster-backup-controller.yml
+++ b/images/cluster-backup-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/cluster-backup-controller-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/cluster-permission.yml
+++ b/images/cluster-permission.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/cluster-permission-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 enabled_repos:

--- a/images/config-policy-controller.yml
+++ b/images/config-policy-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/config-policy-controller-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/console.yml
+++ b/images/console.yml
@@ -19,7 +19,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/console-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/endpoint-monitoring-operator.yml
+++ b/images/endpoint-monitoring-operator.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/endpoint-monitoring-operator-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/governance-policy-addon-controller.yml
+++ b/images/governance-policy-addon-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/governance-policy-addon-controller-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/governance-policy-framework-addon.yml
+++ b/images/governance-policy-framework-addon.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/governance-policy-framework-addon-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/governance-policy-propagator.yml
+++ b/images/governance-policy-propagator.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/governance-policy-propagator-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/grafana-dashboard-loader.yml
+++ b/images/grafana-dashboard-loader.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/grafana-dashboard-loader-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -19,7 +19,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/grafana-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/insights-client.yml
+++ b/images/insights-client.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/insights-client-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/insights-metrics.yml
+++ b/images/insights-metrics.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/insights-metrics-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/klusterlet-addon-controller.yml
+++ b/images/klusterlet-addon-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/klusterlet-addon-controller-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/kube-rbac-proxy-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/kube-state-metrics-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/memcached-exporter.yml
+++ b/images/memcached-exporter.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/memcached-exporter-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/metrics-collector.yml
+++ b/images/metrics-collector.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/metrics-collector-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/mtv-integrations.yml
+++ b/images/mtv-integrations.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/mtv-integrations-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/multicloud-integrations.yml
+++ b/images/multicloud-integrations.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/multicloud-integrations-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 enabled_repos:

--- a/images/multicluster-observability-addon.yml
+++ b/images/multicluster-observability-addon.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/multicluster-observability-addon-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/multicluster-observability-operator.yml
+++ b/images/multicluster-observability-operator.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/multicluster-observability-operator-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/multicluster-operators-application.yml
+++ b/images/multicluster-operators-application.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/multicluster-operators-application-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 enabled_repos:

--- a/images/multicluster-operators-channel.yml
+++ b/images/multicluster-operators-channel.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/multicluster-operators-channel-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 enabled_repos:

--- a/images/multicluster-operators-subscription.yml
+++ b/images/multicluster-operators-subscription.yml
@@ -19,7 +19,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/multicluster-operators-subscription-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 enabled_repos:

--- a/images/multicluster-role-assignment.yml
+++ b/images/multicluster-role-assignment.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/multicluster-role-assignment-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -13,7 +13,6 @@ delivery:
   delivery_repo_names:
   - rhacm2/multiclusterhub-rhel9
   bundle_delivery_repo_name: rhacm2/acm-operator-bundle
-for_payload: false
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/must-gather.yml
+++ b/images/must-gather.yml
@@ -21,7 +21,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/must-gather-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 enabled_repos:

--- a/images/node-exporter.yml
+++ b/images/node-exporter.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/node-exporter-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/obo-prometheus-operator.yml
+++ b/images/obo-prometheus-operator.yml
@@ -19,7 +19,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/obo-prometheus-rhel9-operator
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/observatorium-operator.yml
+++ b/images/observatorium-operator.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/observatorium-operator-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/observatorium.yml
+++ b/images/observatorium.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/observatorium-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/prometheus-alertmanager.yml
+++ b/images/prometheus-alertmanager.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/prometheus-alertmanager-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/prometheus-config-reloader-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/prometheus-operator-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/prometheus.yml
+++ b/images/prometheus.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/prometheus-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/rbac-query-proxy.yml
+++ b/images/rbac-query-proxy.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/rbac-query-proxy-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/search-collector.yml
+++ b/images/search-collector.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/search-collector-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/search-indexer.yml
+++ b/images/search-indexer.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/search-indexer-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/search-v2-api.yml
+++ b/images/search-v2-api.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/search-v2-api-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/search-v2-operator.yml
+++ b/images/search-v2-operator.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/search-v2-operator-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/siteconfig.yml
+++ b/images/siteconfig.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/siteconfig-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/submariner-addon.yml
+++ b/images/submariner-addon.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/submariner-addon-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/thanos-receive-controller.yml
+++ b/images/thanos-receive-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/thanos-receive-controller-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/thanos-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:

--- a/images/volsync-addon-controller.yml
+++ b/images/volsync-addon-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - rhacm2/volsync-addon-controller-rhel9
-for_payload: false
 dependents:
 - multiclusterhub-operator
 from:


### PR DESCRIPTION
## Summary

Removes the `for_payload` field from all image configs in this branch.

`for_payload` defaults to `false` when the field is not present in the config. Every image in this branch already had it explicitly set to `false`, so this is a no-op cleanup with no behavior change.

Made with [Cursor](https://cursor.com)