### PR TITLE
Change product from acm to rhacm2 for bundle name label fix

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,7 +1,7 @@
 freeze_automation: false
 name: acm-2.16
 csv_namespace: open-cluster-management
-product: acm
+product: rhacm2
 version: 2.16.4
 
 vars:


### PR DESCRIPTION
## Summary
- Changes `product: acm` to `product: rhacm2` in group.yml for acm-2.16

## Context
The OLM bundle `name` label is generated as `{product}/{bundle_short_name}`. With `product: acm`, bundles get labels like `acm/acm-operator-bundle`, but Konflux validation expects `rhacm2/acm-operator-bundle` (matching the delivery repo namespace used by non-bundle images).

Companion PR in art-tools adds the `rhacm2` product mapping to all constants/maps: https://github.com/openshift-eng/art-tools/pull/3273

## Test plan
- [ ] Verify bundle builds produce `rhacm2/...` name labels
- [ ] Confirm Konflux LabelValidationError is resolved
