### PR TITLE
ART-23148: Migrate golang streams to openshift/golang-builder (pinned NVRs) on openshift-4.19

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -38,7 +38,7 @@ rhel-8-golang:
 rhel-9-golang-1.24:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202605181913.p2.gffe23cf.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.24-rhel9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -47,14 +47,14 @@ rhel-9-golang-1.24:
 rhel-8-golang-1.24:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.24.13-202605181913.p2.g3562721.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.24-rhel8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.23:
-  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
@@ -62,7 +62,7 @@ partner-rhel-8-golang-1.23:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-9-golang-1.23:
-  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.23-openshift-{MAJOR}.{MINOR}

--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -38,7 +38,7 @@ rhel-8-golang:
 rhel-9-golang-1.24:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.24-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.24.13-202608271630.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -47,14 +47,14 @@ rhel-9-golang-1.24:
 rhel-8-golang-1.24:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.24-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.24.13-202608271630.p2.gedd1cdd.assembly.stream.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-8-golang-1.23:
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el8
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
@@ -62,7 +62,7 @@ partner-rhel-8-golang-1.23:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.23-openshift-{MAJOR}.{MINOR}
 
 partner-rhel-9-golang-1.23:
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.23-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.23.10-202608241902.p2.gedd1cdd.assembly.stream.el9
   mirror: true
   mirror_manifest_list: true
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.23-openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
Migrate golang builder stream entries from `art-images-base` to `openshift/golang-builder` using pinned NVR pullspecs.

**Before:**
```yaml
image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

**After:**
```yaml
image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

Registry moves to `openshift/golang-builder`; NVRs stay pinned (not floating tags) so CVE tracking and build reproducibility keep working until [ART-23167](https://redhat.atlassian.net/browse/ART-23167) validates floating-tag toolchain support.

## Image verification

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.24.13-202608271630.p2.gedd1cdd.assembly.stream.el8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.24.13",
  "release": "202608271630.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.24.13-12.el8_10"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.24.13-202608271630.p2.gedd1cdd.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.24.13",
  "release": "202608271630.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.24.13-12.el9"
}

JIRA: https://redhat.atlassian.net/browse/ART-23148