### PR TITLE
logging-6.6: Convert ubi9 base images to floating tags

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -6,7 +6,7 @@ rhel-9-golang:
 
 rhel9:
   # To match OCP: https://github.com/openshift-eng/ocp-build-data/blob/7a86cf1525b49c3156e54884454a3a5964d6b832/releases.yml#L163
-  image: registry.redhat.io/ubi9-minimal@sha256:6c79f4fb38a20d496c859025d57e4074835e849d5d14819c4e021ad78446bce8
+  image: registry.redhat.io/ubi9-minimal:9.8
 
 rhel9-micro:
-  image: registry.redhat.io/ubi9/ubi-micro:9.7
+  image: registry.redhat.io/ubi9/ubi-micro:9.8


### PR DESCRIPTION
I have seen this change happening for the builder image ... and I think we can do the same thing for the ubi9 base-image as well...

I noticed that the `ubi9/ubi-minimal` and `ubi9-minimal` repositories contain the same image (same for `...-micro`) ... don't know which one is preferred, so I kept the mix for now. We should switch both to the same variant at some point.

Refs [LOG-9965](https://redhat.atlassian.net/browse/LOG-9965)

/cc @ashwindasr @rayfordj 
/label tide/merge-method-squash
