### PR TITLE
ART-23148: Migrate golang streams to openshift/golang-builder (pinned NVRs) on openshift-4.15

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.20-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.20.12-202608271630.p2.gedd1cdd.assembly.stream.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -32,7 +32,7 @@ golang:
 
 ibm-rhel-8-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.20-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.20.12-202608271630.p2.gedd1cdd.assembly.stream.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
@@ -40,7 +40,7 @@ ibm-rhel-8-golang-1.20:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.20-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.20.12-202608271630.p2.gedd1cdd.assembly.stream.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -52,7 +52,7 @@ rhel-9-golang:
 
 # Go 1.19 on RHEL 9 (pinned); matches openshift-4.12 rhel-9-golang art-images-base image.
 rhel-9-golang-1.19:
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.19-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.19.13-202608271629.p2.gedd1cdd.assembly.stream.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -64,7 +64,7 @@ rhel-9-golang-1.19:
 
 ibm-rhel-9-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.20-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.20.12-202608271630.p2.gedd1cdd.assembly.stream.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
@@ -109,7 +109,7 @@ nodejs:
   mirror: true
 
 rhel-9-golang-1.21:
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.21-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.21.13-202608260704.p2.gedd1cdd.assembly.stream.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -120,4 +120,4 @@ rhel-9-golang-1.21:
     - registry.ci.openshift.org/ocp-priv/builder:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1-22:
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.22-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.12-202608131106.p2.g7d3050a.assembly.stream.el9

--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.20.12-202608101943.p2.g9e54c20.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.20-rhel8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -32,7 +32,7 @@ golang:
 
 ibm-rhel-8-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.20.12-202608101943.p2.g9e54c20.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.20-rhel8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.20-openshift-{MAJOR}.{MINOR}
@@ -40,7 +40,7 @@ ibm-rhel-8-golang-1.20:
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.20.12-202608101943.p2.g9e54c20.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.20-rhel9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -52,7 +52,7 @@ rhel-9-golang:
 
 # Go 1.19 on RHEL 9 (pinned); matches openshift-4.12 rhel-9-golang art-images-base image.
 rhel-9-golang-1.19:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.19.13-202604231941.p2.g805400d.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.19-rhel9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -64,7 +64,7 @@ rhel-9-golang-1.19:
 
 ibm-rhel-9-golang-1.20:
   # Mirror non-embargoed golang builders for IBM
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.20.12-202608101943.p2.g9e54c20.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.20-rhel9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.20-openshift-{MAJOR}.{MINOR}
@@ -109,7 +109,7 @@ nodejs:
   mirror: true
 
 rhel-9-golang-1.21:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.21.13-202606092245.p2.gce417c9.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.21-rhel9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -120,4 +120,4 @@ rhel-9-golang-1.21:
     - registry.ci.openshift.org/ocp-priv/builder:rhel-9-golang-1.21-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1-22:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.22.12-202605111509.p2.g6a298d3.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.22-rhel9


### PR DESCRIPTION
Migrate golang builder stream entries from `art-images-base` to `openshift/golang-builder` using pinned NVR pullspecs.

**Before:**
```yaml
image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

**After:**
```yaml
image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

Registry moves to `openshift/golang-builder`; NVRs stay pinned (not floating tags) so CVE tracking and build reproducibility keep working until [ART-23167](https://redhat.atlassian.net/browse/ART-23167) validates floating-tag toolchain support.

## Image verification

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.19.13-202608271629.p2.gedd1cdd.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.19.13",
  "release": "202608271629.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.19.13-28.el9"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.20.12-202608271630.p2.gedd1cdd.assembly.stream.el8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.20.12",
  "release": "202608271630.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.20.12-32.el8"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.20.12-202608271630.p2.gedd1cdd.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.20.12",
  "release": "202608271630.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.20.12-32.el9"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.21.13-202608260704.p2.gedd1cdd.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.21.13",
  "release": "202608260704.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.21.13-19.el9"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.12-202608131106.p2.g7d3050a.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.22.12",
  "release": "202608131106.p2.g7d3050a.assembly.stream.el9",
  "golang_nvr": "golang-1.22.12-16.el9"
}

JIRA: https://redhat.atlassian.net/browse/ART-23148