### PR TITLE
ART-23257: Add two new approvers and simplify to single group (logging-6.4)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -62,11 +62,10 @@ assemblies:
 
 mr_approvers:
   QE:
+    - cahartma
     - kbharti
     - rojacob
-  DOCS:
-    - kbharti
-    - rojacob
+    - vparfono
 
 public_upstreams:
 - private: "https://github.com/openshift-priv"


### PR DESCRIPTION
/label tide/merge-method-squash