### PR TITLE
Delete unused etcd golang version configurations

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -134,32 +134,6 @@ rhel-9-golang-1.23-ci-build-root:
   transform: rhel-9/ci-build-root
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-{MAJOR}.{MINOR}
 
-# IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
-# approval to diverge from what kube apiserver uses for a given release.
-etcd_golang-1.16:
-  image: openshift/golang-builder:v1.16.12-202306121749.el8.g74bd633
-  mirror: true
-  # No transform required as etcd does not yum install any packages.
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.16
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.16
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-priv/builder.
-  upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-priv/builder:rhel-8-etcd-golang-1.16
-
-# IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
-# approval to diverge from what kube apiserver uses for a given release.
-etcd_golang:
-  image: openshift/golang-builder:v1.19.13-202408070335.gfa00de2.el8
-  mirror: true
-  # No transform required as etcd does not yum install any packages.
-  # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.19
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.19
-  # To ensure consistency in our builds and allow CI to use the same build, mirror the upstream builder image from ocp/builder to ocp-priv/builder.
-  upstream_image_mirror:
-    - registry.ci.openshift.org/ocp-priv/builder:rhel-8-etcd-golang-1.19
-
 rhel8:
   # the most recent release at present. since we yum update this, it does not need to float.
   # it is important that we not build from unreleased builds and publish them.


### PR DESCRIPTION
Removed etcd version configurations for golang 1.16 and 1.19. These streams are no longer being used.