### PR TITLE
ACM to ART: Bump version to 2.16.5 (next unreleased after 2.16.4)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -2,7 +2,7 @@ freeze_automation: false
 name: acm-2.16
 csv_namespace: open-cluster-management
 product: acm
-version: 2.16.3
+version: 2.16.5
 
 vars:
   GO_LATEST: "1.26"

--- a/group.yml
+++ b/group.yml
@@ -2,7 +2,7 @@ freeze_automation: false
 name: acm-2.16
 csv_namespace: open-cluster-management
 product: acm
-version: 2.16.5
+version: 2.16.4
 
 vars:
   GO_LATEST: "1.26"


### PR DESCRIPTION
2.16.4 has been released, so the group version should be the next unreleased version (2.16.5) for in-development builds.