### PR TITLE
driver-toolkit: remove duplicate/stale RHEL 9.4 baseos/appstream repos

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -27,10 +27,6 @@ delivery:
   - openshift4/driver-toolkit-rhel9
 enabled_repos:
 - rhel-9-server-ose-rpms-embargoed
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
-- rhel-9-baseos-rpms
-- rhel-9-appstream-rpms
 - rhel-9-rt-rpms
 - rhel-96-baseos
 - rhel-96-appstream


### PR DESCRIPTION
## Summary
- `driver-toolkit.yml` enabled both the RHEL 9.4 (`rhel-9-baseos-rpms`, `rhel-9-appstream-rpms`, each duplicated) and RHEL 9.6 (`rhel-96-baseos`, `rhel-96-appstream`) baseos/appstream repos at the same time.
- The base image chain (`openshift-base-rhel9` → `openshift-enterprise-base-rhel9` → `driver-toolkit`) starts from the RHEL 9.4 ELS stream (`rhel9-4-els`), so `glibc-2.34-100.el9_4.13` is already installed. With `RHEL_VERSION=9.6`, `dnf install kernel-devel` needs `glibc-devel` from the 9.6 appstream repo, which requires `glibc-2.34-168.el9_6.25` — but the stale 9.4 repos being enabled alongside it block dnf from resolving the upgrade, causing a version conflict on every arch (`kernel-devel` install step).
- Removing the duplicate/stale 9.4 `enabled_repos` entries lets dnf resolve the glibc upgrade cleanly via the 9.6 repos.

## Test plan
- [x] Kick off a driver-toolkit build (e.g. s390x/ppc64le e4s path) and confirm the `dnf -y install kernel-devel...` step no longer hits the glibc-devel/glibc version conflict.
- [ ] Confirm the SBOM step runs (previously skipped due to the earlier build failure).