### PR TITLE
Kube compare golang bump 4.21

### DIFF
--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -21,7 +21,7 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-8-golang
+  - stream: rhel-8-golang-{GO_EXTRA}
   - stream: rhel-9-golang
   member: openshift-enterprise-cli
 name: openshift/kube-compare-artifacts-rhel9

--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -22,7 +22,7 @@ for_payload: false
 from:
   builder:
   - stream: rhel-8-golang-{GO_EXTRA}
-  - stream: rhel-9-golang
+  - stream: rhel-9-golang-{GO_EXTRA}
   member: openshift-enterprise-cli
 name: openshift/kube-compare-artifacts-rhel9
 payload_name: kube-compare-artifacts

--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -21,8 +21,8 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-8-golang-{GO_EXTRA}
-  - stream: rhel-9-golang-{GO_EXTRA}
+  - stream: rhel-8-golang-1.25
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-cli
 name: openshift/kube-compare-artifacts-rhel9
 payload_name: kube-compare-artifacts


### PR DESCRIPTION
Use golang 1.25 golang builder (`GO_EXTRA` stream builder) due to build error in `kube-compare-artifacts` component - golang version 1.25+ is required.