### PR TITLE
ART-23116: Update rhcos iso version for machine-os-images 4.18

### DIFF
--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -44,11 +44,11 @@ konflux:
       # These are the same URLs that openshift-install coreos print-stream-json outputs.
       # Whenever it changes, update these URLs to match .architectures.{arch}.artifacts.metal.formats.iso.disk.location
       resources:
-      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/x86_64/rhcos-418.94.202602022246-0-live.x86_64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202608142238-0/x86_64/rhcos-418.94.202608142238-0-live.x86_64.iso
         filename: coreos-x86_64.iso
-      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/aarch64/rhcos-418.94.202602022246-0-live.aarch64.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202608142238-0/aarch64/rhcos-418.94.202608142238-0-live.aarch64.iso
         filename: coreos-aarch64.iso
-      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/ppc64le/rhcos-418.94.202602022246-0-live.ppc64le.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202608142238-0/ppc64le/rhcos-418.94.202608142238-0-live.ppc64le.iso
         filename: coreos-ppc64le.iso
-      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202602022246-0/s390x/rhcos-418.94.202602022246-0-live.s390x.iso
+      - url: https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.18-9.4/builds/418.94.202608142238-0/s390x/rhcos-418.94.202608142238-0-live.s390x.iso
         filename: coreos-s390x.iso


### PR DESCRIPTION
Bump rhcos iso version for machine-os-images


rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED