### PR TITLE
Remove for_payload field from image configs

### DIFF
--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -12,7 +12,6 @@ distgit:
 enabled_repos:
 - rhel-98-baseos-rpms
 - rhel-98-appstream-rpms
-for_payload: false
 for_release: false
 from:
   stream: rhel9

--- a/images/oadp-cli-binaries.yml
+++ b/images/oadp-cli-binaries.yml
@@ -23,7 +23,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-cli-binaries-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-hypershift-velero-plugin.yml
+++ b/images/oadp-hypershift-velero-plugin.yml
@@ -24,7 +24,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-hypershift-velero-plugin-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-kubevirt-velero-plugin.yml
+++ b/images/oadp-kubevirt-velero-plugin.yml
@@ -24,7 +24,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-kubevirt-velero-plugin-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-mustgather.yml
+++ b/images/oadp-mustgather.yml
@@ -24,7 +24,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-mustgather-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-non-admin.yml
+++ b/images/oadp-non-admin.yml
@@ -16,7 +16,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-non-admin-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-operator.yml
+++ b/images/oadp-operator.yml
@@ -27,7 +27,6 @@ delivery:
   bundle_delivery_repo_name: oadp/oadp-operator-bundle
   delivery_repo_names:
     - oadp/oadp-rhel9-operator
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-velero-plugin-for-aws.yml
+++ b/images/oadp-velero-plugin-for-aws.yml
@@ -24,7 +24,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-velero-plugin-for-aws-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-velero-plugin-for-gcp.yml
+++ b/images/oadp-velero-plugin-for-gcp.yml
@@ -24,7 +24,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-velero-plugin-for-gcp-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-velero-plugin-for-legacy-aws.yml
+++ b/images/oadp-velero-plugin-for-legacy-aws.yml
@@ -24,7 +24,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-velero-plugin-for-legacy-aws-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-velero-plugin-for-microsoft-azure.yml
+++ b/images/oadp-velero-plugin-for-microsoft-azure.yml
@@ -24,7 +24,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-velero-plugin.yml
+++ b/images/oadp-velero-plugin.yml
@@ -24,7 +24,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-velero-plugin-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms

--- a/images/oadp-velero.yml
+++ b/images/oadp-velero.yml
@@ -27,7 +27,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - oadp/oadp-velero-rhel9
-for_payload: false
 enabled_repos:
   - rhel-98-appstream-rpms
   - rhel-98-baseos-rpms


### PR DESCRIPTION
## Summary

Removes the `for_payload` field from all image configs in this branch.

`for_payload` defaults to `false` when the field is not present in the config. Every image in this branch already had it explicitly set to `false`, so this is a no-op cleanup with no behavior change.

The commit message includes `scan-sources-konflux:noop` (and the legacy `scan-sources:noop`) so this merge does not trigger unnecessary rebuilds due to the config digest change.

Made with [Cursor](https://cursor.com)