### PR TITLE
Revert "NO-JIRA: debug 4.12 ibm-vpc-node-label-updater (#12236)"

### DIFF
--- a/images/ibm-vpc-node-label-updater.yml
+++ b/images/ibm-vpc-node-label-updater.yml
@@ -8,12 +8,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ibm-vpc-node-label-updater.git
       web: https://github.com/openshift/ibm-vpc-node-label-updater
-    modifications:
-      # ca-certificates is installed in member openshift-enterprise-base
-      # https://github.com/openshift/ibm-vpc-node-label-updater/blob/release-4.12/Dockerfile.openshift#L8
-      - action: replace
-        match: "yum install --setopt=tsflags=nodocs -y ca-certificates"
-        replacement: "echo yum install --setopt=tsflags=nodocs -y ca-certificates"
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
This reverts commit 2187bc935274ca50ab030768d178761aca8de809.

proper fix is https://github.com/openshift-eng/art-tools/pull/3285, [test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/fgallott/job/ocp4-konflux/997/console)

