### PR TITLE
MCE to ART: Fix delivery repo names to match Konflux product registry

### DIFF
--- a/images/cluster-api-webhook-config.yml
+++ b/images/cluster-api-webhook-config.yml
@@ -17,7 +17,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - multicluster-engine/cluster-api-webhook-config-rhel9
+  - multicluster-engine/mce-capi-webhook-config-rhel9
 dependents:
 - backplane-operator
 enabled_repos:
@@ -27,7 +27,7 @@ from:
   builder:
     - stream: rhel-9-golang-1.25
   member: base-rhel9
-name: multicluster-engine/cluster-api-webhook-config-rhel9
+name: multicluster-engine/mce-capi-webhook-config-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/discovery-operator.yml
+++ b/images/discovery-operator.yml
@@ -11,7 +11,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - multicluster-engine/discovery-operator-rhel9
+  - multicluster-engine/discovery-rhel9
 dependents:
 - backplane-operator
 enabled_repos:
@@ -21,7 +21,7 @@ from:
   builder:
     - stream: rhel-9-golang-1.26
   member: base-rhel9
-name: multicluster-engine/discovery-operator-rhel9
+name: multicluster-engine/discovery-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/hypershift-addon-operator.yml
+++ b/images/hypershift-addon-operator.yml
@@ -11,14 +11,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - multicluster-engine/hypershift-addon-operator-rhel9
+  - multicluster-engine/hypershift-addon-rhel9-operator
 dependents:
 - backplane-operator
 from:
   builder:
     - stream: rhel-9-golang
   member: base-rhel9
-name: multicluster-engine/hypershift-addon-operator-rhel9
+name: multicluster-engine/hypershift-addon-rhel9-operator
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/hypershift-release.yml
+++ b/images/hypershift-release.yml
@@ -15,14 +15,14 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - multicluster-engine/hypershift-release-rhel9
+  - multicluster-engine/hypershift-rhel9-operator
 dependents:
 - backplane-operator
 from:
   builder:
     - stream: rhel-9-golang-1.25
   member: base-rhel9
-name: multicluster-engine/hypershift-release-rhel9
+name: multicluster-engine/hypershift-rhel9-operator
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/image-based-install-operator.yml
+++ b/images/image-based-install-operator.yml
@@ -16,7 +16,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - multicluster-engine/image-based-install-operator-rhel9
+  - multicluster-engine/image-based-install-rhel9
 dependents:
 - backplane-operator
 enabled_repos:
@@ -26,7 +26,7 @@ from:
   builder:
     - stream: rhel-9-golang-1.25
   member: base-rhel9
-name: multicluster-engine/image-based-install-operator-rhel9
+name: multicluster-engine/image-based-install-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -11,7 +11,7 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 delivery:
   delivery_repo_names:
-  - multicluster-engine/kube-rbac-proxy-rhel9
+  - multicluster-engine/kube-rbac-proxy-mce-rhel9
 dependents:
 - backplane-operator
 enabled_repos:
@@ -21,7 +21,7 @@ from:
   builder:
     - stream: rhel-9-golang-1.25
   member: base-rhel9
-name: multicluster-engine/kube-rbac-proxy-rhel9
+name: multicluster-engine/kube-rbac-proxy-mce-rhel9
 owners:
 - acm-cicd@redhat.com
 jira:


### PR DESCRIPTION
Align name and delivery_repo_names in 6 image configurations to match the canonical delivery repo names in the MCE 2.11 ReleasePlanAdmission.

Changes:
- cluster-api-webhook-config-rhel9 -> mce-capi-webhook-config-rhel9
- discovery-operator-rhel9 -> discovery-rhel9
- hypershift-addon-operator-rhel9 -> hypershift-addon-rhel9-operator
- hypershift-release-rhel9 -> hypershift-rhel9-operator
- image-based-install-operator-rhel9 -> image-based-install-rhel9
- kube-rbac-proxy-rhel9 -> kube-rbac-proxy-mce-rhel9

Without this fix, stage release validation fails with LabelValidationError because the name label on built images does not match the registered delivery repo name.