### PR TITLE
Remove for_payload field from image configs

### DIFF
--- a/images/base-rhel8.yml
+++ b/images/base-rhel8.yml
@@ -20,7 +20,6 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-for_payload: false
 for_release: false
 from:
   stream: rhel8

--- a/images/openshift-migration-controller.yml
+++ b/images/openshift-migration-controller.yml
@@ -22,7 +22,6 @@ distgit:
 enabled_repos:
   - rhel-8-appstream-rpms
   - rhel-8-baseos-rpms
-for_payload: false
 from:
   builder:
     - stream: rhel-8-golang

--- a/images/openshift-migration-hook-runner.yml
+++ b/images/openshift-migration-hook-runner.yml
@@ -17,7 +17,6 @@ distgit:
 enabled_repos:
   - rhel-8-appstream-rpms
   - rhel-8-baseos-rpms
-for_payload: false
 from:
   stream: aap-25
 name: rhmtc/openshift-migration-hook-runner-rhel8

--- a/images/openshift-migration-log-reader.yml
+++ b/images/openshift-migration-log-reader.yml
@@ -17,7 +17,6 @@ distgit:
 enabled_repos:
   - rhel-8-appstream-rpms
   - rhel-8-baseos-rpms
-for_payload: false
 from:
   builder:
     - stream: ose-must-gather

--- a/images/openshift-migration-must-gather.yml
+++ b/images/openshift-migration-must-gather.yml
@@ -31,7 +31,6 @@ distgit:
 enabled_repos:
   - rhel-8-appstream-rpms
   - rhel-8-baseos-rpms
-for_payload: false
 from:
   builder:
     - stream: ose-must-gather

--- a/images/openshift-migration-openvpn.yml
+++ b/images/openshift-migration-openvpn.yml
@@ -26,7 +26,6 @@ enabled_repos:
   - rhel-8-appstream-rpms
   - rhel-8-baseos-rpms
   - rhel-8-codeready-builder-rpms
-for_payload: false
 from:
   builder:
     - stream: rhel-8-builder

--- a/images/openshift-migration-operator.yml
+++ b/images/openshift-migration-operator.yml
@@ -17,7 +17,6 @@ enabled_repos:
   - rhel-8-appstream-rpms
   - rhel-8-baseos-rpms
   - rhocp-4.7-for-rhel-8-x86_64-rpms
-for_payload: false
 from:
   stream: ose-ansible-operator
 konflux:

--- a/images/openshift-migration-registry.yml
+++ b/images/openshift-migration-registry.yml
@@ -25,7 +25,6 @@ distgit:
 enabled_repos:
   - rhel-8-appstream-rpms
   - rhel-8-baseos-rpms
-for_payload: false
 from:
   builder:
     - stream: rhel-8-golang

--- a/images/openshift-migration-rsync-transfer.yml
+++ b/images/openshift-migration-rsync-transfer.yml
@@ -29,7 +29,6 @@ distgit:
 enabled_repos:
   - rhel-8-appstream-rpms
   - rhel-8-baseos-rpms
-for_payload: false
 from:
   builder:
     - stream: rhel-8-golang

--- a/images/openshift-migration-ui.yml
+++ b/images/openshift-migration-ui.yml
@@ -21,7 +21,6 @@ distgit:
 enabled_repos:
   - rhel-88-appstream-rpms
   - rhel-88-baseos-rpms
-for_payload: false
 from:
   builder:
     - stream: nodejs-18

--- a/images/openshift-migration-velero-plugin-for-mtc.yml
+++ b/images/openshift-migration-velero-plugin-for-mtc.yml
@@ -21,7 +21,6 @@ distgit:
 enabled_repos:
   - rhel-8-appstream-rpms
   - rhel-8-baseos-rpms
-for_payload: false
 from:
   builder:
     - stream: rhel-8-golang


### PR DESCRIPTION
## Summary

Removes the `for_payload` field from all image configs in this branch.

`for_payload` defaults to `false` when the field is not present in the config. Every image in this branch already had it explicitly set to `false`, so this is a no-op cleanup with no behavior change.

The commit message includes `scan-sources-konflux:noop` (and the legacy `scan-sources:noop`) so this merge does not trigger unnecessary rebuilds due to the config digest change.

Made with [Cursor](https://cursor.com)