### PR TITLE
zero-trust-1.1: add QE and DOCS mr_approvers

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -43,6 +43,12 @@ OCP_TARGET_VERSIONS: [
 assemblies:
   enabled: true
 
+mr_approvers:
+  QE:
+    - sayadas
+  DOCS:
+    - snarayan
+
 public_upstreams:
 - private: "https://github.com/openshift-priv"
   public:  "https://github.com/openshift"


### PR DESCRIPTION
## Summary
- Add `mr_approvers.QE` with `sayadas` (Sayak Das)
- Add `mr_approvers.DOCS` with `snarayan` (Shubha)

## Test plan
- [ ] Verify approvers are members of ocp-shipment-data (or layered-products group)
- [ ] Confirm shipment release MR gets QE + DOCS approval rules applied