### PR TITLE
Fix jira issue component for ose-support-log-gather-operator in product.yml

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -1346,4 +1346,4 @@ bug_mapping:
     microshift-bootc-container:
       issue_component: MicroShift
     ose-support-log-gather-operator-container:
-      issue_component: oc
+      issue_component: must-gather


### PR DESCRIPTION
`issue_component` for `ose-support-log-gather-operator` should be `must-gather` instead of `oc` as per https://redhat.atlassian.net/browse/ART-13925 (see `bug_component`). 
Pointed out in https://redhat.atlassian.net/browse/OCPBUGS-104849?focusedCommentId=17886988

ref https://redhat-internal.slack.com/archives/C095ZUCRX8T/p1786004050145999