### PR TITLE
logging-6.5: Remove stale CLI artifacts parent stream

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -19,7 +19,6 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-    - stream: ose-cli-artifacts
   member: base-rhel9
 name: openshift-logging/cluster-logging-rhel9-operator
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -4,10 +4,6 @@ rhel-9-golang:
     - rhel-9-golang-{GO_LATEST}
   image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9
 
-# Using floating tags to pickup the latest RPMs
-ose-cli-artifacts:
-  image: registry.redhat.io/openshift4/ose-cli-artifacts-rhel9:v4.21
-
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
   image: registry.redhat.io/ubi9-minimal@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221


### PR DESCRIPTION
The Cluster Logging Operator upstream removed the `origin-cli-artifacts` Dockerfile stage when must-gather was refactored in Go.

Remove the stale `ose-cli-artifacts` builder dependency and now-unused stream so build metadata matches the two upstream `FROM` directives.

Upstream change: https://github.com/openshift/cluster-logging-operator/commit/d35335511b0e