### PR TITLE
feat: add Cluster Observability Operator 1.5 image configuration

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -20,6 +20,5 @@ approvers:
 - thegreyd
 - pruan-rht
 - fgallott
-- jan--f
 # this is to keep automation from complaining about ownership of base image builds
 component: Release

--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ reviewers:
 - thegreyd
 - pruan-rht
 - fgallott
+- jan--f
 approvers:
 - ashwindasr
 - joepvd
@@ -20,5 +21,6 @@ approvers:
 - thegreyd
 - pruan-rht
 - fgallott
+- jan--f
 # this is to keep automation from complaining about ownership of base image builds
 component: Release

--- a/OWNERS
+++ b/OWNERS
@@ -9,7 +9,6 @@ reviewers:
 - thegreyd
 - pruan-rht
 - fgallott
-- jan--f
 approvers:
 - ashwindasr
 - joepvd

--- a/group.yml
+++ b/group.yml
@@ -1,0 +1,107 @@
+name: coo-1.5
+csv_namespace: cluster-observability-operator
+product: coo
+version: 1.5.2
+
+vars:
+  GO_LATEST: "1.26"
+  GO_EXTRA: "1.26"
+  MAJOR: 4
+  MINOR: 22
+
+arches:
+- x86_64
+- aarch64
+- ppc64le
+- s390x
+
+operator_image_ref_mode: manifest-list
+konflux:
+  arches:
+  - x86_64
+  - aarch64
+  - ppc64le
+  - s390x
+  cachi2:
+    enabled: true
+    gomod_version_patch: true
+    lockfile:
+      force: true
+      backend: rpm-lockfile-prototype
+  sast:
+    enabled: true
+  network_mode: hermetic
+
+OCP_TARGET_VERSIONS: [
+  "4.12",
+  "4.14",
+  "4.16",
+  "4.18",
+  "4.19",
+  "4.20",
+  "4.21",
+  "4.22",
+  "5.0",
+]
+
+assemblies:
+  enabled: true
+
+public_upstreams:
+# Global mapping for openshift org repos (majority of components)
+- private: "https://github.com/openshift-priv"
+  public: "https://github.com/openshift"
+# ocp-build-data itself
+- private: "https://github.com/openshift-priv/ocp-build-data"
+  public: "https://github.com/openshift-eng/ocp-build-data"
+# rhobs org repos
+- private: "https://github.com/openshift-priv/cluster-observability-operator"
+  public: "https://github.com/rhobs/observability-operator"
+- private: "https://github.com/openshift-priv/obo-prometheus-operator"
+  public: "https://github.com/rhobs/obo-prometheus-operator"
+- private: "https://github.com/openshift-priv/perses"
+  public: "https://github.com/rhobs/perses"
+- private: "https://github.com/openshift-priv/perses-operator"
+  public: "https://github.com/rhobs/perses-operator"
+# korrel8r org
+- private: "https://github.com/openshift-priv/korrel8r"
+  public: "https://github.com/korrel8r/korrel8r"
+# Repos where priv name differs from public name
+- private: "https://github.com/openshift-priv/alertmanager"
+  public: "https://github.com/openshift/prometheus-alertmanager"
+
+urls:
+  brewhub: https://brewhub.engineering.redhat.com/brewhub
+  brew_image_host: registry-proxy.engineering.redhat.com
+  brew_image_namespace: rh-osbs
+
+repos:
+  rhel-9-baseos-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/baseos/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/baseos/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/baseos/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/baseos/os/
+    content_set:
+      default: rhel-9-for-x86_64-baseos-rpms
+      aarch64: rhel-9-for-aarch64-baseos-rpms
+      ppc64le: rhel-9-for-ppc64le-baseos-rpms
+      s390x: rhel-9-for-s390x-baseos-rpms
+    reposync:
+      enabled: false
+
+  rhel-9-appstream-rpms:
+    conf:
+      baseurl:
+        aarch64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/aarch64/appstream/os/
+        ppc64le: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/ppc64le/appstream/os/
+        s390x: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/s390x/appstream/os/
+        x86_64: https://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9.7/x86_64/appstream/os/
+    content_set:
+      default: rhel-9-for-x86_64-appstream-rpms
+      aarch64: rhel-9-for-aarch64-appstream-rpms
+      ppc64le: rhel-9-for-ppc64le-appstream-rpms
+      s390x: rhel-9-for-s390x-appstream-rpms
+    reposync:
+      enabled: false

--- a/group.yml
+++ b/group.yml
@@ -24,8 +24,6 @@ konflux:
   - s390x
   cachi2:
     enabled: true
-  sast:
-    enabled: true
   network_mode: hermetic
 
 OCP_TARGET_VERSIONS: [

--- a/group.yml
+++ b/group.yml
@@ -24,7 +24,6 @@ konflux:
   - s390x
   cachi2:
     enabled: true
-    gomod_version_patch: true
     lockfile:
       force: true
   sast:

--- a/group.yml
+++ b/group.yml
@@ -24,8 +24,6 @@ konflux:
   - s390x
   cachi2:
     enabled: true
-    lockfile:
-      force: true
   sast:
     enabled: true
   network_mode: hermetic

--- a/group.yml
+++ b/group.yml
@@ -27,7 +27,6 @@ konflux:
     gomod_version_patch: true
     lockfile:
       force: true
-      backend: rpm-lockfile-prototype
   sast:
     enabled: true
   network_mode: hermetic

--- a/images/alertmanager.yml
+++ b/images/alertmanager.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/alertmanager.git
+      web: https://github.com/openshift/prometheus-alertmanager
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: alertmanager-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/alertmanager-rhel9
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/alertmanager-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -1,0 +1,22 @@
+base_only: true
+content:
+  source:
+    git:
+      branch:
+        target: openshift-base-rhel9
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: base-rhel9-container
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+for_payload: false
+for_release: false
+from:
+  stream: rhel9
+name: art-core/base-rhel9
+owners:
+- aos-team-art@redhat.com
+canonical_builders_from_upstream: false

--- a/images/cluster-health-analyzer.yml
+++ b/images/cluster-health-analyzer.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/cluster-health-analyzer.git
+      web: https://github.com/openshift/cluster-health-analyzer
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: cluster-health-analyzer-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/cluster-health-analyzer-rhel9
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/cluster-health-analyzer-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/cluster-observability-operator.yml
+++ b/images/cluster-observability-operator.yml
@@ -1,0 +1,33 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/cluster-observability-operator.git
+      web: https://github.com/rhobs/observability-operator
+distgit:
+  bundle_component: cluster-observability-operator-bundle-container
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: cluster-observability-rhel9-operator-container
+delivery:
+  bundle_delivery_repo_name: cluster-observability-operator/cluster-observability-operator-bundle
+  delivery_repo_names:
+  - cluster-observability-operator/cluster-observability-rhel9-operator
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/cluster-observability-rhel9-operator
+name_in_bundle: cluster-observability-rhel9-operator
+owners:
+- team-monitoring@redhat.com
+update-csv:
+  bundle-dir: bundle/manifests/
+  manifests-dir: bundle/metadata/
+  registry: image-registry.openshift-image-registry.svc:5000
+  valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'

--- a/images/dashboards-console-plugin.yml
+++ b/images/dashboards-console-plugin.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/console-dashboards-plugin.git
+      web: https://github.com/openshift/console-dashboards-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: dashboards-console-plugin-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/dashboards-console-plugin-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/dashboards-console-plugin-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/distributed-tracing-console-plugin-pf4.yml
+++ b/images/distributed-tracing-console-plugin-pf4.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/distributed-tracing-console-plugin.git
+      web: https://github.com/openshift/distributed-tracing-console-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: distributed-tracing-console-plugin-pf4-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/distributed-tracing-console-plugin-pf4-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/distributed-tracing-console-plugin-pf4-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/distributed-tracing-console-plugin-pf5.yml
+++ b/images/distributed-tracing-console-plugin-pf5.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/distributed-tracing-console-plugin.git
+      web: https://github.com/openshift/distributed-tracing-console-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: distributed-tracing-console-plugin-pf5-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/distributed-tracing-console-plugin-pf5-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/distributed-tracing-console-plugin-pf5-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/distributed-tracing-console-plugin-pf6.yml
+++ b/images/distributed-tracing-console-plugin-pf6.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/distributed-tracing-console-plugin.git
+      web: https://github.com/openshift/distributed-tracing-console-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: distributed-tracing-console-plugin-pf6-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/distributed-tracing-console-plugin-pf6-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/distributed-tracing-console-plugin-pf6-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/distributed-tracing-console-plugin.yml
+++ b/images/distributed-tracing-console-plugin.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/distributed-tracing-console-plugin.git
+      web: https://github.com/openshift/distributed-tracing-console-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: distributed-tracing-console-plugin-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/distributed-tracing-console-plugin-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/distributed-tracing-console-plugin-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/korrel8r.yml
+++ b/images/korrel8r.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/korrel8r.git
+      web: https://github.com/korrel8r/korrel8r
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: korrel8r-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/korrel8r-rhel9
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/korrel8r-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/logging-console-plugin-pf4.yml
+++ b/images/logging-console-plugin-pf4.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/logging-view-plugin.git
+      web: https://github.com/openshift/logging-view-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: logging-console-plugin-pf4-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/logging-console-plugin-pf4-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/logging-console-plugin-pf4-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/logging-console-plugin-pf5.yml
+++ b/images/logging-console-plugin-pf5.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/logging-view-plugin.git
+      web: https://github.com/openshift/logging-view-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: logging-console-plugin-pf5-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/logging-console-plugin-pf5-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/logging-console-plugin-pf5-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/logging-console-plugin.yml
+++ b/images/logging-console-plugin.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/logging-view-plugin.git
+      web: https://github.com/openshift/logging-view-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: logging-console-plugin-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/logging-console-plugin-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/logging-console-plugin-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/monitoring-console-plugin-pf5.yml
+++ b/images/monitoring-console-plugin-pf5.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/monitoring-plugin.git
+      web: https://github.com/openshift/monitoring-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: monitoring-console-plugin-pf5-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/monitoring-console-plugin-pf5-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/monitoring-console-plugin-pf5-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/monitoring-console-plugin-pf6.yml
+++ b/images/monitoring-console-plugin-pf6.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/monitoring-plugin.git
+      web: https://github.com/openshift/monitoring-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: monitoring-console-plugin-pf6-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/monitoring-console-plugin-pf6-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/monitoring-console-plugin-pf6-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/monitoring-console-plugin.yml
+++ b/images/monitoring-console-plugin.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/monitoring-plugin.git
+      web: https://github.com/openshift/monitoring-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: monitoring-console-plugin-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/monitoring-console-plugin-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/monitoring-console-plugin-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/obo-prometheus-operator-admission-webhook.yml
+++ b/images/obo-prometheus-operator-admission-webhook.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: cmd/admission-webhook/Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/obo-prometheus-operator.git
+      web: https://github.com/rhobs/obo-prometheus-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: obo-prometheus-operator-admission-webhook-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/obo-prometheus-operator-admission-webhook-rhel9
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/obo-prometheus-operator-admission-webhook-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/obo-prometheus-operator-config-reloader.yml
+++ b/images/obo-prometheus-operator-config-reloader.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: cmd/prometheus-config-reloader/Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/obo-prometheus-operator.git
+      web: https://github.com/rhobs/obo-prometheus-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: obo-prometheus-operator-prometheus-config-reloader-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/obo-prometheus-operator-prometheus-config-reloader-rhel9
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/obo-prometheus-operator-prometheus-config-reloader-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/obo-prometheus-operator.yml
+++ b/images/obo-prometheus-operator.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/obo-prometheus-operator.git
+      web: https://github.com/rhobs/obo-prometheus-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: obo-prometheus-rhel9-operator-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/obo-prometheus-rhel9-operator
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/obo-prometheus-rhel9-operator
+owners:
+- team-monitoring@redhat.com

--- a/images/perses-operator.yml
+++ b/images/perses-operator.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/perses-operator.git
+      web: https://github.com/rhobs/perses-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: perses-rhel9-operator-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/perses-rhel9-operator
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/perses-rhel9-operator
+owners:
+- team-monitoring@redhat.com

--- a/images/perses.yml
+++ b/images/perses.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/perses.git
+      web: https://github.com/rhobs/perses
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: perses-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/perses-rhel9
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/perses-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/prometheus.yml
+++ b/images/prometheus.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/prometheus.git
+      web: https://github.com/openshift/prometheus
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: prometheus-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/prometheus-rhel9
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/prometheus-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -1,0 +1,25 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/thanos.git
+      web: https://github.com/openshift/thanos
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: thanos-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/thanos-rhel9
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/thanos-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/troubleshooting-panel-console-plugin-pf6.yml
+++ b/images/troubleshooting-panel-console-plugin-pf6.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/troubleshooting-panel-console-plugin.git
+      web: https://github.com/openshift/troubleshooting-panel-console-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: troubleshooting-panel-console-plugin-pf6-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/troubleshooting-panel-console-plugin-pf6-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/troubleshooting-panel-console-plugin-pf6-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/images/troubleshooting-panel-console-plugin.yml
+++ b/images/troubleshooting-panel-console-plugin.yml
@@ -1,0 +1,31 @@
+cachito:
+  packages:
+    npm:
+    - path: web
+    gomod:
+    - path: .
+content:
+  source:
+    dockerfile: Dockerfile.art
+    git:
+      branch:
+        target: release-coo-1.5
+      url: git@github.com:openshift-priv/troubleshooting-panel-console-plugin.git
+      web: https://github.com/openshift/troubleshooting-panel-console-plugin
+    pkg_managers:
+    - npm
+    - gomod
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: troubleshooting-panel-console-plugin-rhel9-container
+delivery:
+  delivery_repo_names:
+  - cluster-observability-operator/troubleshooting-panel-console-plugin-rhel9
+from:
+  builder:
+  - stream: nodejs-rhel9
+  - stream: rhel-9-golang
+  member: base-rhel9
+name: cluster-observability-operator/troubleshooting-panel-console-plugin-rhel9
+owners:
+- team-monitoring@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -1,0 +1,9 @@
+---
+rhel-9-golang:
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9
+
+nodejs-rhel9:
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi9-nodejs-22:1-3
+
+rhel9:
+  image: registry.redhat.io/ubi9/ubi-minimal:9.7


### PR DESCRIPTION
Complete ocp-build-data configuration for COO 1.5 on the coo-1.5 branch.

group.yml:
- Konflux hermetic build settings
- 4 arches (x86_64, aarch64, ppc64le, s390x)
- OCP target versions (4.12, 4.14, 4.16, 4.18-4.22)

streams.yml: Go 1.26 builder, Node.js 22, UBI 9.7 base

24 component image configs (all using Dockerfile.art):
- cluster-observability-operator (main operator + OLM bundle)
- obo-prometheus-operator + admission-webhook + config-reloader
- prometheus, alertmanager, thanos
- korrel8r, perses, perses-operator
- cluster-health-analyzer
- base-rhel9
- Console plugins with PatternFly version variants:
  * monitoring (base/pf5/pf6)
  * logging (base/pf4/pf5)
  * troubleshooting-panel (base/pf6)
  * distributed-tracing (base/pf4/pf5/pf6)
  * dashboards (single variant)

Assisted-by: claude-opus-4-6@default