### PR TITLE
Add arm64 VM override for hive to match upstream

### DIFF
--- a/images/hive.yml
+++ b/images/hive.yml
@@ -37,3 +37,6 @@ owners:
 jira:
   project: ACM
   component: mce-hive-container
+konflux:
+  vm_override:
+    aarch64: linux-mxlarge/arm64


### PR DESCRIPTION
## Summary
- Adds `konflux.vm_override` for `aarch64: linux-mxlarge/arm64` to `images/hive.yml`
- Matches the upstream `.tekton/hive-mce-211-push.yaml` VM size configuration
- Fixes arm64 build timeouts caused by insufficient VM resources during Go compilation

## Reference
- Upstream tekton config: https://github.com/openshift/hive/blob/master/.tekton/hive-mce-211-push.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)