### PR TITLE
MTA 8.1: version bump & freeze automation

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,8 +1,8 @@
-freeze_automation: false
+freeze_automation: true
 name: mta-8.1
 csv_namespace: mta
 product: mta
-version: 8.1.3
+version: 8.1.4
 
 vars:
   # The go versions used by the various CI builder images.


### PR DESCRIPTION
freezing automation to stop builds which are producing broken/failing FBC.

@dymurray , after upstream version bump and ready for 8.1.4, please PR to set `freeze_automation: false` again to resume builds.  Thanks!