### PR TITLE
Update mta-ops repo branch for mta-8.3

### DIFF
--- a/images/mta-ops.yml
+++ b/images/mta-ops.yml
@@ -7,7 +7,7 @@ content:
     dockerfile: konflux.Dockerfile
     git:
       branch:
-        target: mta-8.2
+        target: main
       url: git@github.com:openshift-priv/migtools-mta-crane.git
       web: https://github.com/migtools/mta-crane
 jira:


### PR DESCRIPTION
Updating mta-8.3 branch to pick up source code from main branch, after feature freeze , we'll cut mta-8.3 d/s and update the same.