### PR TITLE
Build goose from source and onboard agent-sandbox and skills

### DIFF
--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -13,6 +13,8 @@ cachito:
           packages: ":all:"
           arch: "x86_64,aarch64"
           py_version: 311
+    cargo:
+      - path: images/agent-base/goose/
 content:
   source:
     dockerfile: images/agent-base/Containerfile
@@ -23,11 +25,44 @@ content:
       web: https://github.com/migtools/mta-agentic-controller
     modifications:
       - action: replace
-        match: 'curl -fsSL "https://github.com/block/goose/releases/download/${GOOSE_VERSION}/goose-${GOOSE_ARCH}.tar.bz2" -o /tmp/goose.tar.bz2'
-        replacement: "cp /cachi2/output/deps/generic/goose-${GOOSE_ARCH}.tar.bz2 /tmp/goose.tar.bz2"
+        match: "RUN go mod download"
+        replacement: "# go mod download removed - deps pre-fetched by cachi2"
+      - action: replace
+        match: |-
+          RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+              && apt-get update && apt-get install -y \
+                  build-essential \
+                  git \
+                  cmake \
+                  pkg-config \
+                  libssl-dev \
+                  libclang-dev \
+                  clang \
+                  libdbus-1-dev \
+                  libxcb1-dev \
+                  perl \
+              && rm -rf /var/lib/apt/lists/*
+        replacement: |-
+          RUN dnf install -y \
+              gcc gcc-c++ git cmake pkgconfig openssl-devel clang clang-devel dbus-devel libxcb-devel perl \
+              rust cargo \
+              && dnf clean all
+      - action: replace
+        match: 'ENV PATH="/root/.cargo/bin:${PATH}"'
+        replacement: "# cargo from rpm is already on PATH"
+      - action: replace
+        match: |-
+          RUN git clone https://github.com/aaif-goose/goose.git . \
+              && git checkout ${GOOSE_VERSION} \
+        replacement: |-
+          RUN tar -xzf /cachi2/output/deps/generic/goose-v1.45.0.tar.gz --strip-components=1 \
+      - action: replace
+        match: '&& cargo build --release -p goose-cli --bin goose \'
+        replacement: '&& rm -f .cargo/config.toml && cargo build --release -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - pip
+    - cargo
 jira:
   project: MTA
   component: Analysis
@@ -39,6 +74,7 @@ delivery:
 enabled_repos:
 - rhel-98-appstream-rpms
 - rhel-98-baseos-rpms
+- rhel-98-codeready-builder-rpms
 from:
   builder:
     - stream: rhel-9-golang
@@ -51,10 +87,22 @@ dependents:
   - mta-operator
 konflux:
   cachi2:
+    lockfile:
+      rpms:
+        - cargo
+        - clang
+        - clang-devel
+        - cmake
+        - dbus-devel
+        - gcc
+        - gcc-c++
+        - git
+        - libxcb-devel
+        - openssl-devel
+        - perl
+        - rust
     artifact_lockfile:
       enabled: true
       resources:
-        - url: https://github.com/block/goose/releases/download/v1.45.0/goose-x86_64-unknown-linux-gnu.tar.bz2
-          filename: goose-x86_64-unknown-linux-gnu.tar.bz2
-        - url: https://github.com/block/goose/releases/download/v1.45.0/goose-aarch64-unknown-linux-gnu.tar.bz2
-          filename: goose-aarch64-unknown-linux-gnu.tar.bz2
+        - url: https://github.com/aaif-goose/goose/archive/refs/tags/v1.45.0.tar.gz
+          filename: goose-v1.45.0.tar.gz

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -43,9 +43,12 @@ content:
                   perl \
               && rm -rf /var/lib/apt/lists/*
         replacement: |-
+          # rust-toolset (AppStream) provides Rust 1.92.0 on RHEL 9.8, which is the
+          # highest available via RPM. goose declares rust-version = "1.94.1" but we
+          # override the MSRV gate with --ignore-rust-version (see cargo build step below).
           RUN dnf install -y \
               gcc gcc-c++ git cmake pkgconfig openssl-devel clang clang-devel dbus-devel libxcb-devel perl \
-              rust cargo \
+              rust-toolset \
               && dnf clean all
       - action: replace
         match: 'ENV PATH="/root/.cargo/bin:${PATH}"'
@@ -58,7 +61,13 @@ content:
           RUN tar -xzf /cachi2/output/deps/generic/goose-v1.45.0.tar.gz --strip-components=1 \
       - action: replace
         match: '&& cargo build --release -p goose-cli --bin goose \'
-        replacement: '&& rm -f .cargo/config.toml && cargo build --release -p goose-cli --bin goose \'
+        # --ignore-rust-version bypasses the MSRV gate (goose declares rust-version = "1.94.1"
+        # but RHEL 9.8 tops out at 1.92.0 via rust-toolset). The build will still fail if goose
+        # actually uses a language feature introduced after 1.92.0, which surfaces a clear error.
+        # rm -f .cargo/config.toml removes any config shipped by the goose source tarball that
+        # would conflict with cachi2's offline vendor settings (cachi2 injects its own config
+        # via CARGO_HOME rather than the source tree).
+        replacement: '&& rm -f .cargo/config.toml && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - pip
@@ -89,7 +98,9 @@ konflux:
   cachi2:
     lockfile:
       rpms:
-        - cargo
+        # rust-toolset (AppStream) is used instead of the plain rust/cargo CRB packages
+        # because it ships Rust 1.92.0 on RHEL 9.8, versus ~1.75.x from CRB.
+        - rust-toolset
         - clang
         - clang-devel
         - cmake
@@ -100,7 +111,6 @@ konflux:
         - libxcb-devel
         - openssl-devel
         - perl
-        - rust
     artifact_lockfile:
       enabled: true
       resources:

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -14,7 +14,7 @@ cachito:
           arch: "x86_64,aarch64"
           py_version: 311
     cargo:
-      - path: images/agent-base/goose/
+      - path: images/agent-base/goose-src/
 content:
   source:
     dockerfile: images/agent-base/Containerfile
@@ -30,17 +30,7 @@ content:
       - action: replace
         match: |-
           RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-              && apt-get update && apt-get install -y \
-                  build-essential \
-                  git \
-                  cmake \
-                  pkg-config \
-                  libssl-dev \
-                  libclang-dev \
-                  clang \
-                  libdbus-1-dev \
-                  libxcb1-dev \
-                  perl \
+              && apt-get update && apt-get install -y build-essential git cmake pkg-config libssl-dev libclang-dev clang libdbus-1-dev libxcb1-dev perl \
               && rm -rf /var/lib/apt/lists/*
         replacement: |-
           # rust-toolset (AppStream) provides Rust 1.92.0 on RHEL 9.8, which is the
@@ -53,12 +43,6 @@ content:
       - action: replace
         match: 'ENV PATH="/root/.cargo/bin:${PATH}"'
         replacement: "# cargo from rpm is already on PATH"
-      - action: replace
-        match: |-
-          RUN git clone https://github.com/aaif-goose/goose.git . \
-              && git checkout ${GOOSE_VERSION} \
-        replacement: |-
-          RUN tar -xzf /cachi2/output/deps/generic/goose-v1.45.0.tar.gz --strip-components=1 \
       - action: replace
         match: '&& cargo build --release -p goose-cli --bin goose \'
         # --ignore-rust-version bypasses the MSRV gate (goose declares rust-version = "1.94.1"
@@ -111,8 +95,3 @@ konflux:
         - libxcb-devel
         - openssl-devel
         - perl
-    artifact_lockfile:
-      enabled: true
-      resources:
-        - url: https://github.com/aaif-goose/goose/archive/refs/tags/v1.45.0.tar.gz
-          filename: goose-v1.45.0.tar.gz

--- a/images/mta-agent-sandbox.yml
+++ b/images/mta-agent-sandbox.yml
@@ -1,0 +1,40 @@
+base_image_release:
+  force: true
+cachito:
+  packages:
+    gomod:
+      - path: .
+content:
+  source:
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: release-0.5
+      url: git@github.com:openshift-priv/migtools-agent-sandbox.git
+      web: https://github.com/migtools/agent-sandbox
+    modifications:
+      - action: replace
+        match: "RUN go mod download"
+        replacement: "# go mod download removed - deps pre-fetched by cachi2"
+    pkg_managers:
+    - gomod
+jira:
+  project: MTA
+  component: Analysis
+distgit:
+  component: mta-agent-sandbox-container
+delivery:
+  delivery_repo_names:
+  - mta/mta-agent-sandbox-rhel9
+enabled_repos:
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  stream: rhel9
+name: mta/mta-agent-sandbox-rhel9
+owners:
+- mta-devs@redhat.com
+dependents:
+  - mta-operator

--- a/images/mta-agent-skills.yml
+++ b/images/mta-agent-skills.yml
@@ -1,0 +1,26 @@
+base_image_release:
+  force: true
+content:
+  source:
+    dockerfile: catalog/Containerfile
+    git:
+      branch:
+        target: main
+      url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
+      web: https://github.com/migtools/mta-agentic-controller
+jira:
+  project: MTA
+  component: Analysis
+distgit:
+  component: mta-agent-skills-container
+delivery:
+  delivery_repo_names:
+  - mta/mta-agent-skills-rhel9
+enabled_repos:
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
+name: mta/mta-agent-skills-rhel9
+owners:
+- mta-devs@redhat.com
+dependents:
+  - mta-operator


### PR DESCRIPTION
**Rust MSRV vs RHEL 9.8 CRB package.**
`images/agent-base/goose/Cargo.toml` in mta-agentic-controller declares rust-version = "1.94.1". The build installs rust and cargo from rhel-98-codeready-builder-rpms. RHEL 9.8 CRB ships Rust well behind that MSRV — cargo hard-fails when the installed toolchain is older than the declared minimum. This will break the hermetic build until either the MSRV is overridden or a newer Rust RPM is available.

The fix consists in using rust-toolset from AppStream distribution instead of plain rust/cargo CRB packages to use a newer rust version.

**Onboard agent sandbox**
Include new component agent-sandbox needed for the new agentic-controller. Forked in https://github.com/migtools/mta-agentic-controller. I have created a new branch `release-0.5` in the fork out of tag `v0.5.0`, to keep with the usage of branches instead of tags.

**Onboard skills image**
Also onboarding the skills component