### PR TITLE
[4.21] Use golang 1.25 for aws-karpenter-provider-aws builds (part 2)

### DIFF
--- a/images/aws-karpenter-provider-aws.yml
+++ b/images/aws-karpenter-provider-aws.yml
@@ -9,7 +9,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          member: ci-openshift-build-root-latest.rhel9
+          member: ci-openshift-build-root-extra.rhel9
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9
   component: aws-karpenter-provider-aws-container


### PR DESCRIPTION
This is a follow-up to #12483

Fixes https://github.com/openshift/aws-karpenter-provider-aws/pull/39