### PR TITLE
ART-23148: Migrate golang streams to openshift/golang-builder (pinned NVRs) on openshift-4.22

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.25-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.12-202608271548.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.25-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.11-202608271541.p2.gedd1cdd.assembly.stream.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -38,7 +38,7 @@ rhel-8-golang:
 rhel-9-golang-1.26:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -47,7 +47,7 @@ rhel-9-golang-1.26:
 rhel-8-golang-1.26:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.

--- a/streams.yml
+++ b/streams.yml
@@ -20,7 +20,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.12-202608131531.p2.gedd1cdd.assembly.stream.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.25-rhel9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -29,7 +29,7 @@ rhel-9-golang:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.11-202607131221.p2.g3c0977b.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.25-rhel8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -38,7 +38,7 @@ rhel-8-golang:
 rhel-9-golang-1.26:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202607161626.p2.g48af02f.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -47,7 +47,7 @@ rhel-9-golang-1.26:
 rhel-8-golang-1.26:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202607272002.p2.g5a9ab9d.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
Migrate golang builder stream entries from `art-images-base` to `openshift/golang-builder` using pinned NVR pullspecs.

**Before:**
```yaml
image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

**After:**
```yaml
image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

Registry moves to `openshift/golang-builder`; NVRs stay pinned (not floating tags) so CVE tracking and build reproducibility keep working until [ART-23167](https://redhat.atlassian.net/browse/ART-23167) validates floating-tag toolchain support.

## Image verification

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.11-202608271541.p2.gedd1cdd.assembly.stream.el8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.25.11",
  "release": "202608271541.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.25.11-1.el8_10"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.12-202608271548.p2.gedd1cdd.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.25.12",
  "release": "202608271548.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.25.12-2.el9_8"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.26.7",
  "release": "202608270918.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.26.7-1.module+el8.10.0+24751+b3673b3e"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.26.7",
  "release": "202608270918.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.26.7-1.el9_8"
}

JIRA: https://redhat.atlassian.net/browse/ART-23148