### PR TITLE
ART-23115: nmstate-console-plugin: migrate yarn to npm [4.19]

### DIFF
--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -7,17 +7,14 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/nmstate-console-plugin.git
+      url_pull: https://github.com/lgarciaaco/nmstate-console-plugin.git
       web: https://github.com/openshift/nmstate-console-plugin
-    modifications:
-    - action: replace
-      match: "./artifacts/yarn-${YARN_VERSION}.tar.gz"
-      replacement: "/cachi2/output/deps/generic/yarn-${YARN_VERSION}.tar.gz"
     ci_alignment:
       streams_prs:
         ci_build_root:
           member: ci-openshift-build-root-latest.rhel9
     pkg_managers:
-    - yarn
+    - npm
 dependents:
 - openshift-kubernetes-nmstate-operator
 distgit:
@@ -51,6 +48,3 @@ konflux:
     lockfile:
       modules:
       - nginx:1.24
-    artifact_lockfile:
-      resources:
-      - url: https://ocp-artifacts.engineering.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -7,7 +7,6 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/nmstate-console-plugin.git
-      url_pull: https://github.com/lgarciaaco/nmstate-console-plugin.git
       web: https://github.com/openshift/nmstate-console-plugin
     ci_alignment:
       streams_prs:

--- a/images/nmstate-console-plugin.yml
+++ b/images/nmstate-console-plugin.yml
@@ -44,6 +44,8 @@ owners:
 konflux:
   cachito:
     mode: removal
+  vm_override:
+    aarch64: linux-d160-m2xlarge/arm64
   cachi2:
     lockfile:
       modules:


### PR DESCRIPTION
## Summary
Test build of nmstate-console-plugin yarn-to-npm migration against lgarciaaco fork of the upstream source.

## Problem
**Before:** Image builds with `pkg_managers: yarn`, pulling source from `openshift-priv/nmstate-console-plugin` on `release-4.19`, with a yarn artifact modification and cachi2 artifact_lockfile for the yarn tarball.

**After:** Image builds with `pkg_managers: npm`, pulling source from `lgarciaaco/nmstate-console-plugin` on `release-4.19` via `url_pull`. yarn artifact_lockfile and Dockerfile modifications removed.

This is a test-only fork PR to validate [openshift-eng/ocp-build-data#12510](https://github.com/openshift-eng/ocp-build-data/pull/12510) against personal fork before merging upstream.