### PR TITLE
Revert RHCOS repository change to ocp-v4.0-art-dev

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -103,24 +103,24 @@ cachito:
 rhcos:
   payload_tags:
     - name: rhel-coreos
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
       rhel_version: "{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}"
       meta_type: commitmeta
       primary: true
     - name: rhel-coreos-extensions
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image-extensions
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image-extensions
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}-node-image
       rhel_version: "{RHCOS_EL_MAJOR}.{RHCOS_EL_MINOR}"
       meta_type: meta
     - name: rhel-coreos-10
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
       rhel_version: "{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}"
       meta_type: commitmeta
     - name: rhel-coreos-10-extensions
-      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image-extensions
-      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v5.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
+      rhcos_index_tag: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image-extensions
+      rhel_build_id_index: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{MAJOR}.{MINOR}-{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}-node-image
       rhel_version: "{RHCOS_10_EL_MAJOR}.{RHCOS_10_EL_MINOR}"
       meta_type: meta
   enabled_repos:


### PR DESCRIPTION
Reverts PR #12604, which changed the openshift-5.0 RHCOS index configuration from ocp-v4.0-art-dev to ocp-v5.0-art-dev. The v5 RHCOS index tags are not available, causing ocp4-scan-konflux to fail with manifest unknown while resolving the latest RHCOS source. Restore the v4 repository until v5 RHCOS images are available.