### PR TITLE
STOR-2998: Remove cachito for gcp-pd-csi-driver-operator

### DIFF
--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -2,10 +2,6 @@ arches:
 - x86_64
 - ppc64le
 - aarch64
-cachito:
-  packages:
-    gomod:
-    - path: legacy/gcp-pd-csi-driver-operator
 content:
   source:
     dockerfile: Dockerfile.gcp-pd
@@ -23,8 +19,6 @@ content:
         - lgtm
         - jira/valid-reference
         - verified
-    pkg_managers:
-    - gomod
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: ose-gcp-pd-csi-driver-operator-container


### PR DESCRIPTION
https://redhat.atlassian.net/browse/STOR-2998

openshift/csi-operator Dockerfile.gcp-pd was updated in https://github.com/openshift/csi-operator/pull/576 to build the gcp-pd-csi-driver-operator directly from `/` and not from `/legacy/`.