### PR TITLE
ART-23148: Migrate golang streams to openshift/golang-builder (pinned NVRs) on openshift-4.13

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202608121854.p2.g7d3050a.assembly.stream.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.19-rhel8
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -32,7 +32,7 @@ golang:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202608121854.p2.g7d3050a.assembly.stream.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.19-rhel9
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -56,7 +56,7 @@ rhel-9-golang-ci-build-root:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 etcd_rhel9_golang:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202608121854.p2.g7d3050a.assembly.stream.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.19-rhel9
   mirror: false
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -91,4 +91,4 @@ nodejs:
 rhel-9-golang-1-22:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.22.12-202605111509.p2.g6a298d3.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.22-rhel9

--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.19-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.19.13-202608271629.p2.gedd1cdd.assembly.stream.el8
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -32,7 +32,7 @@ golang:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.19-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.19.13-202608271629.p2.gedd1cdd.assembly.stream.el9
   mirror: true
   transform: rhel-9/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-{MAJOR}.{MINOR}.art
@@ -56,7 +56,7 @@ rhel-9-golang-ci-build-root:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 etcd_rhel9_golang:
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.19-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.19.13-202608271629.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # No transform required as etcd does not yum install
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -91,4 +91,4 @@ nodejs:
 rhel-9-golang-1-22:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.22-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.12-202608131106.p2.g7d3050a.assembly.stream.el9


### PR DESCRIPTION
Migrate golang builder stream entries from `art-images-base` to `openshift/golang-builder` using pinned NVR pullspecs.

**Before:**
```yaml
image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

**After:**
```yaml
image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

Registry moves to `openshift/golang-builder`; NVRs stay pinned (not floating tags) so CVE tracking and build reproducibility keep working until [ART-23167](https://redhat.atlassian.net/browse/ART-23167) validates floating-tag toolchain support.

## Image verification

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.19.13-202608271629.p2.gedd1cdd.assembly.stream.el8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.19.13",
  "release": "202608271629.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.19.13-28.el8"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.19.13-202608271629.p2.gedd1cdd.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.19.13",
  "release": "202608271629.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.19.13-28.el9"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.12-202608131106.p2.g7d3050a.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.22.12",
  "release": "202608131106.p2.g7d3050a.assembly.stream.el9",
  "golang_nvr": "golang-1.22.12-16.el9"
}

JIRA: https://redhat.atlassian.net/browse/ART-23148