### PR TITLE
Bump OVE UI ISO embedded OCP release to 4.22.11

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -24,9 +24,9 @@ konflux:
     memory: "8Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
-  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.22.9-x86_64"
+  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.22.11-x86_64"
   - "MAJOR_MINOR_VERSION=4.22"
-  - "PATCH_VERSION=9"
+  - "PATCH_VERSION=11"
   - "ARCH=x86_64"
 
 assemblies:

--- a/streams.yml
+++ b/streams.yml
@@ -1,6 +1,6 @@
 ---
 agent-preinstall-image-builder:
-  image: registry.ci.openshift.org/ocp/4.22:agent-preinstall-image-builder
+  image: quay-proxy.ci.openshift.org/openshift/ci:ocp_{MAJOR}.{MINOR}_agent-preinstall-image-builder
 
 scratch:
   image: scratch


### PR DESCRIPTION
## Summary
- Update `konflux.build_args` in `group.yml` to embed OCP **4.22.11** in the OVE agent installer ISO build
  - Changes `RELEASE_VALUE` to `quay.io/openshift-release-dev/ocp-release:4.22.11-x86_64` and `PATCH_VERSION` to `11`
- Update `streams.yml` to use the quay-proxy `agent-preinstall-image-builder` pullspec (follow-up to [agent-installer-utils#321](https://github.com/openshift/agent-installer-utils/pull/321))
  - Old: `registry.ci.openshift.org/ocp/4.22:agent-preinstall-image-builder`
  - New: `quay-proxy.ci.openshift.org/openshift/ci:ocp_{MAJOR}.{MINOR}_agent-preinstall-image-builder` (expands to `ocp_4.22_agent-preinstall-image-builder` for this group)

## Context
Prepares the `installer-ove-ui-4.22` branch for a new `art-agent-installer-iso` Konflux/Jenkins build.

Upstream `agent-installer-utils` already switched the ISO builder image to quay-proxy in PR #321, but doozer rebase overwrites the Dockerfile `FROM` line using `streams.yml` via `art-agent-installer-iso.yml` (`from.builder.stream: agent-preinstall-image-builder`). The stale stream entry was reverting the pullspec on every rebase.

## Test plan
- [ ] Merge PR
- [ ] Trigger layered-products build with `GROUP=installer-ove-ui-4.22`, `ASSEMBLY=stream`, `IMAGE_LIST=art-agent-installer-iso`, and this branch as `DOOZER_DATA_GITREF`
- [ ] Confirm rebase leaves Dockerfile `FROM` on quay-proxy (not `registry.ci.openshift.org`)