### PR TITLE
feat(golang): enable assemblies for golang builder group

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -6,6 +6,9 @@ arches:
 - s390x
 - aarch64
 
+assemblies:
+  enabled: true
+
 # These values are injected at runtime for the specific group that the builder is built for
 vars:
   MAJOR: major


### PR DESCRIPTION
## Summary

Enable assembly support in the `golang` group so that `elliott release new`
can validate shipment-gated delivery for golang builders.

The shipment CI (`generate_ci_files.py`) passes `--assembly=stream` to
`elliott release new`, but `runtime.assembly` is forced to `None` when
`assemblies.enabled` is not set in `group.yml`. This causes:

```
ValueError: shipment.metadata.assembly=stream is expected to be the same as runtime.assembly=None
```

Adding `assemblies.enabled: true` allows the assembly name to propagate
through the runtime, unblocking the shipment pipeline for golang builder images.

Ref: [ART-20930](https://redhat.atlassian.net/browse/ART-20930)