### PR TITLE
Add cri-o RPM configuration for 5.0

### DIFF
--- a/rpms/cri-o.yml
+++ b/rpms/cri-o.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/cri-o.git
+      web: https://github.com/openshift/cri-o
+    specfile: cri-o.spec
+name: cri-o
+owners:
+- sgrunert@redhat.com
+- qiwan@redhat.com
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+- rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+- rhaos-{MAJOR}.{MINOR}-rhel-10-hotfix


### PR DESCRIPTION
## Summary
- Introduces `rpms/cri-o.yml` from openshift-4.23 to openshift-5.0

## Test plan
- [ ] Verify the RPM config is picked up correctly by ocp-build-data tooling
- [ ] Confirm target tags and branch patterns resolve properly for 5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)