### PR TITLE
Map cnf-tests delivery repos to Low latency validation tooling

### DIFF
--- a/delivery_component_mapping.yml
+++ b/delivery_component_mapping.yml
@@ -5980,3 +5980,11 @@ bug_mapping:
       issue_component: GitOps ZTP
     ose-aws-ecr-image-credential-provider:
       issue_component: Cloud Compute / Cloud Controller Manager
+    openshift4/cnf-tests-rhel8:
+      issue_component: Low latency validation tooling
+    openshift4/cnf-tests-rhel9:
+      issue_component: Low latency validation tooling
+    openshift5/cnf-tests-rhel9:
+      issue_component: Low latency validation tooling
+    redhat-user-workloads/cnf-tests-4-15:
+      issue_component: Low latency validation tooling

--- a/product.yml
+++ b/product.yml
@@ -1349,3 +1349,15 @@ bug_mapping:
       issue_component: networking-ingress-commatrix
     ose-support-log-gather-operator-container:
       issue_component: must-gather
+    # CPAAS-built cnf-tests delivery repos (excluded from ART images/*.yml via
+    # group.yml exclude_components). ProdSec CVE trackers use these delivery
+    # names as pscomponent; without these entries they can be misrouted.
+    openshift4/cnf-tests-rhel8:
+      issue_component: Low latency validation tooling
+    openshift4/cnf-tests-rhel9:
+      issue_component: Low latency validation tooling
+    openshift5/cnf-tests-rhel9:
+      issue_component: Low latency validation tooling
+    redhat-user-workloads/cnf-tests-4-15:
+      issue_component: Low latency validation tooling
+


### PR DESCRIPTION
## Summary
- Add missing CVE component mappings for CPAAS-built `cnf-tests` delivery repos so ProdSec trackers resolve to **Low latency validation tooling** (same as existing `cnf-tests-container`).
- These delivery names are absent from ART `images/*.yml` because `cnf-tests-container` is listed under `group.yml` `exclude_components` (CPAAS-built), so `scripts/gen_cve_mapping` never emits them.
- Without these entries, open OCPBUGS CVE trackers with `pscomponent:openshift4/cnf-tests-*` (and related) have been landing on the wrong component (`CNF-Cert-TNF` / certsuite).

Mapped delivery repos:
- `openshift4/cnf-tests-rhel8`
- `openshift4/cnf-tests-rhel9`
- `openshift5/cnf-tests-rhel9`
- `redhat-user-workloads/cnf-tests-4-15`

## Test plan
- [ ] Confirm keys appear under `bug_mapping.components` in `delivery_component_mapping.yml` with `issue_component: Low latency validation tooling`
- [ ] Confirm `product.yml` manual section includes the same delivery names for future `scripts/gen_cve_mapping` runs
- [ ] Spot-check an existing tracker (e.g. [OCPBUGS-99936](https://redhat.atlassian.net/browse/OCPBUGS-99936)) would now map `openshift4/cnf-tests-rhel8` → Low latency validation tooling

Assisted-By: Cursor