### PR TITLE
Fix kubevirt-velero-plugin branch target for oadp-1.4

### DIFF
--- a/images/oadp-kubevirt-velero-plugin.yml
+++ b/images/oadp-kubevirt-velero-plugin.yml
@@ -7,11 +7,11 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-v0.7
+        target: oadp-1.4
       url: git@github.com:openshift-priv/migtools-kubevirt-velero-plugin.git
       web: https://github.com/migtools/kubevirt-velero-plugin
     modifications:
-      # https://github.com/migtools/kubevirt-velero-plugin/blob/release-v0.7/konflux.Dockerfile#L9
+      # https://github.com/migtools/kubevirt-velero-plugin/blob/oadp-1.4/konflux.Dockerfile#L9
       - action: replace
         match: "dnf -y"
         replacement: "microdnf -y"


### PR DESCRIPTION
## Summary

- The `oadp-kubevirt-velero-plugin` image config was pointing to `release-v0.7` instead of `oadp-1.4`
- `release-v0.7` last commit: `05c1e9f` from **February 17, 2026**
- `oadp-1.4` latest commit: `f058de1` from **August 10, 2026**
- This means ART has been building a 6-month-old snapshot of this component
- All other OADP components in this group correctly target `oadp-1.4`

## Changes

- Updated `branch.target` from `release-v0.7` to `oadp-1.4`
- Updated the comment URL to reference the correct branch

*Posted via [Claude Code](https://claude.ai/code)*