### PR TITLE
5.0: set canonical_builders_from_upstream to false

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -248,7 +248,7 @@ check_golang_versions: "x.y"
 # canonical_builders_from_upstream can be overridden by every single image
 # If set to False, it will use the default art config
 # If set to True, it will honor the image's config
-canonical_builders_from_upstream: true
+canonical_builders_from_upstream: false
 
 # This is a toggle to allow streams prs to not yet be opened. This can be useful when golang
 # builders are not yet set up correctly for the release at branch cut time, and we want to limit


### PR DESCRIPTION
Change canonical_builders_from_upstream to false.