### PR TITLE
5.0: ose-ovn-kubernetes, remove rhel-8-golang

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -36,7 +36,6 @@ base_image_release:
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: rhel-8-golang
   member: ovn-kubernetes-base
 canonical_builders_from_upstream: false
 labels:


### PR DESCRIPTION
follows https://github.com/openshift/ovn-kubernetes/pull/3149