### PR TITLE
ART-22875: (4.17) Disable all dpu-operator images

### DIFF
--- a/images/dpu-cni.yml
+++ b/images/dpu-cni.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.CNI.rhel

--- a/images/dpu-daemon.yml
+++ b/images/dpu-daemon.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.daemon.rhel

--- a/images/dpu-operator.yml
+++ b/images/dpu-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel
@@ -29,8 +30,3 @@ name: openshift/ose-dpu-rhel9-operator
 name_in_bundle: dpu-operator
 owners:
 - multus-dev@redhat.com
-update-csv:
-  bundle-dir: 'stable/'
-  manifests-dir: manifests
-  registry: image-registry.openshift-image-registry.svc:5000
-  valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -19,7 +19,6 @@ dependents:
 - ingress-node-firewall-operator
 - ose-gcp-filestore-csi-driver-operator
 - ose-smb-csi-driver-operator
-- dpu-operator
 - openshift-kubernetes-nmstate-operator
 - sriov-network-operator
 distgit:


### PR DESCRIPTION
## Summary
- Disable all 3 DPU image configs (`mode: disabled`) — stops new builds
- Remove `update-csv` from `dpu-operator.yml` — excludes DPU operator from FBC catalog
- Remove `dpu-operator` from `kube-rbac-proxy.yml` dependents list

## Context
The dpu-operator project is being archived ([NHE-2501](https://redhat.atlassian.net/browse/NHE-2501)):
- No active customer adoption for the past couple of years
- Development upstreamed to [OPI](https://github.com/opiproject/dpu-operator/)
- Several unfixed CVEs flagged in the repository

Tracking Jira: [ART-22875](https://redhat.atlassian.net/browse/ART-22875)