### PR TITLE
[MTA] Declare new images for agentic-controller

### DIFF
--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -1,0 +1,64 @@
+cachito:
+  packages:
+    gomod:
+      - path: harness/
+    pip:
+      - path: hack/cachi2
+        requirements_files:
+        - requirements.txt
+content:
+  source:
+    dockerfile: images/agent-base/Containerfile
+    git:
+      branch:
+        target: release-0.10
+      url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
+      web: https://github.com/migtools/mta-agentic-controller
+    modifications:
+      - action: replace
+        match: "RUN go mod download"
+        replacement: "# go mod download removed - deps pre-fetched by cachi2"
+      - action: replace
+        match: 'curl -fsSL "https://github.com/block/goose/releases/download/${GOOSE_VERSION}/goose-${GOOSE_ARCH}.tar.bz2" -o /tmp/goose.tar.bz2'
+        replacement: "cp /cachi2/output/deps/generic/goose.tar.bz2 /tmp/goose.tar.bz2"
+      - action: replace
+        match: "python3 -m pip install --no-cache-dir graphifyy==0.7.17"
+        replacement: "python3 -m pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip/ graphifyy==0.7.17"
+    pkg_managers:
+    - gomod
+    - pip
+jira:
+  project: MTA
+  component: Analysis
+distgit:
+  component: mta-agent-base-container
+delivery:
+  delivery_repo_names:
+  - mta/mta-agent-base-rhel9
+enabled_repos:
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: mta/mta-agent-base-rhel9
+owners:
+- mta-devs@redhat.com
+dependents:
+  - mta-agent-java
+  - mta-operator
+konflux:
+  cachi2:
+    lockfile:
+      rpms:
+      - gcc
+      - gcc-c++
+      - python3-devel
+      - libffi-devel
+      - pkg-config
+    artifact_lockfile:
+      enabled: true
+      resources:
+        - url: https://github.com/block/goose/releases/download/v1.45.0/goose-x86_64-unknown-linux-gnu.tar.bz2
+          filename: goose.tar.bz2

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -11,7 +11,7 @@ content:
     dockerfile: images/agent-base/Containerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
       web: https://github.com/migtools/mta-agentic-controller
     modifications:

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -1,3 +1,5 @@
+base_image_release:
+  force: true
 cachito:
   packages:
     gomod:
@@ -20,7 +22,7 @@ content:
         replacement: "# go mod download removed - deps pre-fetched by cachi2"
       - action: replace
         match: 'curl -fsSL "https://github.com/block/goose/releases/download/${GOOSE_VERSION}/goose-${GOOSE_ARCH}.tar.bz2" -o /tmp/goose.tar.bz2'
-        replacement: "cp /cachi2/output/deps/generic/goose.tar.bz2 /tmp/goose.tar.bz2"
+        replacement: "cp /cachi2/output/deps/generic/goose-${GOOSE_ARCH}.tar.bz2 /tmp/goose.tar.bz2"
       - action: replace
         match: "python3 -m pip install --no-cache-dir graphifyy==0.7.17"
         replacement: "python3 -m pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip/ graphifyy==0.7.17"
@@ -61,4 +63,6 @@ konflux:
       enabled: true
       resources:
         - url: https://github.com/block/goose/releases/download/v1.45.0/goose-x86_64-unknown-linux-gnu.tar.bz2
-          filename: goose.tar.bz2
+          filename: goose-x86_64-unknown-linux-gnu.tar.bz2
+        - url: https://github.com/block/goose/releases/download/v1.45.0/goose-aarch64-unknown-linux-gnu.tar.bz2
+          filename: goose-aarch64-unknown-linux-gnu.tar.bz2

--- a/images/mta-agent-java.yml
+++ b/images/mta-agent-java.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: images/agent-java/Containerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
       web: https://github.com/migtools/mta-agentic-controller
 jira:

--- a/images/mta-agent-java.yml
+++ b/images/mta-agent-java.yml
@@ -1,0 +1,26 @@
+content:
+  source:
+    dockerfile: images/agent-java/Containerfile
+    git:
+      branch:
+        target: release-0.10
+      url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
+      web: https://github.com/migtools/mta-agentic-controller
+jira:
+  project: MTA
+  component: Analysis
+distgit:
+  component: mta-agent-java-container
+delivery:
+  delivery_repo_names:
+  - mta/mta-agent-java-rhel9
+enabled_repos:
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
+from:
+  member: mta-agent-base
+name: mta/mta-agent-java-rhel9
+owners:
+- mta-devs@redhat.com
+dependents:
+  - mta-operator

--- a/images/mta-agentic-controller.yml
+++ b/images/mta-agentic-controller.yml
@@ -8,7 +8,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
       web: https://github.com/migtools/mta-agentic-controller
     modifications:

--- a/images/mta-agentic-controller.yml
+++ b/images/mta-agentic-controller.yml
@@ -1,0 +1,37 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+      - path: api/
+content:
+  source:
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: release-0.10
+      url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
+      web: https://github.com/migtools/mta-agentic-controller
+    modifications:
+      - action: replace
+        match: "RUN go mod download"
+        replacement: "# go mod download removed - deps pre-fetched by cachi2"
+jira:
+  project: MTA
+  component: Analysis
+distgit:
+  component: mta-agentic-controller-container
+delivery:
+  delivery_repo_names:
+  - mta/mta-agentic-controller-rhel9
+enabled_repos:
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: mta/mta-agentic-controller-rhel9
+owners:
+- mta-devs@redhat.com
+dependents:
+  - mta-operator

--- a/images/mta-analyzer-addon.yml
+++ b/images/mta-analyzer-addon.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-tackle2-addon-analyzer.git
       web: https://github.com/migtools/mta-tackle2-addon-analyzer
 jira:

--- a/images/mta-analyzer-lsp.yml
+++ b/images/mta-analyzer-lsp.yml
@@ -9,7 +9,7 @@ content:
     dockerfile: konflux.analyzer-lsp.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
 jira:

--- a/images/mta-analyzer-rpc.yml
+++ b/images/mta-analyzer-rpc.yml
@@ -9,7 +9,7 @@ content:
     dockerfile: konflux.analyzer-rpc.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-kai.git
       web: https://github.com/migtools/mta-kai
 jira:

--- a/images/mta-cli.yml
+++ b/images/mta-cli.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-kantra.git
       web: https://github.com/migtools/mta-kantra
 jira:

--- a/images/mta-discovery-addon.yml
+++ b/images/mta-discovery-addon.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-tackle2-addon-discovery.git
       web: https://github.com/migtools/mta-tackle2-addon-discovery
 jira:

--- a/images/mta-dotnet-external-provider.yml
+++ b/images/mta-dotnet-external-provider.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
 #      url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       url: git@github.com:openshift-priv/migtools-mta-c-sharp-analyzer-provider.git
 #      web: https://github.com/migtools/mta-analyzer-lsp

--- a/images/mta-go-external-provider.yml
+++ b/images/mta-go-external-provider.yml
@@ -11,7 +11,7 @@ content:
     dockerfile: konflux.go-external-provider.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
 jira:

--- a/images/mta-hub.yml
+++ b/images/mta-hub.yml
@@ -10,7 +10,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-tackle2-hub.git
       web: https://github.com/migtools/mta-tackle2-hub
     pkg_managers:

--- a/images/mta-java-external-provider.yml
+++ b/images/mta-java-external-provider.yml
@@ -10,7 +10,7 @@ content:
     dockerfile: konflux.java-external-provider.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
 jira:

--- a/images/mta-jdtls-server-base.yml
+++ b/images/mta-jdtls-server-base.yml
@@ -5,7 +5,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-java-analyzer-bundle.git
       web: https://github.com/migtools/mta-java-analyzer-bundle
 jira:

--- a/images/mta-nodejs-external-provider.yml
+++ b/images/mta-nodejs-external-provider.yml
@@ -10,7 +10,7 @@ content:
     dockerfile: konflux.nodejs-external-provider.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
 jira:

--- a/images/mta-operator.yml
+++ b/images/mta-operator.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-operator.git
       web: https://github.com/migtools/mta-operator
       allow_unprotected_branch: true

--- a/images/mta-platform-addon.yml
+++ b/images/mta-platform-addon.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-tackle2-addon-platform.git
       web: https://github.com/migtools/mta-tackle2-addon-platform
 jira:

--- a/images/mta-python-external-provider.yml
+++ b/images/mta-python-external-provider.yml
@@ -16,7 +16,7 @@ content:
     dockerfile: konflux.python-external-provider.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-analyzer-lsp.git
       web: https://github.com/migtools/mta-analyzer-lsp
     pkg_managers:

--- a/images/mta-solution-server.yml
+++ b/images/mta-solution-server.yml
@@ -3,7 +3,7 @@ content:
     dockerfile: konflux.solution-server.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-kai.git
       web: https://github.com/migtools/mta-kai
 jira:

--- a/images/mta-static-report.yml
+++ b/images/mta-static-report.yml
@@ -14,7 +14,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-static-report.git
       web: https://github.com/migtools/mta-static-report
 jira:

--- a/images/mta-ui.yml
+++ b/images/mta-ui.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: release-0.10
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-tackle2-ui.git
       web: https://github.com/migtools/mta-tackle2-ui
     modifications:


### PR DESCRIPTION
The agentic controller is a new tool within the MTA ecosystem which harnesses agents to automate migrations.

- We want to avoid creating additional Dockerfiles (`konflux.Dockerfile`) as much as possible, since that duplication will certainly lead to mistakes when having to update. I'm using the `content.source.modifications` field in hopes that any change necessary to make images compliant can be done there.
- The `target` is currently set to `main`. We haven't yet created the `release-0.11` branch, from which `mta-8.3` will be created. This will have to be changed when the release branch is created.
- :arrow_right: [Original u/s repository](https://github.com/konveyor/agentic-controller)