### PR TITLE
[4.21] OCPBUGS-104008: Use golang 1.25 for aws-karpenter-provider-aws builds

### DIFF
--- a/images/aws-karpenter-provider-aws.yml
+++ b/images/aws-karpenter-provider-aws.yml
@@ -22,7 +22,7 @@ for_payload: true
 payload_name: aws-karpenter-provider-aws
 from:
   builder:
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-base-rhel9
 name: openshift/aws-karpenter-provider-aws-rhel9
 owners:


### PR DESCRIPTION
We have decided to switch from golang 1.24 to 1.25 as part of the remediation for a CVE.

Fixes https://github.com/openshift/aws-karpenter-provider-aws/pull/38