### PR TITLE
Remove for_payload field from image configs

### DIFF
--- a/images/addon-manager.yml
+++ b/images/addon-manager.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/addon-manager-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/azure-service-operator.yml
+++ b/images/azure-service-operator.yml
@@ -26,7 +26,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/azure-service-operator-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/backplane-must-gather.yml
+++ b/images/backplane-must-gather.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/backplane-must-gather-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -13,7 +13,6 @@ delivery:
   delivery_repo_names:
   - multicluster-engine/backplane-rhel9-operator
   bundle_delivery_repo_name: multicluster-engine/mce-operator-bundle
-for_payload: false
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -12,7 +12,6 @@ distgit:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-for_payload: false
 for_release: false
 from:
   stream: rhel9

--- a/images/capoa-bootstrap.yml
+++ b/images/capoa-bootstrap.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/capoa-bootstrap-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/capoa-control-plane.yml
+++ b/images/capoa-control-plane.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/capoa-control-plane-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/cluster-api-provider-agent.yml
+++ b/images/cluster-api-provider-agent.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-provider-agent-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/cluster-api-provider-aws.yml
+++ b/images/cluster-api-provider-aws.yml
@@ -19,7 +19,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-provider-aws-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/cluster-api-provider-azure.yml
+++ b/images/cluster-api-provider-azure.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-provider-azure-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/cluster-api-provider-kubevirt.yml
+++ b/images/cluster-api-provider-kubevirt.yml
@@ -19,7 +19,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-provider-kubevirt-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/cluster-api-webhook-config.yml
+++ b/images/cluster-api-webhook-config.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-api-webhook-config-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/cluster-curator-controller.yml
+++ b/images/cluster-curator-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-curator-controller-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/cluster-image-set-controller.yml
+++ b/images/cluster-image-set-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-image-set-controller-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/cluster-proxy.yml
+++ b/images/cluster-proxy.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/cluster-proxy-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/clusterclaims-controller.yml
+++ b/images/clusterclaims-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/clusterclaims-controller-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/clusterlifecycle-state-metrics.yml
+++ b/images/clusterlifecycle-state-metrics.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/clusterlifecycle-state-metrics-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/console-mce.yml
+++ b/images/console-mce.yml
@@ -19,7 +19,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/console-mce-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/discovery-operator.yml
+++ b/images/discovery-operator.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/discovery-operator-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/hive.yml
+++ b/images/hive.yml
@@ -22,7 +22,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/hive-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/hypershift-addon-operator.yml
+++ b/images/hypershift-addon-operator.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/hypershift-addon-operator-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/hypershift-cli.yml
+++ b/images/hypershift-cli.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/hypershift-cli-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/hypershift-release.yml
+++ b/images/hypershift-release.yml
@@ -16,7 +16,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/hypershift-release-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/image-based-install-operator.yml
+++ b/images/image-based-install-operator.yml
@@ -17,7 +17,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/image-based-install-operator-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/kube-rbac-proxy-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/managed-serviceaccount.yml
+++ b/images/managed-serviceaccount.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/managed-serviceaccount-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 enabled_repos:

--- a/images/managedcluster-import-controller-addon.yml
+++ b/images/managedcluster-import-controller-addon.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/managedcluster-import-controller-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/multicloud-manager.yml
+++ b/images/multicloud-manager.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/multicloud-manager-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/placement.yml
+++ b/images/placement.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/placement-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/provider-credential-controller.yml
+++ b/images/provider-credential-controller.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/provider-credential-controller-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/registration-operator.yml
+++ b/images/registration-operator.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/registration-operator-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/registration.yml
+++ b/images/registration.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/registration-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:

--- a/images/work.yml
+++ b/images/work.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - multicluster-engine/work-rhel9
-for_payload: false
 dependents:
 - backplane-operator
 from:


### PR DESCRIPTION
## Summary

Removes the `for_payload` field from all image configs in this branch.

`for_payload` defaults to `false` when the field is not present in the config. Every image in this branch already had it explicitly set to `false`, so this is a no-op cleanup with no behavior change.

Made with [Cursor](https://cursor.com)