### PR TITLE
logging-6.2: Remove stale CLI artifacts parent stream

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -19,7 +19,6 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-    - stream: ose-cli-artifacts
   member: base-rhel9
 name: openshift-logging/cluster-logging-rhel9-operator
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -4,10 +4,6 @@ rhel-9-golang:
     - rhel-9-golang-{GO_LATEST}
   image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9
 
-# Using floating tags to pickup the latest RPMs
-ose-cli-artifacts:
-  image: registry.redhat.io/openshift4/ose-cli-artifacts-rhel9:v4.19
-
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
   image: registry.redhat.io/ubi9-minimal@sha256:6c79f4fb38a20d496c859025d57e4074835e849d5d14819c4e021ad78446bce8


### PR DESCRIPTION
The Cluster Logging Operator upstream removed the `origin-cli-artifacts` Dockerfile stage when must-gather was refactored in Go.

Remove the stale `ose-cli-artifacts` builder dependency and now-unused stream so build metadata matches the two upstream `FROM` directives.

Upstream change: https://github.com/openshift/cluster-logging-operator/commit/367fdfb8a468