### PR TITLE
ACM to ART: Fix console runtime base to use nodejs-24 instead of base-rhel9

### DIFF
--- a/images/console.yml
+++ b/images/console.yml
@@ -24,7 +24,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-nodejs-24
-  member: base-rhel9
+  stream: rhel-9-nodejs-24
 name: rhacm2/console-rhel9
 owners:
 - acm-cicd@redhat.com


### PR DESCRIPTION
The console component runs `node backend.mjs` at runtime, so the final stage needs Node.js available. Using `member: base-rhel9` (UBI Minimal) as the runtime base causes "node not found" at container startup.

Changed to `stream: rhel-9-nodejs-24` to match MCE's working console-mce configuration which uses the same upstream source.