### PR TITLE
Fix openshift-priv repo names with quay- prefix

### DIFF
--- a/images/container-security-operator-bundle.yml
+++ b/images/container-security-operator-bundle.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: redhat-3.16
-      url: git@github.com:openshift-priv/container-security-operator.git
+      url: git@github.com:openshift-priv/quay-container-security-operator.git
       web: https://github.com/quay/container-security-operator
 jira:
   project: PROJQUAY

--- a/images/container-security-operator.yml
+++ b/images/container-security-operator.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: redhat-3.16
-      url: git@github.com:openshift-priv/container-security-operator.git
+      url: git@github.com:openshift-priv/quay-container-security-operator.git
       web: https://github.com/quay/container-security-operator
 jira:
   project: PROJQUAY

--- a/images/quay-bridge-operator-bundle.yml
+++ b/images/quay-bridge-operator-bundle.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: redhat-3.16
-      url: git@github.com:openshift-priv/quay-bridge-operator.git
+      url: git@github.com:openshift-priv/quay-quay-bridge-operator.git
       web: https://github.com/quay/quay-bridge-operator
 jira:
   project: PROJQUAY

--- a/images/quay-bridge-operator.yml
+++ b/images/quay-bridge-operator.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: redhat-3.16
-      url: git@github.com:openshift-priv/quay-bridge-operator.git
+      url: git@github.com:openshift-priv/quay-quay-bridge-operator.git
       web: https://github.com/quay/quay-bridge-operator
 jira:
   project: PROJQUAY

--- a/images/quay-builder-qemu.yml
+++ b/images/quay-builder-qemu.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: redhat-3.16
-      url: git@github.com:openshift-priv/quay-builder-qemu.git
+      url: git@github.com:openshift-priv/quay-quay-builder-qemu.git
       web: https://github.com/quay/quay-builder-qemu
 jira:
   project: PROJQUAY

--- a/images/quay-builder.yml
+++ b/images/quay-builder.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: redhat-3.16
-      url: git@github.com:openshift-priv/quay-builder.git
+      url: git@github.com:openshift-priv/quay-quay-builder.git
       web: https://github.com/quay/quay-builder
 jira:
   project: PROJQUAY

--- a/images/quay-clair.yml
+++ b/images/quay-clair.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: release-4.7
-      url: git@github.com:openshift-priv/clair.git
+      url: git@github.com:openshift-priv/quay-clair.git
       web: https://github.com/quay/clair
 jira:
   project: PROJQUAY

--- a/images/quay-operator-bundle.yml
+++ b/images/quay-operator-bundle.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: redhat-3.16
-      url: git@github.com:openshift-priv/quay-operator.git
+      url: git@github.com:openshift-priv/quay-quay-operator.git
       web: https://github.com/quay/quay-operator
 jira:
   project: PROJQUAY

--- a/images/quay-operator.yml
+++ b/images/quay-operator.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: redhat-3.16
-      url: git@github.com:openshift-priv/quay-operator.git
+      url: git@github.com:openshift-priv/quay-quay-operator.git
       web: https://github.com/quay/quay-operator
 jira:
   project: PROJQUAY

--- a/images/quay-quay.yml
+++ b/images/quay-quay.yml
@@ -4,7 +4,7 @@ content:
     git:
       branch:
         target: redhat-3.16
-      url: git@github.com:openshift-priv/quay.git
+      url: git@github.com:openshift-priv/quay-quay.git
       web: https://github.com/quay/quay
 jira:
   project: PROJQUAY


### PR DESCRIPTION
openshift-priv mirrors quay/ repos with a quay- prefix (e.g. quay/quay-operator → openshift-priv/quay-quay-operator)