### PR TITLE
[openshift-5.1] Add rhel-9-golang builder stage to openshift-enterprise-keepalived-ipfailover  to reflect changes from upstream

### DIFF
--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -21,6 +21,8 @@ enabled_repos:
 - rhel-9-appstream-rpms
 for_payload: true
 from:
+  builder:
+  - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
 labels:
   License: GPLv2+


### PR DESCRIPTION
Reflect upstream changes from https://github.com/openshift/images/pull/245/changes#diff-f81d88cb390bf4c19c2067e1819be262179a43d71aa82f356482c8584de94503 - Add rhel-9-golang builder stage.
Fixes:
```
ValueError: Build metadata for openshift-enterprise-keepalived-ipfailover expected 1 parent images, but found 2 in Dockerfile (2 total FROM directives, 0 are stage references)
``` 

[Test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/44078/)