### PR TITLE
split oc-mirror image config into RHEL8 and RHEL9 variants

### DIFF
--- a/images/oc-mirror.rhel8.yml
+++ b/images/oc-mirror.rhel8.yml
@@ -1,0 +1,26 @@
+cachito:
+  enabled: true
+  packages:
+    gomod:
+    - path: .
+    - path: v1/
+content:
+  source:
+    dockerfile: images/cli/Dockerfile.konflux.rhel8
+    git:
+      branch:
+        target: main
+      url: git@github.com:openshift-priv/oc-mirror.git
+      web: https://github.com/openshift/oc-mirror
+distgit:
+  branch: oc-mirror-{MAJOR}.{MINOR}-rhel-8
+  component: oc-mirror-rhel8-container
+from:
+  builder:
+  - stream: rhel-8-golang
+  - stream: rhel8
+name: openshift5/oc-mirror-2-0-rhel8
+owners:
+- jpower@redhat.com
+- dmesser@redhat.com
+- aflom@redhat.com

--- a/images/oc-mirror.rhel9.yml
+++ b/images/oc-mirror.rhel9.yml
@@ -6,23 +6,20 @@ cachito:
     - path: v1/
 content:
   source:
-    # TODO(ART-21250): confirm dockerfile path once upstream Containerfile lands
-    dockerfile: images/cli/Dockerfile.konflux
+    dockerfile: images/cli/Dockerfile.konflux.rhel9
     git:
       branch:
-        # TODO(ART-21250): confirm git.branch.target (main vs release-2.0)
         target: main
       url: git@github.com:openshift-priv/oc-mirror.git
       web: https://github.com/openshift/oc-mirror
 distgit:
   branch: oc-mirror-{MAJOR}.{MINOR}-rhel-9
-  component: oc-mirror-container
+  component: oc-mirror-rhel9-container
 from:
   builder:
-  - stream: rhel-8-golang
   - stream: rhel-9-golang
   - stream: rhel9
-name: openshift5/oc-mirror-2-0
+name: openshift5/oc-mirror-2-0-rhel9
 owners:
 - jpower@redhat.com
 - dmesser@redhat.com


### PR DESCRIPTION
## Summary

- Upstream PR [openshift/oc-mirror#1490](https://github.com/openshift/oc-mirror/pull/1490) splits `Dockerfile.konflux` into `Dockerfile.konflux.rhel8` and `Dockerfile.konflux.rhel9`
- Split `images/oc-mirror.yml` into `images/oc-mirror.rhel8.yml` and `images/oc-mirror.rhel9.yml` to match
- Each variant points at its own Dockerfile, uses only the relevant builder stream, and gets its own distgit component (`oc-mirror-rhel8-container` / `oc-mirror-rhel9-container`)

## Test plan

- [ ] Verify `images/oc-mirror.rhel8.yml` and `images/oc-mirror.rhel9.yml` are valid YAML
- [ ] Confirm old `images/oc-mirror.yml` is removed
- [ ] Trigger a Konflux build for each variant once upstream PR #1490 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)