### PR TITLE
[ART-22834] Re-enable cri-o RPM build for openshift-5.0

### DIFF
--- a/rpms/cri-o.yml
+++ b/rpms/cri-o.yml
@@ -1,4 +1,3 @@
-mode: disabled
 content:
   source:
     git:


### PR DESCRIPTION
The priv fork (`openshift-priv/cri-o` `release-5.0`) has been force-pushed to match public. `cri-o.spec` is now present at repo root, which was the original scan failure that caused `mode: disabled` to be added in #12247.

Removes `mode: disabled` so cri-o builds resume and `publish-rpms` keeps the `5.0-el9-beta` deps mirror current for MicroShift.

**Background:**
- #12106 added `rpms/cri-o.yml` on 12 Aug; scan broke the same day (missing `cri-o.spec` on stale priv fork)
- #12247 set `mode: disabled` to unblock; the one pre-disable brew build (`cri-o-1.36.3-7.rhaos5.0.git50e187f.el9`) is what kept the 5.0 mirror alive
- Priv force-push requested from @Justin Pierce (asked in Slack — https://redhat-internal.slack.com/archives/CBN38N3MW/p1785313903727889)

Jira: [ART-22834](https://redhat.atlassian.net/browse/ART-22834)