### PR TITLE
Add rsync transfer image for MTA-Ops

### DIFF
--- a/images/mta-rsync-transfer.yml
+++ b/images/mta-rsync-transfer.yml
@@ -1,0 +1,30 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: konflux.Dockerfile
+    git:
+      branch:
+        target: master
+      url: git@github.com:openshift-priv/migtools-mta-rsync-transfer.git
+      web: https://github.com/migtools/mta-rsync-transfer
+jira:
+  project: MTA
+  component: mta-ops
+distgit:
+  component: mta-rsync-transfer-container
+delivery:
+  delivery_repo_names:
+  - mta/mta-rsync-transfer-rhel9
+enabled_repos:
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: mta/mta-rsync-transfer-rhel9
+owners:
+- mta-devs@redhat.com


### PR DESCRIPTION
Adding rsync transfer image for MTA-Ops CLI , needs to be shipped with MTA 8.3 release