### PR TITLE
logging-6.0: Remove stale CLI artifacts parent stream

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -19,7 +19,6 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-    - stream: ose-cli-artifacts
   member: base-rhel9
 name: openshift-logging/cluster-logging-rhel9-operator
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -4,10 +4,6 @@ rhel-9-golang:
     - rhel-9-golang-{GO_LATEST}
   image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202607161626.p2.g48af02f.el9
 
-# Using floating tags to pickup the latest RPMs
-ose-cli-artifacts:
-  image: registry.redhat.io/openshift4/ose-cli-artifacts-rhel9:v4.19
-
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
   image: registry.redhat.io/ubi9-minimal@sha256:17fd831ced9434de0a984d60b3fbe61008308261ba98bbc348d6fbdef05fa7c0


### PR DESCRIPTION
The Cluster Logging Operator upstream removed the `origin-cli-artifacts` Dockerfile stage when must-gather was refactored in Go.

Remove the stale `ose-cli-artifacts` builder dependency and now-unused stream so build metadata matches the two upstream `FROM` directives.

Upstream change: https://github.com/openshift/cluster-logging-operator/commit/bfb082be1b6e