### PR TITLE
external-secrets-1.1: add QE and DOCS mr_approvers

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -44,8 +44,10 @@ assemblies:
   enabled: true
 
 mr_approvers:
-  QE: []
-  DOCS: []
+  QE:
+    - sbhor
+  DOCS:
+    - snarayan
 
 public_upstreams:
 - private: "https://github.com/openshift-priv"


### PR DESCRIPTION
## Summary
- Set `mr_approvers.QE` to `sbhor` (Siddhi Bhor)
- Set `mr_approvers.DOCS` to `snarayan` (Shubha)

## Test plan
- [ ] Verify approvers are members of ocp-shipment-data (or layered-products group)
- [ ] Confirm shipment release MR gets QE + DOCS approval rules applied