### PR TITLE
ART-23116: Bump rhcos iso version for machine-os-images

### DIFF
--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -43,11 +43,11 @@ konflux:
       # These are the same URLs that openshift-install coreos print-stream-json outputs.
       # Whenever it changes, update these URLs to match .architectures.{arch}.artifacts.metal.formats.iso.disk.location
       resources:
-      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/x86_64/rhcos-9.6.20260616-0-live-iso.x86_64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260818-0/x86_64/rhcos-9.6.20260818-0-live-iso.x86_64.iso
         filename: coreos-x86_64.iso
-      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/aarch64/rhcos-9.6.20260616-0-live-iso.aarch64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260818-0/aarch64/rhcos-9.6.20260818-0-live-iso.aarch64.iso
         filename: coreos-aarch64.iso
-      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/ppc64le/rhcos-9.6.20260616-0-live-iso.ppc64le.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260818-0/ppc64le/rhcos-9.6.20260818-0-live-iso.ppc64le.iso
         filename: coreos-ppc64le.iso
-      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260616-0/s390x/rhcos-9.6.20260616-0-live-iso.s390x.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20260818-0/s390x/rhcos-9.6.20260818-0-live-iso.s390x.iso
         filename: coreos-s390x.iso


### PR DESCRIPTION
Bump rhcos iso version for machine-os-images

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED