### PR TITLE
Kube compare golang bump 4.20

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -24,7 +24,7 @@ vars:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
   GO_LATEST: "1.24"
-  GO_EXTRA: "1.24"  # There is no extra version at this time, so just duplicate latest.
+  GO_EXTRA: "1.25"  # There is no extra version at this time, so just duplicate latest.
 
 compliance:
   rpm_shim:

--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -21,8 +21,8 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-8-golang
-  - stream: rhel-9-golang
+  - stream: rhel-8-golang-{GO_EXTRA}
+  - stream: rhel-9-golang-{GO_EXTRA}
   member: openshift-enterprise-cli
 name: openshift/kube-compare-artifacts-rhel9
 payload_name: kube-compare-artifacts

--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -21,8 +21,8 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-8-golang-{GO_EXTRA}
-  - stream: rhel-9-golang-{GO_EXTRA}
+  - stream: rhel-8-golang-1.25
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-cli
 name: openshift/kube-compare-artifacts-rhel9
 payload_name: kube-compare-artifacts

--- a/streams.yml
+++ b/streams.yml
@@ -38,7 +38,7 @@ rhel-8-golang:
 rhel-9-golang-1.25:
   aliases:
     - rhel-9-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.11-202607210212.p2.g6245b3b.el9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.12-202608271548.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
@@ -47,7 +47,7 @@ rhel-9-golang-1.25:
 rhel-8-golang-1.25:
   aliases:
     - rhel-8-golang-{GO_EXTRA}
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.11-202607131221.p2.g3c0977b.el8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.11-202608271541.p2.gedd1cdd.assembly.stream.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.

--- a/streams.yml
+++ b/streams.yml
@@ -35,6 +35,25 @@ rhel-8-golang:
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
 
+rhel-9-golang-1.25:
+  aliases:
+    - rhel-9-golang-{GO_EXTRA}
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.11-202607210212.p2.g6245b3b.el9
+  mirror: false
+  # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
+  # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
+rhel-8-golang-1.25:
+  aliases:
+    - rhel-8-golang-{GO_EXTRA}
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.11-202607131221.p2.g3c0977b.el8
+  mirror: false
+  # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
+  # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
+
 partner-rhel-8-golang-1.24:
   image: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:golang-builder-v1.24.13-202604221752.p2.gcb9763d.el8
   mirror: true


### PR DESCRIPTION
- Update `GO_EXTRA` to 1.25, and add the builders to `streams.yml` for `rhel8` and `rhel9` 
- Use golang 1.25 golang builder (GO_EXTRA stream builder) due to build error in kube-compare-artifacts component - golang version 1.25+ is required.