### PR TITLE
feat(baseimages): migrate vector, clo to ubi9-micro

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -19,7 +19,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-  member: base-rhel9
+  stream: ubi9-micro
 name: openshift-logging/cluster-logging-rhel9-operator
 owners:
 - jcantril@redhat.com

--- a/images/vector.yml
+++ b/images/vector.yml
@@ -27,7 +27,7 @@ enabled_repos:
 from:
   builder:
     - member: base-rhel9
-  member: base-rhel9
+  stream: ubi9-micro
 name: openshift-logging/vector-rhel9
 owners:
 - jcantril@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -9,4 +9,4 @@ rhel9:
   image: registry.redhat.io/ubi9-minimal@sha256:6c79f4fb38a20d496c859025d57e4074835e849d5d14819c4e021ad78446bce8
 
 rhel9-micro:
-  image: registry.redhat.io/ubi9/ubi-micro:9.7
+  image: registry.redhat.io/ubi9/ubi-micro:9.8


### PR DESCRIPTION
ref: LOG-9961, [LOG-9725](https://redhat.atlassian.net/browse/LOG-9725)

/hold

at @xperimental request

blocked by:
* https://github.com/openshift/cluster-logging-operator/pull/3446
* https://github.com/ViaQ/vector/pull/309