### PR TITLE
MCE on ART (PQC) - Switch rhel9 stream to ubi-minimal-pqc for post-quantum cryptography

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -19,4 +19,4 @@ rhel9-ubi:
   image: registry.redhat.io/ubi9/ubi:latest
 
 rhel9:
-  image: registry.redhat.io/ubi9/ubi-minimal:9.7
+  image: registry.redhat.io/ubi9/ubi-minimal-pqc:latest


### PR DESCRIPTION
Update the base-rhel9 stream from ubi9/ubi-minimal:9.7 to ubi9/ubi-minimal-pqc:latest, enabling PQC support for all MCE 5.0 components that use base-rhel9 as their final base image.

Ref: ACM-40663