### PR TITLE
Add bundle_name_override for multiclusterhub-operator bundle name label

### DIFF
--- a/images/multiclusterhub-operator.yml
+++ b/images/multiclusterhub-operator.yml
@@ -22,6 +22,7 @@ from:
     - stream: rhel-9-golang
   member: base-rhel9
 name: rhacm2/multiclusterhub-rhel9
+bundle_name_override: acm-operator-bundle
 update-csv:
   name: advanced-cluster-management
   manifests-dir: bundle


### PR DESCRIPTION
## Summary
- Adds `bundle_name_override: acm-operator-bundle` to `images/multiclusterhub-operator.yml`

## Context
Without the top-level `bundle_name_override`, `get_olm_bundle_short_name()` falls back to the default `{distgit_key}-bundle` derivation, producing `multiclusterhub-operator-bundle`. This causes a Konflux `LabelValidationError`:

```
Component 'acm-2-16-acm-operator-bundle' name label ('rhacm2/multiclusterhub-operator-bundle') does not match expected name ('rhacm2/acm-operator-bundle')
```

The `bundle_delivery_repo_name: rhacm2/acm-operator-bundle` already in the YAML confirms the correct expected short name is `acm-operator-bundle`. This follows the same pattern as MCE's `backplane-operator.yml` which uses `bundle_name_override: mce-operator-bundle`.

Note: the existing `konflux.component.bundle_name_override: acm-2-16-acm-operator-bundle` is for the Konflux Component resource name, not the image `name` label — both are needed.

## Test plan
- [ ] Confirm bundle build produces `name` label `rhacm2/acm-operator-bundle`
- [ ] Verify LabelValidationError is resolved in Konflux
