### PR TITLE
ART-23148: Migrate golang streams to openshift/golang-builder (floating tags) on mtc-1.8

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -23,7 +23,7 @@ ose-must-gather:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.9-202605121249.p2.g2aa6a05.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.25-rhel8
 
 rhel-8-builder:
   image: registry.redhat.io/ubi8/ubi:latest


### PR DESCRIPTION
Migrate golang builder stream entries from pinned NVRs at `art-images-base` to floating major.minor tags at `openshift/golang-builder`.

**Before:**
```yaml
image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

**After:**
```yaml
image: registry.redhat.io/openshift/golang-builder:golang-builder-vX.Y-rhelN
```

Floating tags resolve to the latest build for that golang major.minor.

## Floating tag resolution

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:golang-builder-v1.25-rhel8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.25.11",
  "release": "202608271541.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.25.11-1.el8_10"
}

JIRA: https://redhat.atlassian.net/browse/ART-23148