### PR TITLE
ART-21794: Update unified golang branch Dockerfiles

### DIFF
--- a/Dockerfiles/1-19.rhel8.Dockerfile
+++ b/Dockerfiles/1-19.rhel8.Dockerfile
@@ -46,7 +46,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-19.rhel9.Dockerfile
+++ b/Dockerfiles/1-19.rhel9.Dockerfile
@@ -46,7 +46,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-20.rhel8.Dockerfile
+++ b/Dockerfiles/1-20.rhel8.Dockerfile
@@ -46,7 +46,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-20.rhel9.Dockerfile
+++ b/Dockerfiles/1-20.rhel9.Dockerfile
@@ -46,7 +46,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-21.rhel8.Dockerfile
+++ b/Dockerfiles/1-21.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-21.rhel9.Dockerfile
+++ b/Dockerfiles/1-21.rhel9.Dockerfile
@@ -48,7 +48,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-22.rhel8.Dockerfile
+++ b/Dockerfiles/1-22.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-22.rhel9.Dockerfile
+++ b/Dockerfiles/1-22.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-23.rhel8.Dockerfile
+++ b/Dockerfiles/1-23.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-23.rhel9.Dockerfile
+++ b/Dockerfiles/1-23.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-24.rhel8.Dockerfile
+++ b/Dockerfiles/1-24.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-24.rhel9.Dockerfile
+++ b/Dockerfiles/1-24.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-25.rhel8.Dockerfile
+++ b/Dockerfiles/1-25.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-25.rhel9.Dockerfile
+++ b/Dockerfiles/1-25.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-26.rhel10.Dockerfile
+++ b/Dockerfiles/1-26.rhel10.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 RUN dnf clean all -y
 

--- a/Dockerfiles/1-26.rhel8.Dockerfile
+++ b/Dockerfiles/1-26.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-26.rhel9.Dockerfile
+++ b/Dockerfiles/1-26.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "golang-*$VERSION*" && \
+    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (amd64 only)
 COPY cross.tar.gz .


### PR DESCRIPTION
## Summary
- Update every Dockerfile in the unified golang branch based on openshift-eng/art-tools#3013 to use `dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}"`

Jira: https://issues.redhat.com/browse/ART-21794