### PR TITLE
Disable art bump PRs for ovnk 4.22

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -13,8 +13,7 @@ content:
       web: https://github.com/openshift/ovn-kubernetes
     ci_alignment:
       streams_prs:
-        ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+        enabled: false
     pkg_managers:
     - gomod
 distgit:

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -9,8 +9,7 @@ content:
       web: https://github.com/openshift/ovn-kubernetes
     ci_alignment:
       streams_prs:
-        ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+        enabled: false
     pkg_managers: []
 distgit:
   component: ose-ovn-kubernetes-base-container

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -12,8 +12,7 @@ content:
       web: https://github.com/openshift/ovn-kubernetes
     ci_alignment:
       streams_prs:
-        ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+        enabled: false
     pkg_managers:
     - gomod
 distgit:


### PR DESCRIPTION
We're syncing the 5.0 ART bumps into 4.22 via openshift/ovn-kubernetes#3358. Thus, the ART bumps in 4.22 are needed to be disabled.