### PR TITLE
Remove extra parent image overwrite

### DIFF
--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -24,7 +24,6 @@ for_payload: true
 from:
   builder:
   - stream: rhel-9-golang
-  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/egress-router-cni-rhel9
 payload_name: egress-router-cni


### PR DESCRIPTION
Remove extra parent image overwrite due to [upstream change](https://github.com/openshift/egress-router-cni/commit/baeee331a9702b79e7c2d4b7aa2e5b69e12d267e)
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED