### PR TITLE
Add lifecycle-agent-operator-bundle CVE mapping to LCA Operator

### DIFF
--- a/delivery_component_mapping.yml
+++ b/delivery_component_mapping.yml
@@ -5338,6 +5338,8 @@ bug_mapping:
       issue_component: Networking / ovn-kubernetes
     lifecycle-agent-operator-bundle-container:
       issue_component: LCA Operator
+    lifecycle-agent-operator-bundle:
+      issue_component: LCA Operator
     local-storage-operator-metadata-container:
       issue_component: Storage / Local Storage Operator
     local-storage-static-provisioner-container:

--- a/product.yml
+++ b/product.yml
@@ -259,6 +259,11 @@ bug_mapping:
       issue_component: Networking / ovn-kubernetes
     lifecycle-agent-operator-bundle-container:
       issue_component: LCA Operator
+    # Konflux component name. ProdSec strips openshift4/ from the pscomponent
+    # label and looks up this key; the brew name above has a -container suffix
+    # that does not match, so trackers fall back to Security.
+    lifecycle-agent-operator-bundle:
+      issue_component: LCA Operator
     local-storage-diskmaker-container:
       issue_component: Storage / Local Storage Operator
     local-storage-operator-container:


### PR DESCRIPTION
## Summary

- Add `lifecycle-agent-operator-bundle` → `LCA Operator` next to the existing brew name `lifecycle-agent-operator-bundle-container`.
- ProdSec CVE trackers use `pscomponent:openshift4/lifecycle-agent-operator-bundle`. After stripping the `openshift4/` prefix, lookup is `lifecycle-agent-operator-bundle`, which was missing from `product.yml`.
- Without this key, trackers fall back to **Security** instead of Pavel Postler's LCA sustaining team (`LCA operator`). Example: [OCPBUGS-89798](https://redhat.atlassian.net/browse/OCPBUGS-89798).

The existing `-container` brew mapping is left in place for older trackers labeled `pscomponent:lifecycle-agent-operator-bundle-container`.

## Test plan

- [ ] Confirm `lifecycle-agent-operator-bundle` maps to `LCA Operator` in `product.yml` and `delivery_component_mapping.yml`
- [ ] New trackers with `pscomponent:openshift4/lifecycle-agent-operator-bundle` should route to **LCA operator**, not Security
- [ ] Existing `-container` brew trackers should keep routing to **LCA operator**

Made with [Cursor](https://cursor.com)