### PR TITLE
oadp-1.6: bump version to 1.6.2 and update golang builder

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -2,7 +2,7 @@ freeze_automation: false
 name: oadp-1.6
 csv_namespace: oadp
 product: oadp
-version: 1.6.1
+version: 1.6.2
 
 vars:
   # The go versions used by the various CI builder images.

--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606100741.p2.ged14a27.el9
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202608111835.p2.g1c0e65f.el9
 
 rhel-9-nodejs-24:
   image: registry.redhat.io/ubi9/nodejs-24:latest


### PR DESCRIPTION
## Why the changes were made

- Bump the OADP 1.6 product version from 1.6.1 to 1.6.2 in `group.yml`
- Update the `rhel-9-golang` builder in `streams.yml` to `v1.26.5-202608111835.p2.g1c0e65f.el9`, aligning with the golang stream from the `openshift-5.0` branch

## How to test the changes made

- Verify `group.yml` reflects `version: 1.6.2`
- Verify `streams.yml` `rhel-9-golang` image tag matches the openshift-5.0 stream

*Posted via [Claude Code](https://claude.ai/code)*