### PR TITLE
Kube compare golang bump 4.19

### DIFF
--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -21,7 +21,7 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-8-golang
+  - stream: rhel-8-golang-{GO_EXTRA}
   - stream: rhel-9-golang
   member: openshift-enterprise-cli
 name: openshift/kube-compare-artifacts-rhel9

--- a/images/kube-compare-artifacts.yml
+++ b/images/kube-compare-artifacts.yml
@@ -21,8 +21,8 @@ delivery:
 for_payload: false
 from:
   builder:
-  - stream: rhel-8-golang-{GO_EXTRA}
-  - stream: rhel-9-golang
+  - stream: rhel-8-golang-1.25
+  - stream: rhel-9-golang-1.25
   member: openshift-enterprise-cli
 name: openshift/kube-compare-artifacts-rhel9
 payload_name: kube-compare-artifacts

--- a/streams.yml
+++ b/streams.yml
@@ -53,6 +53,21 @@ rhel-8-golang-1.24:
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
+rhel-9-golang-1.25:
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.11-202607210212.p2.g6245b3b.el9
+  mirror: false
+  # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
+  # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
+rhel-8-golang-1.25:
+  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.11-202607131221.p2.g3c0977b.el8
+  mirror: false
+  # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
+  # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+
+
 partner-rhel-8-golang-1.23:
   image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.23.10-202608071452.p2.g9e54c20.el8
   mirror: true

--- a/streams.yml
+++ b/streams.yml
@@ -54,14 +54,14 @@ rhel-8-golang-1.24:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang-1.25:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.11-202607210212.p2.g6245b3b.el9
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.12-202608271548.p2.gedd1cdd.assembly.stream.el9
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
 
 rhel-8-golang-1.25:
-  image: registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.25.11-202607131221.p2.g3c0977b.el8
+  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.11-202608271541.p2.gedd1cdd.assembly.stream.el8
   mirror: false
   # Since mirror: false, an images/ci-openshift-golang-builder* metadata must push to this location.
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.


### PR DESCRIPTION
- Add `rhel-{8,9}-golang-1.25` to `streams.yml`
- Use golang 1.25 golang builderdue to build error in kube-compare-artifacts component - golang version 1.25+ is required.