### PR TITLE
ART-21903 Require exact Golang NVR in unified builder Dockerfiles

### DIFF
--- a/Dockerfiles/1-19.rhel8.Dockerfile
+++ b/Dockerfiles/1-19.rhel8.Dockerfile
@@ -46,7 +46,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-19.rhel9.Dockerfile
+++ b/Dockerfiles/1-19.rhel9.Dockerfile
@@ -46,7 +46,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-20.rhel8.Dockerfile
+++ b/Dockerfiles/1-20.rhel8.Dockerfile
@@ -46,7 +46,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-20.rhel9.Dockerfile
+++ b/Dockerfiles/1-20.rhel9.Dockerfile
@@ -46,7 +46,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-21.rhel8.Dockerfile
+++ b/Dockerfiles/1-21.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-21.rhel9.Dockerfile
+++ b/Dockerfiles/1-21.rhel9.Dockerfile
@@ -48,7 +48,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-22.rhel8.Dockerfile
+++ b/Dockerfiles/1-22.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-22.rhel9.Dockerfile
+++ b/Dockerfiles/1-22.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-23.rhel8.Dockerfile
+++ b/Dockerfiles/1-23.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-23.rhel9.Dockerfile
+++ b/Dockerfiles/1-23.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-24.rhel8.Dockerfile
+++ b/Dockerfiles/1-24.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-24.rhel9.Dockerfile
+++ b/Dockerfiles/1-24.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-25.rhel8.Dockerfile
+++ b/Dockerfiles/1-25.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-25.rhel9.Dockerfile
+++ b/Dockerfiles/1-25.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-26.rhel10.Dockerfile
+++ b/Dockerfiles/1-26.rhel10.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 RUN dnf clean all -y
 

--- a/Dockerfiles/1-26.rhel8.Dockerfile
+++ b/Dockerfiles/1-26.rhel8.Dockerfile
@@ -47,7 +47,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (x86_64 only)
 COPY cross.tar.gz .

--- a/Dockerfiles/1-26.rhel9.Dockerfile
+++ b/Dockerfiles/1-26.rhel9.Dockerfile
@@ -49,7 +49,7 @@ RUN dnf update -y && \
         which \
         xz \
         zip && \
-    dnf install -y "${__doozer_golang_nvr:-golang-*$VERSION*}" && \
+    dnf install -y "$__doozer_golang_nvr" && \
     mkdir -p /go/src
 # provide a cross-compiler for windows/mac binaries (amd64 only)
 COPY cross.tar.gz .


### PR DESCRIPTION
## Summary

- require `__doozer_golang_nvr` in all 17 unified Golang builder Dockerfiles
- remove the `golang-*$VERSION*` fallback from RHEL 8, RHEL 9, and RHEL 10 builders

## Why

When package variables are not resolved during lockfile analysis, the fallback broadens to `golang-**`. On RHEL 8 this allowed dependency resolution to select the newest AppStream package, such as Go 1.26, instead of the Go NVR selected by Doozer.

Using only `__doozer_golang_nvr` makes the package request exact and prevents an unrelated Go stream from being selected.

## Dependency

Doozer must emit `__doozer_golang_nvr` in its own `ENV` instruction so the lockfile parser can resolve it. This PR should remain a draft until that companion art-tools change is available.

## Validation

- `git diff --check`
- global `rh-pre-commit`
- global `rh-pre-commit.commit-msg`
- confirmed all 17 Dockerfiles use the exact NVR variable and no version-glob fallback remains
