### PR TITLE
Revert "MTA 8.1: version bump & freeze automation"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,8 +1,8 @@
-freeze_automation: true
+freeze_automation: false
 name: mta-8.1
 csv_namespace: mta
 product: mta
-version: 8.1.4
+version: 8.1.3
 
 vars:
   # The go versions used by the various CI builder images.


### PR DESCRIPTION
Reverts openshift-eng/ocp-build-data#12210 
(returning control/schedule to layered-product team for version bump timing)

https://github.com/openshift-eng/art-tools/pull/3262