### PR TITLE
ACM to ART: Update console builder from nodejs-20 to nodejs-24

### DIFF
--- a/images/console.yml
+++ b/images/console.yml
@@ -23,7 +23,7 @@ dependents:
 - multiclusterhub-operator
 from:
   builder:
-    - stream: rhel-9-nodejs-20
+    - stream: rhel-9-nodejs-24
   member: base-rhel9
 name: rhacm2/console-rhel9
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -8,8 +8,8 @@ rhel-9-golang-1.26:
 rhel-8-golang:
   image: registry.redhat.io/ubi8/go-toolset:1.25
 
-rhel-9-nodejs-20:
-  image: registry.redhat.io/ubi9/nodejs-20-minimal@sha256:a22d96776233a2830007c406874935ace3244abf0581515fbd797d5b1f7b00d5
+rhel-9-nodejs-24:
+  image: registry.redhat.io/ubi9/nodejs-24-minimal:latest
 
 ose-cli:
   image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21


### PR DESCRIPTION
Node.js 20 reached EOL in April 2026, and ubi9/nodejs-20-minimal is now flagged as deprecated by the Konflux deprecated-image-check task. This causes verify-conforma violations for acm-2-16-console, blocking the entire ACM 2.16 release.

The upstream Dockerfile already uses ubi9/nodejs-24-minimal:latest, confirming the codebase is compatible with Node.js 24. Update the stream and console.yml to match.