### PR TITLE
ART-21984: activate dra-driver-sriov (remove mode: wip)

### DIFF
--- a/images/dra-driver-sriov.yml
+++ b/images/dra-driver-sriov.yml
@@ -1,4 +1,3 @@
-mode: wip
 content:
   source:
     dockerfile: Dockerfile.ocp


### PR DESCRIPTION
did a `test` build and was successful...remove `wip` mode to make it official pending the following action 
CSV wiring by the Networking team :warning:
   The sriov-network-operator on release-5.0 does not reference dra-driver-sriov yet. Specifically:
   • manifests/stable/image-references has no dra-driver-sriov tag
   • CSV env vars don't include a DRA driver image entry
   The Networking team needs to add a relatedImages / image-references entry named dra-driver-sriov (plus the corresponding env/daemonset wiring) in the operator. ART cannot invent CSV edits — this is an operator-side change.
