### PR TITLE
Remove for_payload field from image configs

### DIFF
--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -12,7 +12,6 @@ distgit:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-for_payload: false
 for_release: false
 from:
   stream: rhel9

--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -13,7 +13,6 @@ delivery:
   bundle_delivery_repo_name: openshift-logging/cluster-logging-operator-bundle
   delivery_repo_names:
   - openshift-logging/cluster-logging-rhel9-operator
-for_payload: false
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/eventrouter.yml
+++ b/images/eventrouter.yml
@@ -12,7 +12,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - openshift-logging/eventrouter-rhel9
-for_payload: false
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/log-file-metric-exporter.yml
+++ b/images/log-file-metric-exporter.yml
@@ -14,7 +14,6 @@ dependents:
 delivery:
   delivery_repo_names:
   - openshift-logging/log-file-metric-exporter-rhel9
-for_payload: false
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/loki-operator.yml
+++ b/images/loki-operator.yml
@@ -14,7 +14,6 @@ delivery:
   bundle_delivery_repo_name: openshift-logging/loki-operator-bundle
   delivery_repo_names:
   - openshift-logging/loki-rhel9-operator
-for_payload: false
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/loki.yml
+++ b/images/loki.yml
@@ -14,7 +14,6 @@ dependents:
 delivery:
   delivery_repo_names:
   - openshift-logging/logging-loki-rhel9
-for_payload: false
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/lokistack-gateway.yml
+++ b/images/lokistack-gateway.yml
@@ -14,7 +14,6 @@ dependents:
 delivery:
   delivery_repo_names:
   - openshift-logging/lokistack-gateway-rhel9
-for_payload: false
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/opa-openshift.yml
+++ b/images/opa-openshift.yml
@@ -14,7 +14,6 @@ dependents:
 delivery:
   delivery_repo_names:
   - openshift-logging/opa-openshift-rhel9
-for_payload: false
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/vector.yml
+++ b/images/vector.yml
@@ -19,7 +19,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - openshift-logging/vector-rhel9
-for_payload: false
 dependents:
 - cluster-logging-operator
 enabled_repos:


### PR DESCRIPTION
## Summary

Removes the `for_payload` field from all image configs in this branch.

`for_payload` defaults to `false` when the field is not present in the config. Every image in this branch already had it explicitly set to `false`, so this is a no-op cleanup with no behavior change.

The commit message includes `scan-sources-konflux:noop` (and the legacy `scan-sources:noop`) so this merge does not trigger unnecessary rebuilds due to the config digest change.

Made with [Cursor](https://cursor.com)