### PR TITLE
[ART-22834] Add cri-o RPM config for openshift-5.1

### DIFF
--- a/rpms/cri-o.yml
+++ b/rpms/cri-o.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/cri-o.git
+      web: https://github.com/openshift/cri-o
+    specfile: cri-o.spec
+name: cri-o
+owners:
+- sgrunert@redhat.com
+- qiwan@redhat.com
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+- rhaos-{MAJOR}.{MINOR}-rhel-10-candidate
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+- rhaos-{MAJOR}.{MINOR}-rhel-10-hotfix


### PR DESCRIPTION
Adds `rpms/cri-o.yml` to `openshift-5.1` so cri-o RPMs get built and published to the `5.1-el9-beta` deps mirror.

**Problem:** MicroShift 5.1 fails to install because `cri-o` is missing from the deps mirror. `microshift` requires `cri-o >= 1.36.0, < 1.37.0`; the mirror has `cri-tools` but no `cri-o`. Root cause: `rpms/cri-o.yml` was never created for `openshift-5.1` when the branch was cut (5.0 got it in #12106, 5.1 didn't).

**Config:** identical to 4.23/5.0 — no `mode: disabled`. Branch target resolves to `release-5.1` on `openshift-priv/cri-o`, which has been force-pushed to match public.

**Version note:** `release-5.1` tracks upstream cri-o 1.37.x. If MicroShift 5.1 strictly needs `< 1.37.0`, the `branch.target` may need pinning to `release-5.0` — follow-up decision for the team.

Mirror: https://mirror.openshift.com/pub/openshift-v5/x86_64/dependencies/rpms/5.1-el9-beta/
Jira: [ART-22834](https://redhat.atlassian.net/browse/ART-22834)
Companion PR (5.0 re-enable): #12468
