### PR TITLE
ART-23148: Migrate golang streams to openshift/golang-builder (pinned NVRs) on openshift-4.18

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.22.12-202608121842.p2.g7d3050a.assembly.stream.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.22-rhel9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -33,7 +33,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.22.12-202608121842.p2.g7d3050a.assembly.stream.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.22-rhel8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -46,7 +46,7 @@ rhel-8-golang:
 rhel-9-golang-1.23:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202605181541.p2.gbf0298b.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -59,7 +59,7 @@ rhel-9-golang-1.23:
 rhel-8-golang-1.23:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202605181541.p2.gdc331c7.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -70,14 +70,14 @@ rhel-8-golang-1.23:
     - registry.ci.openshift.org/ocp-priv/builder:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.24:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202605181913.p2.gffe23cf.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.24-rhel9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-{MAJOR}.{MINOR}
 
 rhel-8-golang-1.24:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202605181913.p2.g3562721.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.24-rhel8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.

--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.22-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.12-202608131106.p2.g7d3050a.assembly.stream.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -33,7 +33,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.22-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.12-202608271616.p2.gedd1cdd.assembly.stream.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -46,7 +46,7 @@ rhel-8-golang:
 rhel-9-golang-1.23:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9
   mirror: true
   transform: rhel-9/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -59,7 +59,7 @@ rhel-9-golang-1.23:
 rhel-8-golang-1.23:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8
   mirror: true
   transform: rhel-8/golang
   # Leave this upstream information in place even if mirror/transform is disabled. Test Platform read the data.
@@ -70,14 +70,14 @@ rhel-8-golang-1.23:
     - registry.ci.openshift.org/ocp-priv/builder:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.24:
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.24-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.24.13-202608271630.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-{MAJOR}.{MINOR}
 
 rhel-8-golang-1.24:
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.24-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.24.13-202608271630.p2.gedd1cdd.assembly.stream.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
Migrate golang builder stream entries from `art-images-base` to `openshift/golang-builder` using pinned NVR pullspecs.

**Before:**
```yaml
image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

**After:**
```yaml
image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

Registry moves to `openshift/golang-builder`; NVRs stay pinned (not floating tags) so CVE tracking and build reproducibility keep working until [ART-23167](https://redhat.atlassian.net/browse/ART-23167) validates floating-tag toolchain support.

## Image verification

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.12-202608131106.p2.g7d3050a.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.22.12",
  "release": "202608131106.p2.g7d3050a.assembly.stream.el9",
  "golang_nvr": "golang-1.22.12-16.el9"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.22.12-202608271616.p2.gedd1cdd.assembly.stream.el8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.22.12",
  "release": "202608271616.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.22.12-18.el8"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.23.10",
  "release": "202608241902.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.23.10-18.el8"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.23.10",
  "release": "202608241902.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.23.10-18.el9"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.24.13-202608271630.p2.gedd1cdd.assembly.stream.el8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.24.13",
  "release": "202608271630.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.24.13-12.el8_10"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.24.13-202608271630.p2.gedd1cdd.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.24.13",
  "release": "202608271630.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.24.13-12.el9"
}

JIRA: https://redhat.atlassian.net/browse/ART-23148