### PR TITLE
fix(console): use renamed Containerfile.acm on release-5.0

### DIFF
--- a/images/console.yml
+++ b/images/console.yml
@@ -7,7 +7,7 @@ cachito:
     - path: ./backend
 content:
   source:
-    dockerfile: Containerfile.acm.konflux
+    dockerfile: Containerfile.acm
     git:
       branch:
         target: release-5.0


### PR DESCRIPTION
Console's Containerfile got renamed upstream (Containerfile.acm.konflux → Containerfile.acm), so our config has a stale path