### PR TITLE
Add commatrix component mapping to product.yml

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -1345,5 +1345,7 @@ bug_mapping:
       issue_component: Cloud Credential Operator
     microshift-bootc-container:
       issue_component: MicroShift
+    commatrix:
+      issue_component: networking-ingress-commatrix
     ose-support-log-gather-operator-container:
       issue_component: must-gather


### PR DESCRIPTION
## Summary

- Add `commatrix` → `networking-ingress-commatrix` mapping to the manual component assignment section in `product.yml`
- Ensures CVE security trackers for the commatrix component are properly routed to the correct Jira issue component

## Context

The `networking-ingress-commatrix` Jira component currently has no entry in `product.yml`, which means the CVE tracker automation cannot map the component to the correct Jira issue component. This mapping is needed so that security vulnerability tickets are created with the correct component assignment.

The commatrix image is a Konflux-built standalone image at `openshift-kni/commatrix` (Konflux component: `commatrix-5-0`).

Repository: https://github.com/openshift-kni/commatrix