### PR TITLE
ose-support-log-gather-operator: update bundle dir from tech-preview to stable

### DIFF
--- a/images/ose-support-log-gather-operator.yml
+++ b/images/ose-support-log-gather-operator.yml
@@ -35,7 +35,7 @@ name_in_bundle: support-log-gather-operator
 owners:
 - openshift-oap-tech-team@redhat.com
 update-csv:
-  bundle-dir: 'tech-preview/'
+  bundle-dir: 'stable/'
   manifests-dir: bundle/manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
## Summary
The must-gather-operator upstream has promoted the API to GA and moved the OLM bundle from tech-preview to stable channel. This PR reflects the changes from https://github.com/openshift/must-gather-operator/pull/378.

Update the `update-csv.bundle-dir` configuration to match the new bundle directory structure (`stable/` instead of `tech-preview/`).