### PR TITLE
Fix kubevirt-velero-plugin branch target for oadp-1.3

### DIFF
--- a/images/oadp-kubevirt-velero-plugin.yml
+++ b/images/oadp-kubevirt-velero-plugin.yml
@@ -7,11 +7,11 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-v0.6
+        target: oadp-1.3
       url: git@github.com:openshift-priv/migtools-kubevirt-velero-plugin.git
       web: https://github.com/migtools/kubevirt-velero-plugin
     modifications:
-      # https://github.com/migtools/kubevirt-velero-plugin/blob/release-v0.6/konflux.Dockerfile#L9
+      # https://github.com/migtools/kubevirt-velero-plugin/blob/oadp-1.3/konflux.Dockerfile#L9
       - action: replace
         match: "dnf -y"
         replacement: "microdnf -y"


### PR DESCRIPTION
## Summary

- The `oadp-kubevirt-velero-plugin` image config was pointing to `release-v0.6` instead of `oadp-1.3`
- ART has been building a stale snapshot of this component
- All other OADP components in this group correctly target `oadp-1.3`
- Same issue as https://github.com/openshift-eng/ocp-build-data/pull/12323 (oadp-1.4 fix)

## Changes

- Updated `branch.target` from `release-v0.6` to `oadp-1.3`
- Updated the comment URL to reference the correct branch

*Posted via [Claude Code](https://claude.ai/code)*