### PR TITLE
4.13: set konflux plr_template_commitish for update-prefetch-dependencies-0.7.1

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -18,6 +18,7 @@ arches:
 - x86_64
 
 konflux:
+  plr_template_commitish: "openshift-priv@update-prefetch-dependencies-0.7.1"
   arches:
   - x86_64
   cachi2:


### PR DESCRIPTION
## Summary
- Sets `konflux.plr_template_commitish` in `group.yml` to `openshift-priv@update-prefetch-dependencies-0.7.1` to test [openshift-priv/art-konflux-template#176](https://github.com/openshift-priv/art-konflux-template/pull/176)
- Mirror of #12223 for 4.13

## Test plan
- Verify Konflux builds on 4.13 pick up the PLR template from the PR branch
- Revert once the PR is merged and the template is released