### PR TITLE
ART-21984: add dra-driver-sriov operand image for OCP 5.0

### DIFF
--- a/images/dra-driver-sriov.yml
+++ b/images/dra-driver-sriov.yml
@@ -1,0 +1,44 @@
+mode: wip
+content:
+  source:
+    dockerfile: Dockerfile.ocp
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/dra-driver-sriov.git
+      web: https://github.com/openshift/dra-driver-sriov
+    ci_alignment:
+      streams_prs:
+        auto_label:
+        - approved
+        - lgtm
+        ci_build_root:
+          member: ci-openshift-build-root-latest.rhel9
+dependents:
+- sriov-network-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: dra-driver-sriov-container
+delivery:
+  # Maps to honeybadger repo_name
+  repo_name: dra-driver-sriov
+  delivery_repo_names:
+  - openshift5/dra-driver-sriov-rhel9
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+for_payload: false
+from:
+  builder:
+  - stream: rhel-9-golang
+  member: openshift-enterprise-base-rhel9
+name: openshift/dra-driver-sriov-rhel9
+name_in_bundle: dra-driver-sriov
+owners:
+- wizhao@redhat.com
+- anbhat@redhat.com
+- danwinship@redhat.com
+- datucker@redhat.com
+- ljouin@redhat.com
+- sscheink@redhat.com
+- bpickard@redhat.com


### PR DESCRIPTION
Onboard the sriov-network-operator DRA driver operand in wip mode so Konflux can build openshift/dra-driver-sriov-rhel9.

Co-authored-by: Cursor <cursoragent@cursor.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED