### PR TITLE
MCE 5.0 to ART: hypershift-cli: add rhel9 builder for PQC crypto-policy stage

### DIFF
--- a/images/hypershift-cli.yml
+++ b/images/hypershift-cli.yml
@@ -17,6 +17,7 @@ dependents:
 from:
   builder:
     - stream: rhel-9-golang
+    - stream: rhel9
   member: base-rhel9
 name: multicluster-engine/hypershift-cli-rhel9
 owners:


### PR DESCRIPTION
The release-5.0 Containerfile.cli added a new PQC crypto-policy build stage (FROM ubi-minimal-pqc AS policy), increasing the parent image count from 2 to 3. Update the build metadata to match.

This is the same pattern as the earlier console fix (rhel9-ubi stream).