### PR TITLE
ART-22836 [openshift-4.17]: pin Go tool versions in ci-build-root

### DIFF
--- a/ci_transforms/rhel-7/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-7/ci-build-root/Dockerfile
@@ -23,7 +23,6 @@ RUN GOFLAGS='' go install golang.org/x/tools/cmd/cover@latest && \
     GOFLAGS='' go install github.com/tools/godep@latest && \
     GOFLAGS='' go install golang.org/x/lint/golint@latest && \
     GOFLAGS='' go install gotest.tools/gotestsum@latest && \
-    GOFLAGS='' go install github.com/openshift/release/tools/gotest2junit@latest && \
     GOFLAGS='' go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \

--- a/ci_transforms/rhel-8/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-8/ci-build-root/Dockerfile
@@ -46,13 +46,9 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 # Install common go tools upstream devs are expecting in CI.
 # Pure cargo culting from https://github.com/openshift/release/blob/51d92eb6a6d730e932a5daf68829ca7936739904/projects/origin-release/golang-1.13/Dockerfile#L41
 # Clear GOFLAGS temporarily for 1.12  bug:https://github.com/golang/go/issues/32502
-RUN GOFLAGS='' go install golang.org/x/tools/cmd/cover@latest && \
-    GOFLAGS='' go install golang.org/x/tools/cmd/goimports@latest && \
-    GOFLAGS='' go install github.com/tools/godep@latest && \
-    GOFLAGS='' go install golang.org/x/lint/golint@latest && \
+RUN GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
     GOFLAGS='' go install gotest.tools/gotestsum@v1.12.2 && \
-    GOFLAGS='' go install github.com/openshift/release/tools/gotest2junit@latest && \
-    GOFLAGS='' go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
+    GOFLAGS='' go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.15 && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \
     mkdir $GOPATH/bin && \

--- a/ci_transforms/rhel-9/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-9/ci-build-root/Dockerfile
@@ -45,13 +45,9 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
 # Install common go tools upstream devs are expecting in CI.
 # Pure cargo culting from https://github.com/openshift/release/blob/51d92eb6a6d730e932a5daf68829ca7936739904/projects/origin-release/golang-1.13/Dockerfile#L41
 # Clear GOFLAGS temporarily for 1.12  bug:https://github.com/golang/go/issues/32502
-RUN GOFLAGS='' GO111MODULE=on go install golang.org/x/tools/cmd/cover@latest && \
-    GOFLAGS='' GO111MODULE=on go install golang.org/x/tools/cmd/goimports@latest && \
-    GOFLAGS='' GO111MODULE=on go install github.com/tools/godep@latest && \
-    GOFLAGS='' GO111MODULE=on go install golang.org/x/lint/golint@latest && \
-    GOFLAGS='' GO111MODULE=on go install gotest.tools/gotestsum@v1.12.2 && \
-    GOFLAGS='' GO111MODULE=on go install github.com/openshift/release/tools/gotest2junit@latest && \
-    GOFLAGS='' GO111MODULE=on go install github.com/openshift/imagebuilder/cmd/imagebuilder@latest && \
+RUN GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
+    GOFLAGS='' go install gotest.tools/gotestsum@v1.12.2 && \
+    GOFLAGS='' go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.15 && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \
     mkdir $GOPATH/bin && \


### PR DESCRIPTION
## Summary
Pin Go tool versions in `ci_transforms/*/ci-build-root/Dockerfile` so app.ci ci-build-root BuildConfigs stop failing on `@latest` installs (notably goimports requiring Go >= 1.25).

## Problem
**Before:** `goimports@latest`, `gotest2junit@latest`, and unpinned `imagebuilder@latest` in ocp-build-data ci_transforms override doozerlib templates. sync-ci-images stage-2 release BuildConfigs fail; `openshift/release` golang build_root tags stay stale.

**After:** Pinned `goimports@v0.24.0`, `gotestsum@v1.12.2`, `imagebuilder@v1.2.15`. Dropped gotest2junit and deprecated tools. Same pattern verified on openshift-4.18 (#12450).

Related: [ART-22836](https://redhat.atlassian.net/browse/ART-22836)