### PR TITLE
Map openshift/ose-rhel-coreos-{8,9,10} to RHCOS

### DIFF
--- a/delivery_component_mapping.yml
+++ b/delivery_component_mapping.yml
@@ -7444,6 +7444,12 @@ bug_mapping:
       issue_component: RHCOS
     rhcos-x86_64:
       issue_component: RHCOS
+    openshift/ose-rhel-coreos-8:
+      issue_component: RHCOS
+    openshift/ose-rhel-coreos-9:
+      issue_component: RHCOS
+    openshift/ose-rhel-coreos-10:
+      issue_component: RHCOS
     rpm-ostree:
       issue_component: RHCOS
     runc:

--- a/product.yml
+++ b/product.yml
@@ -1260,6 +1260,16 @@ bug_mapping:
       issue_component: RHCOS
     rhcos-x86_64:
       issue_component: RHCOS
+    # lib-newtopia 1.1.9 / SECDATA-1309: RHCOS node-image parent PURL is now
+    # pkg:oci/ose-rhel-coreos-{N}; OSIDB ps_component is
+    # openshift/ose-rhel-coreos-{N}. Keep rhcos above so ART can still match
+    # Downstream Component Name on in-flight trackers.
+    openshift/ose-rhel-coreos-8:
+      issue_component: RHCOS
+    openshift/ose-rhel-coreos-9:
+      issue_component: RHCOS
+    openshift/ose-rhel-coreos-10:
+      issue_component: RHCOS
     rpm-ostree:
       issue_component: RHCOS
     runc:


### PR DESCRIPTION
## Summary
- Add ProdSec `ps_component` names `openshift/ose-rhel-coreos-{8,9,10}` to `bug_mapping.components` so CVE trackers resolve to **RHCOS** (same as the existing `rhcos*` keys).
- After the RHCOS node-image PURL change (`pkg:oci/ose-rhel-coreos-{N}`), OSIDB uses these names. Without the mapping, new OCPBUGS trackers land on the default **Security** component instead of **RHCOS**.
- Keep the existing `rhcos` / `rhcos-*` keys so ART can still match Downstream Component Name on in-flight trackers.

## Test plan
- [ ] Confirm keys appear under `bug_mapping.components` in `product.yml` and `delivery_component_mapping.yml` with `issue_component: RHCOS`
- [ ] Confirm `RHCOS` remains a valid OCPBUGS Jira component
- [ ] After merge, `pspdb update-openshift-components` in product-definitions should pick up the new keys from `product.yml`

Assisted-By: Cursor

Made with [Cursor](https://cursor.com)