### PR TITLE
HYPBLD-862 - Add rhel-9-ubi stream for console crypto-policy stage

### DIFF
--- a/images/console.yml
+++ b/images/console.yml
@@ -23,6 +23,7 @@ dependents:
 - multiclusterhub-operator
 from:
   builder:
+    - stream: rhel9-ubi
     - stream: rhel-9-nodejs-24
   stream: rhel-9-nodejs-24
 name: rhacm2/console-rhel9

--- a/streams.yml
+++ b/streams.yml
@@ -14,5 +14,8 @@ rhel-9-nodejs-24:
 ose-cli:
   image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.22
 
+rhel9-ubi:
+  image: registry.redhat.io/ubi9/ubi:latest
+
 rhel9:
   image: registry.redhat.io/ubi9/ubi-minimal:9.7


### PR DESCRIPTION
The console Containerfile.acm added a crypto-policy build stage (FROM registry.redhat.io/ubi9/ubi:latest AS crypto-policy) that was not reflected in the from: metadata. This caused doozer to fail with: "expected 2 parent images, but found 3 in Dockerfile"

Add the rhel-9-ubi stream and declare it as the first builder entry in images/console.yml to match the actual Dockerfile structure.