### PR TITLE
openshift-5.1: enable automation (freeze_automation: false)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,7 +4,7 @@
 #   - weekdays: always allow manual builds; forbid scheduled builds from Monday to Friday
 #   - no|false: always allow builds
 # Note that ocp4 builds are always permitted  for non-stream assemblies
-freeze_automation: scheduled
+freeze_automation: "false"
 
 vars:
   MAJOR: 5


### PR DESCRIPTION
Set `freeze_automation: false` on `openshift-5.1` to allow scheduled ocp4-scan-konflux and build-sync-konflux runs.

Currently `scheduled` which means only manual builds are permitted. We need automation running now to bootstrap the 5.1 stream.

Manual runs are already going:
- ocp4-scan-konflux #55544
- build-sync-konflux #27537 (with --emergency-ignore-issues)