### PR TITLE
ART-22875: (5.0) Disable all dpu-operator images

### DIFF
--- a/images/dpu-cni.yml
+++ b/images/dpu-cni.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.CNI.rhel

--- a/images/dpu-daemon.yml
+++ b/images/dpu-daemon.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.daemon.rhel

--- a/images/dpu-intel-ipu-p4sdk.yml
+++ b/images/dpu-intel-ipu-p4sdk.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - aarch64
 - x86_64

--- a/images/dpu-intel-ipu-vsp.yml
+++ b/images/dpu-intel-ipu-vsp.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - aarch64
 - x86_64

--- a/images/dpu-intel-netsec-vsp.yml
+++ b/images/dpu-intel-netsec-vsp.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - aarch64
 - x86_64

--- a/images/dpu-marvell-cp-agent.yml
+++ b/images/dpu-marvell-cp-agent.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - aarch64
 - x86_64

--- a/images/dpu-marvell-vsp.yml
+++ b/images/dpu-marvell-vsp.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - aarch64
 - x86_64

--- a/images/dpu-network-resources-injector.yml
+++ b/images/dpu-network-resources-injector.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - aarch64
 - x86_64

--- a/images/dpu-operator.yml
+++ b/images/dpu-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel
@@ -29,8 +30,3 @@ name: openshift/ose-dpu-rhel9-operator
 name_in_bundle: dpu-operator
 owners:
 - multus-dev@redhat.com
-update-csv:
-  bundle-dir: 'stable/'
-  manifests-dir: manifests
-  registry: image-registry.openshift-image-registry.svc:5000
-  valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -19,7 +19,6 @@ dependents:
 - ingress-node-firewall-operator
 - ose-gcp-filestore-csi-driver-operator
 - ose-smb-csi-driver-operator
-- dpu-operator
 - openshift-kubernetes-nmstate-operator
 - sriov-network-operator
 - pf-status-relay-operator


### PR DESCRIPTION
## Summary
- Disable all 9 DPU image configs (`mode: disabled`) — stops new builds
- Remove `update-csv` from `dpu-operator.yml` — excludes DPU operator from FBC catalog
- Remove `dpu-operator` from `kube-rbac-proxy.yml` dependents list

## Context
The dpu-operator project is being archived ([NHE-2501](https://redhat.atlassian.net/browse/NHE-2501)):
- No active customer adoption for the past couple of years
- Development upstreamed to [OPI](https://github.com/opiproject/dpu-operator/)
- Several unfixed CVEs flagged in the repository

Tracking Jira: [ART-22875](https://redhat.atlassian.net/browse/ART-22875)

🤖 Generated with [Claude Code](https://claude.com/claude-code)