### PR TITLE
NO-JIRA: Add 1.26 golang extra builders to 4.22

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -24,7 +24,7 @@ vars:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
   GO_LATEST: "1.25"
-  GO_EXTRA: "1.25"
+  GO_EXTRA: "1.26"
 
 compliance:
   rpm_shim:

--- a/images/ci-openshift-golang-builder-extra.rhel8.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel8.yml
@@ -1,5 +1,3 @@
-# No "extra" builders at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-golang-builder-extra.rhel9.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel9.yml
@@ -1,5 +1,3 @@
-# No "extra" builders at this time
-mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/streams.yml
+++ b/streams.yml
@@ -35,6 +35,24 @@ rhel-8-golang:
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
 
+rhel-9-golang-1.26:
+  aliases:
+    - rhel-9-golang-{GO_EXTRA}
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202607161626.p2.g48af02f.el9
+  mirror: false
+  # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
+  # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
+rhel-8-golang-1.26:
+  aliases:
+    - rhel-8-golang-{GO_EXTRA}
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202607272002.p2.g5a9ab9d.el8
+  mirror: false
+  # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
+  # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
 partner-rhel-8-golang-1.25:
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.25.9-202604242241.p2.g2aa6a05.el8
   mirror: true


### PR DESCRIPTION
Set GO_EXTRA to "1.26", add rhel-{8,9}-golang-1.26 streams pointing at the Go 1.26.5 builder images, and re-enable the previously disabled ci-openshift-golang-builder-extra image definitions for RHEL 8 and 9.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED