### PR TITLE
update rhcos to ocp-v5.0-art-dev

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -103,24 +103,24 @@ cachito:
 rhcos:
   payload_tags:
     - name: rhel-coreos
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
       rhel_version: "{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}"
       meta_type: commitmeta
       primary: true
     - name: rhel-coreos-extensions
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image-extensions
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image-extensions
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
       rhel_version: "{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}"
       meta_type: meta
     - name: rhel-coreos-10
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
       rhel_version: "{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}"
       meta_type: commitmeta
     - name: rhel-coreos-10-extensions
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image-extensions
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image-extensions
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
       rhel_version: "{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}"
       meta_type: meta
   enabled_repos:


### PR DESCRIPTION
```
oc adm release info registry.ci.openshift.org/ocp/release-5:5.0.0-0.nightly-2026-08-30-014421 --pullspecs | grep rhel-coreos
  rhel-coreos                                    quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6957672d25604641911a3a1d8147031014773019686f6f459f87dff214d0362c
  rhel-coreos-10                                 quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c4009ebda18147160206becff0cdca69617b40c264da52689d24cf742aeeeb28
  rhel-coreos-10-extensions                      quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:469631d434a5489819367bbdca4a355d3b60062473deda60afde28eb6b1b42c4
  rhel-coreos-extensions                         quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:43d85fd7035142e221277bbf6f127c16df088bfe7edffd6d11c9aea0f9a93ab6
```

```
for digest in \
  sha256:6957672d25604641911a3a1d8147031014773019686f6f459f87dff214d0362c \
  sha256:c4009ebda18147160206becff0cdca69617b40c264da52689d24cf742aeeeb28 \
  sha256:469631d434a5489819367bbdca4a355d3b60062473deda60afde28eb6b1b42c4 \
  sha256:43d85fd7035142e221277bbf6f127c16df088bfe7edffd6d11c9aea0f9a93ab6; do
  echo -n "$digest → "
  skopeo inspect -n "docker://quay.io/openshift-release-dev/ocp-v5.0-art-dev@${digest}" >/dev/null 2>&1 \
    && echo "✅ exists" || echo "❌ NOT found"
done
sha256:6957672d25604641911a3a1d8147031014773019686f6f459f87dff214d0362c → ✅ exists
sha256:c4009ebda18147160206becff0cdca69617b40c264da52689d24cf742aeeeb28 → ✅ exists
sha256:469631d434a5489819367bbdca4a355d3b60062473deda60afde28eb6b1b42c4 → ✅ exists
sha256:43d85fd7035142e221277bbf6f127c16df088bfe7edffd6d11c9aea0f9a93ab6 → ✅ exists
```
