### PR TITLE
Remove for_payload field from image configs

### DIFF
--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -12,7 +12,6 @@ distgit:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-for_payload: false
 for_release: false
 from:
   stream: rhel9

--- a/images/mta-analyzer-addon.yml
+++ b/images/mta-analyzer-addon.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-analyzer-addon-rhel9
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-analyzer-lsp.yml
+++ b/images/mta-analyzer-lsp.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-analyzer-lsp-rhel9
-for_payload: false
 base_image_release:
   force: true
 enabled_repos:

--- a/images/mta-analyzer-rpc.yml
+++ b/images/mta-analyzer-rpc.yml
@@ -20,7 +20,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-analyzer-rpc-rhel9
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-cli.yml
+++ b/images/mta-cli.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-cli-rhel9
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-discovery-addon.yml
+++ b/images/mta-discovery-addon.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-discovery-addon-rhel9
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-dotnet-external-provider.yml
+++ b/images/mta-dotnet-external-provider.yml
@@ -20,7 +20,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-dotnet-external-provider-rhel9
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-generic-external-provider.yml
+++ b/images/mta-generic-external-provider.yml
@@ -21,7 +21,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-generic-external-provider-rhel9
-for_payload: false
 base_image_release:
   force: true
 enabled_repos:

--- a/images/mta-golang-dependency-provider.yml
+++ b/images/mta-golang-dependency-provider.yml
@@ -20,7 +20,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-golang-dependency-provider-rhel9
-for_payload: false
 base_image_release:
   force: true
 enabled_repos:

--- a/images/mta-hub.yml
+++ b/images/mta-hub.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-hub-rhel9
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-java-external-provider.yml
+++ b/images/mta-java-external-provider.yml
@@ -19,7 +19,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-java-external-provider-rhel9
-for_payload: false
 base_image_release:
   force: true
 enabled_repos:

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -14,7 +14,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-jdtls-server-base-rhel9
-for_payload: false
 base_image_release:
   force: true
 enabled_repos:

--- a/images/mta-operator.yml
+++ b/images/mta-operator.yml
@@ -21,7 +21,6 @@ delivery:
   bundle_delivery_repo_name: mta/mta-operator-bundle
   delivery_repo_names:
   - mta/mta-rhel9-operator
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-platform-addon.yml
+++ b/images/mta-platform-addon.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-platform-addon-rhel9
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -14,7 +14,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-solution-server-rhel9
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms

--- a/images/mta-static-report.yml
+++ b/images/mta-static-report.yml
@@ -23,7 +23,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-static-report-rhel9
-for_payload: false
 base_image_release:
   force: true
 enabled_repos:

--- a/images/mta-ui.yml
+++ b/images/mta-ui.yml
@@ -23,7 +23,6 @@ distgit:
 delivery:
   delivery_repo_names:
   - mta/mta-ui-rhel9
-for_payload: false
 enabled_repos:
 - rhel-9-appstream-rpms
 - rhel-9-baseos-rpms


### PR DESCRIPTION
## Summary

Removes the `for_payload` field from all image configs in this branch.

`for_payload` defaults to `false` when the field is not present in the config. Every image in this branch already had it explicitly set to `false`, so this is a no-op cleanup with no behavior change.

The commit message includes `scan-sources-konflux:noop` (and the legacy `scan-sources:noop`) so this merge does not trigger unnecessary rebuilds due to the config digest change.

Made with [Cursor](https://cursor.com)