### PR TITLE
HYPBLD-847 - ACM to ART: Fix delivery repo names to match product registry

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -46,8 +46,15 @@ Created as part of JIRA ticket [HYPBLD-847](https://redhat.atlassian.net/browse/
 
 ## Delivery Repo Names
 
-- **Decision**: `rhacm2/<component>-rhel9` pattern
-- **Rationale**: Matches existing ACM images in `registry.redhat.io/rhacm2/` namespace. Confirmed from ACM CSV OPERAND_IMAGE values and KRD ReleasePlanAdmission configs.
+- **Decision**: `name` and `delivery_repo_names` must exactly match the delivery repo name registered in the Konflux product registry (ReleasePlanAdmission).
+- **Source of truth**: `konflux-release-data/config/stone-prd-rh01.pg1f.p1/product/ReleasePlanAdmission/crt-redhat-acm/crt-redhat-acm-acm-2-16-rpa-stage.yaml`
+- **Rationale**: ART sets the `name` label on built container images from the `name` field in ocp-build-data. During stage release, Konflux validates this label against the registered delivery repo. A mismatch causes `LabelValidationError`.
+- **Naming patterns** (not uniform — must be looked up per component):
+  - Some components have `acm-` prefix: `acm-cluster-permission-rhel9`, `acm-grafana-rhel9`, `acm-must-gather-rhel9`, etc.
+  - Some components have `-rhel9-operator` suffix (not `-operator-rhel9`): `endpoint-monitoring-rhel9-operator`, `observatorium-rhel9-operator`
+  - Some have completely different names from their ocp-build-data filename: `prometheus-operator.yml` → `acm-prometheus-rhel9`, `search-v2-operator.yml` → `acm-search-v2-rhel9`
+- **Corrected**: Original decision applied a simplified `rhacm2/<component>-rhel9` pattern uniformly, which caused 18 LabelValidationErrors at stage release. Fixed by aligning all names with the authoritative Konflux RPA list.
+- **Lesson**: Never assume a naming pattern — always cross-reference against the Konflux ReleasePlanAdmission for the product version.
 
 ## RHEL 8 Builders
 

--- a/images/cluster-backup-controller.yml
+++ b/images/cluster-backup-controller.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/cluster-backup-controller-rhel9
+  - rhacm2/cluster-backup-rhel9-operator
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/cluster-backup-controller-rhel9
+name: rhacm2/cluster-backup-rhel9-operator
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/cluster-permission.yml
+++ b/images/cluster-permission.yml
@@ -11,7 +11,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/cluster-permission-rhel9
+  - rhacm2/acm-cluster-permission-rhel9
 dependents:
 - multiclusterhub-operator
 enabled_repos:
@@ -21,7 +21,7 @@ from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/cluster-permission-rhel9
+name: rhacm2/acm-cluster-permission-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/endpoint-monitoring-operator.yml
+++ b/images/endpoint-monitoring-operator.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/endpoint-monitoring-operator-rhel9
+  - rhacm2/endpoint-monitoring-rhel9-operator
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/endpoint-monitoring-operator-rhel9
+name: rhacm2/endpoint-monitoring-rhel9-operator
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/governance-policy-addon-controller.yml
+++ b/images/governance-policy-addon-controller.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/governance-policy-addon-controller-rhel9
+  - rhacm2/acm-governance-policy-addon-controller-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang-1.26
   member: base-rhel9
-name: rhacm2/governance-policy-addon-controller-rhel9
+name: rhacm2/acm-governance-policy-addon-controller-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/governance-policy-framework-addon.yml
+++ b/images/governance-policy-framework-addon.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/governance-policy-framework-addon-rhel9
+  - rhacm2/acm-governance-policy-framework-addon-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang-1.26
   member: base-rhel9
-name: rhacm2/governance-policy-framework-addon-rhel9
+name: rhacm2/acm-governance-policy-framework-addon-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -18,14 +18,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/grafana-rhel9
+  - rhacm2/acm-grafana-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/grafana-rhel9
+name: rhacm2/acm-grafana-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/multicluster-observability-addon.yml
+++ b/images/multicluster-observability-addon.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/multicluster-observability-addon-rhel9
+  - rhacm2/acm-multicluster-observability-addon-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/multicluster-observability-addon-rhel9
+name: rhacm2/acm-multicluster-observability-addon-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/multicluster-observability-operator.yml
+++ b/images/multicluster-observability-operator.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/multicluster-observability-operator-rhel9
+  - rhacm2/multicluster-observability-rhel9-operator
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/multicluster-observability-operator-rhel9
+name: rhacm2/multicluster-observability-rhel9-operator
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -21,7 +21,7 @@ from:
     - member: base-rhel9
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/multiclusterhub-operator
+name: rhacm2/multiclusterhub-rhel9
 update-csv:
   name: advanced-cluster-management
   manifests-dir: bundle

--- a/images/must-gather.yml
+++ b/images/must-gather.yml
@@ -20,7 +20,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/must-gather-rhel9
+  - rhacm2/acm-must-gather-rhel9
 dependents:
 - multiclusterhub-operator
 enabled_repos:
@@ -31,7 +31,7 @@ from:
     - stream: ose-cli
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/must-gather-rhel9
+name: rhacm2/acm-must-gather-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/observatorium-operator.yml
+++ b/images/observatorium-operator.yml
@@ -17,14 +17,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/observatorium-operator-rhel9
+  - rhacm2/observatorium-rhel9-operator
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/observatorium-operator-rhel9
+name: rhacm2/observatorium-rhel9-operator
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/prometheus-config-reloader-rhel9
+  - rhacm2/acm-prometheus-config-reloader-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/prometheus-config-reloader-rhel9
+name: rhacm2/acm-prometheus-config-reloader-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/prometheus-operator-rhel9
+  - rhacm2/acm-prometheus-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/prometheus-operator-rhel9
+name: rhacm2/acm-prometheus-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/search-indexer.yml
+++ b/images/search-indexer.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/search-indexer-rhel9
+  - rhacm2/acm-search-indexer-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/search-indexer-rhel9
+name: rhacm2/acm-search-indexer-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/search-v2-api.yml
+++ b/images/search-v2-api.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/search-v2-api-rhel9
+  - rhacm2/acm-search-v2-api-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/search-v2-api-rhel9
+name: rhacm2/acm-search-v2-api-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/search-v2-operator.yml
+++ b/images/search-v2-operator.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/search-v2-operator-rhel9
+  - rhacm2/acm-search-v2-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/search-v2-operator-rhel9
+name: rhacm2/acm-search-v2-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/siteconfig.yml
+++ b/images/siteconfig.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/siteconfig-rhel9
+  - rhacm2/acm-siteconfig-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: rhacm2/siteconfig-rhel9
+name: rhacm2/acm-siteconfig-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/volsync-addon-controller.yml
+++ b/images/volsync-addon-controller.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - rhacm2/volsync-addon-controller-rhel9
+  - rhacm2/acm-volsync-addon-controller-rhel9
 dependents:
 - multiclusterhub-operator
 from:
   builder:
     - stream: rhel-9-golang-1.26
   member: base-rhel9
-name: rhacm2/volsync-addon-controller-rhel9
+name: rhacm2/acm-volsync-addon-controller-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:


### PR DESCRIPTION
Align the name and delivery_repo_names fields in 18 image configurations to match the canonical delivery repo names registered in the Konflux product registry (ReleasePlanAdmission).

Changes fall into two categories:
- Add missing acm- prefix (13 components): cluster-permission, governance-policy-addon-controller, governance-policy-framework-addon, grafana, multicluster-observability-addon, must-gather, prometheus-config-reloader, search-indexer, search-v2-api, siteconfig, volsync-addon-controller, prometheus-operator, search-v2-operator
- Fix naming structure (5 components): cluster-backup-controller, endpoint-monitoring-operator, multiclusterhub-operator, multicluster-observability-operator, observatorium-operator

Without this fix, stage release validation fails with LabelValidationError because the name label on built images does not match the expected delivery repo name.