### PR TITLE
Add konflux component name overrides for zero-trust-workload-identity-manager

### DIFF
--- a/images/zero-trust-workload-identity-manager.yml
+++ b/images/zero-trust-workload-identity-manager.yml
@@ -41,3 +41,7 @@ update-csv:
 jira:
   project: ZTWIM
   component: Zero Trust Workload Identity Manager
+konflux:
+  component:
+    name_override: zt-wim-rhel9
+    bundle_name_override: zt-wim-rhel9-bundle

--- a/images/zero-trust-workload-identity-manager.yml
+++ b/images/zero-trust-workload-identity-manager.yml
@@ -43,5 +43,5 @@ jira:
   component: Zero Trust Workload Identity Manager
 konflux:
   component:
-    name_override: zt-wim-rhel9
+    name_override: zero-trust-1-1-zt-wim-rhel9
     bundle_name_override: zt-wim-rhel9-bundle

--- a/images/zero-trust-workload-identity-manager.yml
+++ b/images/zero-trust-workload-identity-manager.yml
@@ -44,4 +44,4 @@ jira:
 konflux:
   component:
     name_override: zero-trust-1-1-zt-wim-rhel9
-    bundle_name_override: zt-wim-rhel9-bundle
+    bundle_name_override: zero-trust-1-1-zt-wim-rhel9-bundle


### PR DESCRIPTION
## Summary

- Adds `konflux.component.name_override: zt-wim-rhel9` and `konflux.component.bundle_name_override: zt-wim-rhel9-bundle` to the zero-trust-workload-identity-manager image config.
- Fixes the Kubernetes 63-character limit breach for the auto-generated Konflux Component name (`zero-trust-1-1-zero-trust-workload-identity-manager-operator-bundle` = 67 chars).
- Depends on art-tools#3242 which introduces these fields.

## Test plan

- [ ] Verify Konflux Component names resolve to `zt-wim-rhel9` and `zt-wim-rhel9-bundle` during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)