### PR TITLE
ART-23148: Migrate golang streams to openshift/golang-builder (floating tags) on mce-5.0

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -1,12 +1,12 @@
 ---
 rhel-9-golang:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202608111835.p2.g1c0e65f.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9
 
 rhel-9-golang-1.26:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202608111835.p2.g1c0e65f.el9
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9
 
 rhel-8-golang-1.26:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.3-202606191459.p2.g0edc4e2.el8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel8
 
 rhel-9-nodejs-24:
   image: registry.redhat.io/ubi9/nodejs-24-minimal:latest


### PR DESCRIPTION
Migrate golang builder stream entries from pinned NVRs at `art-images-base` to floating major.minor tags at `openshift/golang-builder`.

**Before:**
```yaml
image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-vX.Y.Z-TIMESTAMP.elN
```

**After:**
```yaml
image: registry.redhat.io/openshift/golang-builder:golang-builder-vX.Y-rhelN
```

Floating tags resolve to the latest build for that golang major.minor.

## Floating tag resolution

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel8 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.26.7",
  "release": "202608270918.p2.gedd1cdd.assembly.stream.el8",
  "golang_nvr": "golang-1.26.7-1.module+el8.10.0+24751+b3673b3e"
}

> skopeo inspect --override-os linux --override-arch amd64 docker://registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9 | jq '{version: .Labels.version, release: .Labels.release, golang_nvr: .Labels["io.openshift.build.golang-nvr"]}'
{
  "version": "v1.26.7",
  "release": "202608270918.p2.gedd1cdd.assembly.stream.el9",
  "golang_nvr": "golang-1.26.7-1.el9_8"
}

JIRA: https://redhat.atlassian.net/browse/ART-23148