### PR TITLE
Fix bundle-dir for ose-support-log-gather-operator on 4.23

### DIFF
--- a/images/ose-support-log-gather-operator.yml
+++ b/images/ose-support-log-gather-operator.yml
@@ -35,7 +35,7 @@ name_in_bundle: support-log-gather-operator
 owners:
 - openshift-oap-tech-team@redhat.com
 update-csv:
-  bundle-dir: 'tech-preview/'
+  bundle-dir: 'stable/'
   manifests-dir: bundle/manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
## Summary
- Upstream [`must-gather-operator`](https://github.com/openshift/must-gather-operator) PR [#378](https://github.com/openshift/must-gather-operator/pull/378) ("[MG-331](https://redhat.atlassian.net/browse/MG-331): Promote the must-gather-operator from Tech Preview to GA", merged 2026-08-14) renamed `bundle/manifests/tech-preview/` to `bundle/manifests/stable/` on the `release-4.23` branch.
- This config still declares `update-csv.bundle-dir: 'tech-preview/'`, so doozer's rebase step can no longer find `image-references` and fails with:
  ```
  FileNotFoundError: ose-support-log-gather-operator: image-references file not found in any location: [...]
  ```
- Every `build/ocp4-konflux` run targeting 4.23 has been failing on this image as a result (confirmed reproducible across two separate build attempts).

## Test plan
- [ ] Confirm `bundle/manifests/stable/image-references` exists on `release-4.23` of `must-gather-operator` (verified locally)
- [ ] Retrigger a `build/ocp4-konflux` run for `BUILD_VERSION=4.23` and confirm `ose-support-log-gather-operator` rebases and builds successfully
