### PR TITLE
Update OCP target versions in MTA-8.3 group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -47,16 +47,10 @@ konflux:
 
 # OCP versions to publish FBC builds to
 OCP_TARGET_VERSIONS: [
-  "4.12",
-  "4.13",
-  "4.14",
-  "4.15",
-  "4.16",
-  "4.17",
-  "4.18",
   "4.19",
   "4.20",
   "4.21",
+  "4.22",
 ]
 
 assemblies:


### PR DESCRIPTION
Removed older OCP target versions from the list.