### PR TITLE
Logging 6.7: Import GPG key for CLO hermetic dnf --installroot

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -6,18 +6,10 @@ content:
         target: master
       url: git@github.com:openshift-priv/cluster-logging-operator.git
       web: https://github.com/openshift/cluster-logging-operator
-    # Temporary: rpm-lockfile-prototype treats spaced dnf option arguments as package
-    # names (--installroot /mnt/rootfs, --releasever 9). Remove when Dockerfile.art
-    # uses --flag=value form (openshift/cluster-logging-operator#3453).
-    # Import Red Hat GPG key into the empty installroot before dnf install; hermetic
-    # Hermeto repos have gpgcheck=1 and the staging rpmdb starts empty.
+    # Temporary: import Red Hat GPG key into the empty installroot before dnf install.
+    # Hermetic Hermeto repos have gpgcheck=1 but /mnt/rootfs starts with an empty rpmdb.
+    # Remove when Dockerfile.art imports the key upstream.
     modifications:
-    - action: replace
-      match: "--installroot /mnt/rootfs"
-      replacement: "--installroot=/mnt/rootfs"
-    - action: replace
-      match: "--releasever 9"
-      replacement: "--releasever=9"
     - action: replace
       match: "mkdir -p /mnt/rootfs && \\"
       replacement: "mkdir -p /mnt/rootfs && \\\n    rpm --root=/mnt/rootfs --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release && \\"

--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -8,9 +8,9 @@ content:
       web: https://github.com/openshift/cluster-logging-operator
     # Temporary: rpm-lockfile-prototype treats spaced dnf option arguments as package
     # names (--installroot /mnt/rootfs, --releasever 9). Remove when Dockerfile.art
-    # uses --flag=value form (openshift/cluster-logging-operator#3439).
-    # --nogpgcheck: hermetic Hermeto repos have gpgcheck=1 but --installroot has
-    # an empty rpmdb (no imported keys). Packages are already checksummed in the lockfile.
+    # uses --flag=value form (openshift/cluster-logging-operator#3453).
+    # Import Red Hat GPG key into the empty installroot before dnf install; hermetic
+    # Hermeto repos have gpgcheck=1 and the staging rpmdb starts empty.
     modifications:
     - action: replace
       match: "--installroot /mnt/rootfs"
@@ -19,8 +19,8 @@ content:
       match: "--releasever 9"
       replacement: "--releasever=9"
     - action: replace
-      match: "dnf install -y --installroot=/mnt/rootfs"
-      replacement: "dnf install -y --nogpgcheck --installroot=/mnt/rootfs"
+      match: "mkdir -p /mnt/rootfs && \\"
+      replacement: "mkdir -p /mnt/rootfs && \\\n    rpm --root=/mnt/rootfs --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release && \\"
 distgit:
   component: ose-cluster-logging-operator-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9

--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -9,6 +9,8 @@ content:
     # Temporary: rpm-lockfile-prototype treats spaced dnf option arguments as package
     # names (--installroot /mnt/rootfs, --releasever 9). Remove when Dockerfile.art
     # uses --flag=value form (openshift/cluster-logging-operator#3439).
+    # --nogpgcheck: hermetic Hermeto repos have gpgcheck=1 but --installroot has
+    # an empty rpmdb (no imported keys). Packages are already checksummed in the lockfile.
     modifications:
     - action: replace
       match: "--installroot /mnt/rootfs"
@@ -16,6 +18,9 @@ content:
     - action: replace
       match: "--releasever 9"
       replacement: "--releasever=9"
+    - action: replace
+      match: "dnf install -y --installroot=/mnt/rootfs"
+      replacement: "dnf install -y --nogpgcheck --installroot=/mnt/rootfs"
 distgit:
   component: ose-cluster-logging-operator-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9

--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -8,7 +8,6 @@ content:
       web: https://github.com/openshift/cluster-logging-operator
     # Temporary: import Red Hat GPG key into the empty installroot before dnf install.
     # Hermetic Hermeto repos have gpgcheck=1 but /mnt/rootfs starts with an empty rpmdb.
-    # Remove when Dockerfile.art imports the key upstream.
     modifications:
     - action: replace
       match: "mkdir -p /mnt/rootfs && \\"

--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -6,6 +6,16 @@ content:
         target: master
       url: git@github.com:openshift-priv/cluster-logging-operator.git
       web: https://github.com/openshift/cluster-logging-operator
+    # Temporary: rpm-lockfile-prototype treats spaced dnf option arguments as package
+    # names (--installroot /mnt/rootfs, --releasever 9). Remove when Dockerfile.art
+    # uses --flag=value form (openshift/cluster-logging-operator#3439).
+    modifications:
+    - action: replace
+      match: "--installroot /mnt/rootfs"
+      replacement: "--installroot=/mnt/rootfs"
+    - action: replace
+      match: "--releasever 9"
+      replacement: "--releasever=9"
 distgit:
   component: ose-cluster-logging-operator-container
   branch: rhaos-{MAJOR}.{MINOR}-rhel-9


### PR DESCRIPTION
## Summary
- [openshift/cluster-logging-operator#3453](https://github.com/openshift/cluster-logging-operator/pull/3453) merged: upstream `Dockerfile.art` now uses `--installroot=/mnt/rootfs` and `--releasever=9`, so the rpm-lockfile-prototype flag-form workarounds are removed from this PR.
- Keep a temporary `content.source.modifications` entry that imports the Red Hat release GPG key into the empty installroot before `dnf install`.
- Hermetic Hermeto repos have `gpgcheck=1` but `/mnt/rootfs` starts with an empty rpmdb, so Konflux fails with "no GPG public keys installed" after RPM prefetch succeeds.
- Uses `rpm --root=/mnt/rootfs --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release` from the golang builder image.

## Test plan
- [ ] Rebase `cluster-logging-operator` for logging-6.7 and confirm lockfile generation still succeeds (no `/mnt/rootfs` package-name misparsing).
- [ ] Confirm the rebased Dockerfile contains the `rpm --import` line before `dnf install`.
- [ ] Confirm hermetic `dnf --installroot` proceeds past GPG verification.
- [ ] Remove this modification once `Dockerfile.art` imports the GPG key upstream (rebase will fail the replace if the match string disappears).