### PR TITLE
Remove for_payload field from image configs

### DIFF
--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -12,7 +12,6 @@ distgit:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-for_payload: false
 for_release: false
 from:
   stream: rhel9

--- a/images/external-secrets-bitwarden-sdk-server.yml
+++ b/images/external-secrets-bitwarden-sdk-server.yml
@@ -17,7 +17,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - external-secrets-operator/bitwarden-sdk-server-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/external-secrets-operator.yml
+++ b/images/external-secrets-operator.yml
@@ -18,7 +18,6 @@ delivery:
   bundle_delivery_repo_name: external-secrets-operator/external-secrets-operator-bundle
   delivery_repo_names:
     - external-secrets-operator/external-secrets-operator-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/external-secrets.yml
+++ b/images/external-secrets.yml
@@ -17,7 +17,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - external-secrets-operator/external-secrets-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms


### PR DESCRIPTION
## Summary

Removes the `for_payload` field from all image configs in this branch.

`for_payload` defaults to `false` when the field is not present in the config. Every image in this branch already had it explicitly set to `false`, so this is a no-op cleanup with no behavior change.

The commit message includes `scan-sources-konflux:noop` (and the legacy `scan-sources:noop`) so this merge does not trigger unnecessary rebuilds due to the config digest change.

Made with [Cursor](https://cursor.com)