### PR TITLE
ART-23257: Add two new approvers and simplify to single group (logging-6.5)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -38,14 +38,6 @@ arches:
 
 operator_image_ref_mode: manifest-list
 
-mr_approvers:
-  QE:
-    - kbharti
-    - rojacob
-  DOCS:
-    - kbharti
-    - rojacob
-
 konflux:
   arches:
   - x86_64
@@ -67,6 +59,13 @@ konflux:
 
 assemblies:
   enabled: true
+
+mr_approvers:
+  QE:
+    - cahartma
+    - kbharti
+    - rojacob
+    - vparfono
 
 public_upstreams:
 - private: "https://github.com/openshift-priv"


### PR DESCRIPTION
/label tide/merge-method-squash