### PR TITLE
Pin agent-installer-ui to latest released build in stream assembly [4.21]

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -2752,6 +2752,11 @@ releases:
           component: '*'
       members:
         images:
+          - distgit_key: agent-installer-ui
+            why: Newer builds failing - pin to latest released build
+            metadata:
+              is:
+                nvr: assisted-installer-ui-container-v4.21.0-202608051112.p2.ga5c154e.assembly.stream.el9
           - distgit_key: '*'
             why: Exclude rpm updates that should not cause mass rebuilds
             metadata:


### PR DESCRIPTION
## Summary

- Newer agent-installer-ui builds are failing; pin the stream assembly to the last known good Konflux build
- NVR: `assisted-installer-ui-container-v4.21.0-202608051112.p2.ga5c154e.assembly.stream.el9`
- Image: `registry.redhat.io/openshift4/ose-agent-installer-ui-rhel9:v4.21`

Made with [Cursor](https://cursor.com)