### PR TITLE
Pin agent-installer-ui to latest released build in stream assembly [4.20]

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -2634,6 +2634,11 @@ releases:
           component: '*'
       members:
         images:
+          - distgit_key: agent-installer-ui
+            why: Newer builds failing - pin to latest released build
+            metadata:
+              is:
+                nvr: assisted-installer-ui-container-v4.20.0-202608050632.p2.g52f3224.assembly.stream.el9
           - distgit_key: '*'
             why: Exclude rpm updates that should not cause mass rebuilds
             metadata:


### PR DESCRIPTION
## Summary

- Newer agent-installer-ui builds are failing; pin the stream assembly to the last known good Konflux build
- NVR: `assisted-installer-ui-container-v4.20.0-202608050632.p2.g52f3224.assembly.stream.el9`
- Image: `registry.redhat.io/openshift4/ose-agent-installer-ui-rhel9:v4.20`

Made with [Cursor](https://cursor.com)