### PR TITLE
ART-23153: - Bump 5.0 golang builders to 1.26.7

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202608111835.p2.g1c0e65f.el9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202607272002.p2.g5a9ab9d.el8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -46,7 +46,7 @@ rhel-8-golang-1.25:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.26:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202607272002.p2.g5a9ab9d.el8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.26-openshift-{MAJOR}.{MINOR}
@@ -54,7 +54,7 @@ partner-rhel-8-golang-1.26:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.26-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-9-golang-1.26:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202608111835.p2.g1c0e65f.el9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.26-openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
Created by job run https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fgolang-builder/751

> [!WARNING]
> **Do NOT merge until the golang builder shipment MRs are merged.**
> These images are published via shipment MRs in
> [ocp-shipment-data](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests).
> Merge those MRs first, then merge this PR.
>
> - RHEL 8: `registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el8`
> - RHEL 9: `registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el9`