### PR TITLE
ART-21983: Remove sign_golang_rpm config option

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -30,8 +30,6 @@ urls:
   brew_image_namespace: rh-osbs
   cgit: https://pkgs.devel.redhat.com/cgit
 
-sign_golang_rpm: true
-
 insecure_source: true
 default_image_build_method: osbs2
 

--- a/images/openshift-golang-builder-1-26.rhel10.yml
+++ b/images/openshift-golang-builder-1-26.rhel10.yml
@@ -36,7 +36,6 @@ labels:
   io.k8s.description: golang builder image for Red Hat internal builds
 
 name: openshift/golang-builder
-sign_golang_rpm: false
 
 owners:
 - aos-team-art@redhat.com

--- a/images/openshift-golang-builder-1-26.rhel8.yml
+++ b/images/openshift-golang-builder-1-26.rhel8.yml
@@ -36,7 +36,6 @@ labels:
   io.k8s.description: golang builder image for Red Hat internal builds
 
 name: openshift/golang-builder
-sign_golang_rpm: false
 
 owners:
 - aos-team-art@redhat.com

--- a/images/openshift-golang-builder-1-26.rhel9.yml
+++ b/images/openshift-golang-builder-1-26.rhel9.yml
@@ -36,7 +36,6 @@ labels:
   io.k8s.description: golang builder image for Red Hat internal builds
 
 name: openshift/golang-builder
-sign_golang_rpm: false
 
 owners:
 - aos-team-art@redhat.com


### PR DESCRIPTION
The `sign_golang_rpm` config option is no longer needed. The pipeline now signs all golang RPMs with the internal key regardless of source (RHEL-shipped or OCP-sustaining-built).

Companion PR: openshift-eng/art-tools (sign-all-golang-rpms branch)