### PR TITLE
Remove for_payload field from image configs

### DIFF
--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -12,7 +12,6 @@ distgit:
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms
-for_payload: false
 for_release: false
 from:
   stream: rhel9

--- a/images/spiffe-csi-driver.yml
+++ b/images/spiffe-csi-driver.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/spiffe-helper.yml
+++ b/images/spiffe-helper.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - zero-trust-workload-identity-manager/spiffe-helper-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/spiffe-spire-agent.yml
+++ b/images/spiffe-spire-agent.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/spiffe-spire-controller-manager.yml
+++ b/images/spiffe-spire-controller-manager.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/spiffe-spire-oidc-discovery-provider.yml
+++ b/images/spiffe-spire-oidc-discovery-provider.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/spiffe-spire-server.yml
+++ b/images/spiffe-spire-server.yml
@@ -18,7 +18,6 @@ distgit:
 delivery:
   delivery_repo_names:
     - zero-trust-workload-identity-manager/spiffe-spire-server-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms

--- a/images/zero-trust-workload-identity-manager.yml
+++ b/images/zero-trust-workload-identity-manager.yml
@@ -19,7 +19,6 @@ delivery:
   bundle_delivery_repo_name: zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle
   delivery_repo_names:
     - zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9
-for_payload: false
 enabled_repos:
   - rhel-9-appstream-rpms
   - rhel-9-baseos-rpms


### PR DESCRIPTION
## Summary

Removes the `for_payload` field from all image configs in this branch.

`for_payload` defaults to `false` when the field is not present in the config. Every image in this branch already had it explicitly set to `false`, so this is a no-op cleanup with no behavior change.

The commit message includes `scan-sources-konflux:noop` (and the legacy `scan-sources:noop`) so this merge does not trigger unnecessary rebuilds due to the config digest change.

Made with [Cursor](https://cursor.com)