### PR TITLE
Revert "Disable package-registry-proxy for oc-mirror-plugin (ART-21727)"

### DIFF
--- a/images/oc-mirror-plugin.yml
+++ b/images/oc-mirror-plugin.yml
@@ -43,7 +43,6 @@ owners:
 konflux:
   cachito:
     mode: removal
-  enable_package_registry_proxy: false
 okd:
   content:
     source:


### PR DESCRIPTION
This reverts commit 2cec5b2d4906e8d3261fc557b46796acf76c884e.