### PR TITLE
microshift-bootc: declare base image via from: for hermetic lockfile

### DIFF
--- a/images/microshift-bootc-rhel10.yml
+++ b/images/microshift-bootc-rhel10.yml
@@ -26,6 +26,14 @@ content:
     ci_alignment:
       streams_prs:
         enabled: false
+# Declare the base image via `from:` so doozer resolves it into downstream_parents
+# and generates the RPM lockfile in image mode (rpmdb-aware). Without this, the base
+# is only known via the Containerfile BASE_IMAGE_* ARGs, the lockfile resolves in
+# bare mode, and conditional deps of the base kernel (e.g. microshift's
+# `Requires: (kernel-modules-extra if kernel-core)`) are omitted from the prefetch,
+# breaking the hermetic build. Must match BASE_IMAGE_URL/BASE_IMAGE_TAG above.
+from:
+  image: registry.redhat.io/rhel10/rhel-bootc:10.2
 delivery:
   delivery_repo_names:
   - openshift5/microshift-bootc-rhel10

--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -26,6 +26,14 @@ content:
     ci_alignment:
       streams_prs:
         enabled: false
+# Declare the base image via `from:` so doozer resolves it into downstream_parents
+# and generates the RPM lockfile in image mode (rpmdb-aware). Without this, the base
+# is only known via the Containerfile BASE_IMAGE_* ARGs, the lockfile resolves in
+# bare mode, and conditional deps of the base kernel (e.g. microshift's
+# `Requires: (kernel-modules-extra if kernel-core)`) are omitted from the prefetch,
+# breaking the hermetic build. Must match BASE_IMAGE_URL/BASE_IMAGE_TAG above.
+from:
+  image: registry.redhat.io/rhel9/rhel-bootc:9.8
 delivery:
   delivery_repo_names:
   - openshift5/microshift-bootc-rhel9


### PR DESCRIPTION
## Problem

The `microshift-bootc` (el9) and `microshift-bootc-rhel10` builds for `openshift-5.0` fail during hermetic image build at `dnf install ... microshift`:

```
Problem: package microshift-5.0.0~ec.6-....el9.x86_64 requires
  (kernel-modules-extra if kernel-core), but none of the providers can be installed
  - problem with installed package kernel-core-5.14.0-687.34.1.el9_8.x86_64
```

## Root cause

These images inject their base image (`rhel-bootc`) **only** through the Containerfile `BASE_IMAGE_URL`/`BASE_IMAGE_TAG` ARGs — they have no top-level `from:` stanza. doozer only populates `downstream_parents` from `from:`, so with none present the RPM lockfile is generated in **bare mode** (`resolving 0 extra packages in bare mode`) and the base image rpmdb is never inspected.

In bare mode the resolver doesn't see the base `kernel-core` as installed, so microshift's conditional dependency `Requires: (kernel-modules-extra if kernel-core)` never fires and `kernel-modules-extra` is omitted from the prefetched content set. The hermetic build then can't satisfy it.

## Fix

Add a `from:` stanza matching the ARG-injected base. doozer resolves it into `downstream_parents`, generates the lockfile in **image mode** (rpmdb-aware), and the conditional `kernel-modules-extra` is pulled into the prefetch automatically.

This mirrors the existing `rhcos-node-image` pattern where `from:` and `BASE_IMAGE` ARG modifications coexist. Only these two images on `openshift-5.0` lack a `from:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)