### PR TITLE
[ART-22864] fix(streams): point golang 1.23.10 builders to registry.redhat.io for 4.19

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -54,7 +54,7 @@ rhel-8-golang-1.24:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.23:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
@@ -62,7 +62,7 @@ partner-rhel-8-golang-1.23:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-9-golang-1.23:
-  image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.23-openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
## Summary

PR #12491 (auto-generated by golang-builder #744) incorrectly set the golang 1.23.10 builder
pullspecs to `quay.io/redhat-user-workloads` because the shipment MRs were not yet merged when
the pipeline checked `registry.redhat.io`. This corrects all 4 affected streams back to the
published `registry.redhat.io/openshift/art-images-base` location.

Affected streams: `rhel-9-golang`, `rhel-8-golang`, `partner-rhel-9-golang-1.23`, `partner-rhel-8-golang-1.23`

## Context

- Jenkins job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/744/
- Shipment MRs (now being merged): https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/762 https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/761
- Related: [ART-22836](https://redhat.atlassian.net/browse/ART-22836) (ci-build-root Go tool pinning)