### PR TITLE
microshift-bootc: declare base image via from: for hermetic lockfile [4.21]

### DIFF
--- a/images/microshift-bootc.yml
+++ b/images/microshift-bootc.yml
@@ -26,6 +26,14 @@ content:
     ci_alignment:
       streams_prs:
         enabled: false
+# Declare the base image via `from:` so doozer resolves it into downstream_parents
+# and generates the RPM lockfile in image mode (rpmdb-aware). Without this, the base
+# is only known via the Containerfile BASE_IMAGE_* ARGs, the lockfile resolves in
+# bare mode, and conditional deps of the base kernel (e.g. microshift's
+# `Requires: (kernel-modules-extra if kernel-core)`) are omitted from the prefetch,
+# breaking the hermetic build. Must match BASE_IMAGE_URL/BASE_IMAGE_TAG above.
+from:
+  image: registry.redhat.io/rhel9-eus/rhel-9.6-bootc:9.6
 delivery:
   delivery_repo_names:
   - openshift4/microshift-bootc-rhel9


### PR DESCRIPTION
## Problem

The `microshift-bootc` build fails during hermetic image build at `dnf install ... microshift`:

```
Problem: package microshift-...el9.x86_64 requires
  (kernel-modules-extra if kernel-core), but none of the providers can be installed
  - problem with installed package kernel-core-...el9.x86_64
```

## Root cause

This image injects its base image (`rhel-bootc`) **only** through the Containerfile `BASE_IMAGE_URL`/`BASE_IMAGE_TAG` ARGs — no top-level `from:` stanza. doozer only populates `downstream_parents` from `from:`, so the RPM lockfile is generated in **bare mode** and the base image rpmdb is never inspected. The resolver therefore doesn't see the base `kernel-core` as installed, microshift's conditional dependency `Requires: (kernel-modules-extra if kernel-core)` never fires, and `kernel-modules-extra` is omitted from the prefetched content set — breaking the hermetic build.

## Fix

Add a `from:` stanza matching the ARG-injected base. doozer resolves it into `downstream_parents`, generates the lockfile in **image mode** (rpmdb-aware), and the conditional `kernel-modules-extra` is pulled in automatically. Mirrors the `rhcos-node-image` pattern.

Backport of #12329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)