### PR TITLE
ART-23148: Migrate golang streams to openshift/golang-builder (floating tags) on logging-6.5

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,7 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202607161626.p2.g48af02f.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9
 
 # Using floating tags to pickup the latest RPMs
 ose-cli-artifacts:


### PR DESCRIPTION
Migrate golang builder stream entries from pinned NVRs at `art-images-base` to floating major.minor tags at `openshift/golang-builder`.

**Before:**
```yaml
image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

**After:**
```yaml
image: registry.redhat.io/openshift/golang-builder:golang-builder-vX.Y-rhelN
```

Floating tags resolve to the latest build for that golang major.minor.

## Floating tag resolution

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.26.7",
  "release": "202608270918.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.26.7-1.el9_8"
}

JIRA: https://redhat.atlassian.net/browse/ART-23148