### PR TITLE
Add Atharva-Shinde to OWNERS (openshift-4.21)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -22,6 +22,7 @@ reviewers:
 - pruan-rht
 - fgallott
 - fbladilo
+- Atharva-Shinde
 approvers:
 - sosiouxme
 - jupierce
@@ -46,5 +47,6 @@ approvers:
 - pruan-rht
 - fgallott
 - fbladilo
+- Atharva-Shinde
 # this is to keep automation from complaining about ownership of base image builds
 component: Release


### PR DESCRIPTION
## Summary
Add Atharva-Shinde to both reviewers and approvers in OWNERS file.