### PR TITLE
ART-21984: map dra-driver-sriov-container to Networking / SR-IOV

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -154,6 +154,8 @@ bug_mapping:
       issue_component: Networking / DPU
     dpu-network-resources-injector-container:
       issue_component: Networking / DPU
+    dra-driver-sriov-container:
+      issue_component: Networking / SR-IOV
     driver-toolkit-container:
       issue_component: Driver Toolkit
     dumb-init:


### PR DESCRIPTION
## Summary
- Add dra-driver-sriov-container to product.yml with issue_component Networking / SR-IOV (same as sriov-network-device-plugin-container).
- Companion to https://github.com/openshift-eng/ocp-build-data/pull/12460 (image YAML on openshift-5.0).
- [ART-21984](https://redhat.atlassian.net/browse/ART-21984) / [ART-22818](https://redhat.atlassian.net/browse/ART-22818)

## Test plan
- [ ] Confirm Networking / SR-IOV is the intended Jira component (request mentioned Networking/dra-driver-sriov).
