### PR TITLE
sign golang for 1.26 rhel9

### DIFF
--- a/images/openshift-golang-builder-1-26.rhel9.yml
+++ b/images/openshift-golang-builder-1-26.rhel9.yml
@@ -36,7 +36,6 @@ labels:
   io.k8s.description: golang builder image for Red Hat internal builds
 
 name: openshift/golang-builder
-sign_golang_rpm: false
 
 owners:
 - aos-team-art@redhat.com


### PR DESCRIPTION
we should be good to sign all golang builds

ref slack thread: https://redhat-internal.slack.com/archives/CB95J6R4N/p1786377780493949?thread_ts=1786368455.773119&cid=CB95J6R4N