### PR TITLE
ART-21854 [openshift-5.1]: add driver-toolkit-rhel10 kernel consistency check for OCP5

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -136,10 +136,14 @@ rhcos:
   - rhel-9-appstream-rpms
   - rhel-9-fast-datapath-rpms
   require_consistency:
-    driver-toolkit:
-    - kernel  # since 9.3, kernel-rt is merged into the kernel package.
-    ose-ovn-kubernetes:
-    - libreswan
+    rhel-coreos:
+      driver-toolkit:
+      - kernel  # since 9.3, kernel-rt is merged into the kernel package.
+      ose-ovn-kubernetes:
+      - libreswan
+    rhel-coreos-10:
+      driver-toolkit-rhel10:
+      - kernel
   exempt_rpms: # skip check these rpms as they will aligned with rhel base image in rhcos
   - crun-wasm
   - lld


### PR DESCRIPTION
## Summary

Migrate `require_consistency` in `group.yml` to the stream-aware nested format and add an `rhel-coreos-10` entry so `driver-toolkit-rhel10` kernel packages are validated against `rhcos-rhel10`. Existing `rhel-coreos` (RHEL9) entries keep the same behavior.

Depends on art-tools code change: https://github.com/openshift-eng/art-tools/pull/3238

## Problem

**Before:** `require_consistency` used a flat layout without per-stream entries, so OCP5 dual-stream builds could not enforce kernel consistency for `driver-toolkit-rhel10` on RHEL10 CoreOS.

**After:** Nested `require_consistency.rhel-coreos-10.driver-toolkit-rhel10` checks kernel alignment with `rhcos-rhel10`. The RHEL9 path is unchanged.

Related: [ART-21854](https://redhat.atlassian.net/browse/ART-21854)

## Test plan

- [ ] Run `build-sync-konflux` with `ART_TOOLS_COMMIT` pointing at art-tools PR #3238 and `DOOZER_DATA_GITREF` pointing at this branch
- [ ] Confirm driver-toolkit-rhel10 kernel consistency passes for the rhel-coreos-10 stream
- [ ] Confirm existing rhel-coreos (RHEL9) consistency checks still pass