### PR TITLE
ose-support-log-gather-operator bundle directory from 'tech-preview' to 'stable'

### DIFF
--- a/images/ose-support-log-gather-operator.yml
+++ b/images/ose-support-log-gather-operator.yml
@@ -35,7 +35,7 @@ name_in_bundle: support-log-gather-operator
 owners:
 - openshift-oap-tech-team@redhat.com
 update-csv:
-  bundle-dir: 'tech-preview/'
+  bundle-dir: 'stable/'
   manifests-dir: bundle/manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
follows https://github.com/openshift/must-gather-operator/pull/378/changes#diff-cbe2555dbc9cfcb77609a310e4d885c8795bcd4273c883f03a8d5bb7f97ab27e