### PR TITLE
[OKD] Add okd: stanzas to all for_payload images

### DIFF
--- a/images/agent-installer-ui.yml
+++ b/images/agent-installer-ui.yml
@@ -49,3 +49,7 @@ konflux:
     mode: emulation
   vm_override:
     x86_64: linux-d160-c4xlarge/amd64
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/agentic-skills.yml
+++ b/images/agentic-skills.yml
@@ -19,3 +19,7 @@ name: openshift/agentic-skills
 payload_name: agentic-skills
 owners:
 - mpatel@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -34,3 +34,7 @@ name: openshift/ose-cluster-autoscaler-rhel9
 payload_name: cluster-autoscaler
 owners:
 - avagarwa@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/aws-karpenter-provider-aws.yml
+++ b/images/aws-karpenter-provider-aws.yml
@@ -28,3 +28,7 @@ from:
 name: openshift/aws-karpenter-provider-aws-rhel9
 owners:
 - openshift-autoscaling@redhat.com@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/aws-kms-encryption-provider.yml
+++ b/images/aws-kms-encryption-provider.yml
@@ -32,3 +32,7 @@ owners:
 - agarcial@redhat.com
 - mraee@redhat.com
 - brcox@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/aws-node-termination-handler.yml
+++ b/images/aws-node-termination-handler.yml
@@ -26,3 +26,7 @@ name: openshift/aws-node-termination-handler-rhel9
 owners:
 - hypershift-team@redhat.com@redhat.com
 payload_name: aws-node-termination-handler
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/azure-file-csi-driver-operator.yml
+++ b/images/azure-file-csi-driver-operator.yml
@@ -36,3 +36,7 @@ name: openshift/ose-azure-file-csi-driver-operator-rhel9
 payload_name: azure-file-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/azure-file-csi-driver.yml
+++ b/images/azure-file-csi-driver.yml
@@ -48,3 +48,7 @@ konflux:
       - device-mapper-libs
       - glibc-gconv-extra
       - samba-client-libs
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/azure-kms-encryption-provider.yml
+++ b/images/azure-kms-encryption-provider.yml
@@ -32,3 +32,7 @@ owners:
 - agarcial@redhat.com
 - mraee@redhat.com
 - brcox@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -31,3 +31,7 @@ name: openshift/ose-baremetal-machine-controllers-rhel9
 payload_name: baremetal-machine-controllers
 owners:
 - metal-platform@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -34,3 +34,7 @@ name: openshift/ose-baremetal-runtimecfg-rhel9
 payload_name: baremetal-runtimecfg
 owners:
 - asegurap@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/cluster-etcd-operator.yml
+++ b/images/cluster-etcd-operator.yml
@@ -31,3 +31,7 @@ name: openshift/ose-cluster-etcd-rhel9-operator
 payload_name: cluster-etcd-operator
 owners:
 - sbatsche@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/cluster-monitoring-operator.yml
+++ b/images/cluster-monitoring-operator.yml
@@ -41,3 +41,7 @@ name: openshift/ose-cluster-monitoring-rhel9-operator
 payload_name: cluster-monitoring-operator
 owners:
 - team-monitoring@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-network-rhel9-operator
 payload_name: cluster-network-operator
 owners:
 - aos-networking-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -35,3 +35,7 @@ name: openshift/ose-cluster-node-tuning-rhel9-operator
 payload_name: cluster-node-tuning-operator
 owners:
 - openshift-psap@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/cluster-policy-controller.yml
+++ b/images/cluster-policy-controller.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-policy-controller-rhel9
 payload_name: cluster-policy-controller
 owners:
 - mfojtik@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/cluster-storage-operator.yml
+++ b/images/cluster-storage-operator.yml
@@ -31,3 +31,7 @@ name: openshift/ose-cluster-storage-rhel9-operator
 payload_name: cluster-storage-operator
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/cluster-update-console-plugin.yml
+++ b/images/cluster-update-console-plugin.yml
@@ -41,3 +41,7 @@ konflux:
     lockfile:
       modules:
       - nginx:1.26
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -35,3 +35,7 @@ name: openshift/ose-cluster-version-rhel9-operator
 payload_name: cluster-version-operator
 owners:
 - aos-team-ota@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/configmap-reload.yml
+++ b/images/configmap-reload.yml
@@ -41,3 +41,7 @@ name: openshift/ose-configmap-reloader-rhel9
 payload_name: configmap-reloader
 owners:
 - team-monitoring@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/container-networking-plugins-microshift.yml
+++ b/images/container-networking-plugins-microshift.yml
@@ -41,3 +41,7 @@ owners:
 - tohayash@redhat.com
 - dosmith@redhat.com
 - microshift-devel@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/coredns.yml
+++ b/images/coredns.yml
@@ -27,3 +27,7 @@ name: openshift/ose-coredns-rhel9
 payload_name: coredns
 owners:
 - aos-network-edge@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -38,3 +38,7 @@ name: openshift/ose-csi-external-attacher-rhel9
 payload_name: csi-external-attacher
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -35,3 +35,7 @@ name: openshift/ose-csi-driver-manila-rhel9-operator
 payload_name: csi-driver-manila-operator
 owners:
 - osasinfra-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -31,3 +31,7 @@ name: openshift/ose-csi-driver-manila-rhel9
 payload_name: csi-driver-manila
 owners:
 - osasinfra-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -41,3 +41,7 @@ konflux:
     lockfile:
       rpms:
       - keyutils
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/csi-external-snapshot-metadata.yml
+++ b/images/csi-external-snapshot-metadata.yml
@@ -34,3 +34,7 @@ payload_name: csi-external-snapshot-metadata
 name_in_bundle: csi-external-snapshot-metadata
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -44,3 +44,7 @@ name_in_bundle: csi-livenessprobe
 payload_name: csi-livenessprobe
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/csi-node-driver-registrar.yml
+++ b/images/csi-node-driver-registrar.yml
@@ -39,3 +39,7 @@ name_in_bundle: csi-node-driver-registrar
 payload_name: csi-node-driver-registrar
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -43,3 +43,7 @@ payload_name: csi-external-provisioner
 name_in_bundle: csi-external-provisioner
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/gcp-workload-identity-federation-webhook.yml
+++ b/images/gcp-workload-identity-federation-webhook.yml
@@ -27,3 +27,7 @@ name: openshift/ose-gcp-workload-identity-federation-webhook-rhel9
 payload_name: gcp-workload-identity-federation-webhook
 owners:
 - jstuever@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/golang-github-openshift-oauth-proxy.yml
+++ b/images/golang-github-openshift-oauth-proxy.yml
@@ -31,3 +31,7 @@ name: openshift/ose-oauth-proxy-rhel9
 payload_name: oauth-proxy
 owners:
 - aos-apiserver@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -49,3 +49,6 @@ konflux:
     lockfile:
       rpms:
       - openshift-prometheus-promu
+okd:
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -49,3 +49,6 @@ konflux:
     lockfile:
       rpms:
       - openshift-prometheus-promu
+okd:
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -49,3 +49,6 @@ konflux:
     lockfile:
       rpms:
       - openshift-prometheus-promu
+okd:
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -27,3 +27,7 @@ name: openshift/ose-hypershift-rhel9
 payload_name: hypershift
 owners:
 - hypershift-team@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -40,3 +40,6 @@ konflux:
       rpms:
       - edk2-aarch64
       - edk2-ovmf
+okd:
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -27,3 +27,7 @@ name: openshift/ose-ironic-static-ip-manager-rhel9
 payload_name: ironic-static-ip-manager
 owners:
 - ironic-osp-owners@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/karpenter-operator.yml
+++ b/images/karpenter-operator.yml
@@ -34,3 +34,7 @@ mr_approvers:
   QE:
     - jkyros
     - macao
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -30,3 +30,7 @@ name: openshift/ose-kube-proxy-rhel9
 payload_name: kube-proxy
 owners:
 - aos-networking-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -45,3 +45,7 @@ name_in_bundle: kube-rbac-proxy
 payload_name: kube-rbac-proxy
 owners:
 - aos-apiserver@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/kube-state-metrics.yml
+++ b/images/kube-state-metrics.yml
@@ -41,3 +41,7 @@ name: openshift/ose-kube-state-metrics-rhel9
 payload_name: kube-state-metrics
 owners:
 - team-monitoring@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/marketplace-operator.yml
+++ b/images/marketplace-operator.yml
@@ -29,3 +29,7 @@ name: openshift/ose-operator-marketplace-rhel9
 payload_name: operator-marketplace
 owners:
 - aos-marketplace@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/multus-cni-container-microshift.yml
+++ b/images/multus-cni-container-microshift.yml
@@ -41,3 +41,7 @@ owners:
 - tohayash@redhat.com
 - dosmith@redhat.com
 - microshift-devel@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -37,3 +37,7 @@ name: openshift/ose-multus-cni-rhel9
 payload_name: multus-cni
 owners:
 - multus-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/multus-networkpolicy.yml
+++ b/images/multus-networkpolicy.yml
@@ -34,3 +34,7 @@ name: openshift/ose-multus-networkpolicy-rhel9
 payload_name: multus-networkpolicy
 owners:
 - multus-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/oauth-server.yml
+++ b/images/oauth-server.yml
@@ -29,3 +29,7 @@ name: openshift/ose-oauth-server-rhel9
 payload_name: oauth-server
 owners:
 - mfojtik@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -36,3 +36,6 @@ name: openshift/ose-docker-builder-rhel9
 payload_name: docker-builder
 owners:
 - openshift-build-api@redhat.com
+okd:
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -37,3 +37,7 @@ name: openshift/ose-cli-rhel9
 payload_name: cli
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openshift-enterprise-console-operator.yml
+++ b/images/openshift-enterprise-console-operator.yml
@@ -29,3 +29,7 @@ owners:
 - bpeterse@redhat.com
 - spadgett@redhat.com
 - jforrest@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -28,3 +28,7 @@ name: openshift/ose-deployer-rhel9
 payload_name: deployer
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -42,3 +42,7 @@ name: openshift/ose-hyperkube-rhel9
 payload_name: hyperkube
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -31,3 +31,7 @@ name: openshift/ose-keepalived-ipfailover-rhel9
 payload_name: keepalived-ipfailover
 owners:
 - aos-network-edge@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -39,3 +39,7 @@ name: openshift/ose-pod-rhel9
 payload_name: pod
 owners:
 - aos-pod@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openshift-enterprise-registry.yml
+++ b/images/openshift-enterprise-registry.yml
@@ -35,3 +35,7 @@ name: openshift/ose-docker-registry-rhel9
 payload_name: docker-registry
 owners:
 - openshift-image-registry@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -45,3 +45,7 @@ payload_name: tests
 owners:
 - aos-master@redhat.com
 - openshift-technical-release-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openshift-state-metrics.yml
+++ b/images/openshift-state-metrics.yml
@@ -36,3 +36,7 @@ name: openshift/ose-openshift-state-metrics-rhel9
 payload_name: openshift-state-metrics
 owners:
 - team-monitoring@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openstack-cluster-api-controllers.yml
+++ b/images/openstack-cluster-api-controllers.yml
@@ -27,3 +27,7 @@ name: openshift/ose-openstack-cluster-api-controllers-rhel9
 payload_name: openstack-cluster-api-controllers
 owners:
 - osasinfra-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/openstack-resource-controller.yml
+++ b/images/openstack-resource-controller.yml
@@ -27,3 +27,7 @@ name: openshift/openstack-resource-controller-rhel9
 payload_name: openstack-resource-controller
 owners:
 - osasinfra-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -31,3 +31,7 @@ name: openshift/ose-operator-lifecycle-manager-rhel9
 payload_name: operator-lifecycle-manager
 owners:
 - aos-odin@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -27,3 +27,7 @@ name: openshift/ose-operator-registry-rhel9
 payload_name: operator-registry
 owners:
 - aos-odin@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-agent-installer-orchestrator.yml
+++ b/images/ose-agent-installer-orchestrator.yml
@@ -30,3 +30,7 @@ name: openshift/ose-agent-installer-orchestrator-rhel9
 payload_name: agent-installer-orchestrator
 owners:
 - ocp-agent-team@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-apiserver-network-proxy.yml
+++ b/images/ose-apiserver-network-proxy.yml
@@ -28,3 +28,7 @@ name: openshift/ose-apiserver-network-proxy-rhel9
 payload_name: apiserver-network-proxy
 owners:
 - hypershift-team@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-aws-cloud-controller-manager.yml
+++ b/images/ose-aws-cloud-controller-manager.yml
@@ -46,3 +46,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -40,3 +40,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -35,3 +35,7 @@ name: openshift/ose-aws-ebs-csi-driver-rhel9-operator
 payload_name: aws-ebs-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -39,3 +39,7 @@ name: openshift/ose-aws-ebs-csi-driver-rhel9
 payload_name: aws-ebs-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-aws-pod-identity-webhook.yml
+++ b/images/ose-aws-pod-identity-webhook.yml
@@ -30,3 +30,7 @@ name: openshift/ose-aws-pod-identity-webhook-rhel9
 payload_name: aws-pod-identity-webhook
 owners:
 - sjenning@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-azure-cloud-controller-manager.yml
+++ b/images/ose-azure-cloud-controller-manager.yml
@@ -46,3 +46,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-azure-cloud-node-manager.yml
+++ b/images/ose-azure-cloud-node-manager.yml
@@ -46,3 +46,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -40,3 +40,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-azure-disk-csi-driver-operator.yml
+++ b/images/ose-azure-disk-csi-driver-operator.yml
@@ -35,3 +35,7 @@ name: openshift/ose-azure-disk-csi-driver-rhel9-operator
 payload_name: azure-disk-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-azure-disk-csi-driver.yml
+++ b/images/ose-azure-disk-csi-driver.yml
@@ -39,3 +39,7 @@ name: openshift/ose-azure-disk-csi-driver-rhel9
 payload_name: azure-disk-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-azure-service-operator.yml
+++ b/images/ose-azure-service-operator.yml
@@ -37,3 +37,7 @@ owners:
 - ddonati@redhat.com
 - nbrubake@redhat.com
 - yanyang@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-azure-workload-identity-webhook.yml
+++ b/images/ose-azure-workload-identity-webhook.yml
@@ -30,3 +30,7 @@ name: openshift/ose-azure-workload-identity-webhook-rhel9
 payload_name: azure-workload-identity-webhook
 owners:
 - aos-hive@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-baremetal-cluster-api-controllers.yml
+++ b/images/ose-baremetal-cluster-api-controllers.yml
@@ -30,3 +30,7 @@ name: openshift/ose-baremetal-cluster-api-controllers-rhel9
 payload_name: baremetal-cluster-api-controllers
 owners:
 - metal-platform@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-baremetal-operator.yml
+++ b/images/ose-baremetal-operator.yml
@@ -28,3 +28,7 @@ name: openshift/ose-baremetal-rhel9-operator
 payload_name: baremetal-operator
 owners:
 - metal-platform@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -35,3 +35,7 @@ konflux:
   vm_override:
     x86_64: linux-d160-c4xlarge/amd64
     aarch64: linux-d160-c4xlarge/arm64
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cloud-credential-operator.yml
+++ b/images/ose-cloud-credential-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cloud-credential-rhel9-operator
 payload_name: cloud-credential-operator
 owners:
 - aos-hive@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cloud-network-config-controller.yml
+++ b/images/ose-cloud-network-config-controller.yml
@@ -27,3 +27,7 @@ name: openshift/cloud-network-config-controller-rhel9
 payload_name: cloud-network-config-controller
 owners:
 - aos-networking-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -34,3 +34,7 @@ name: openshift/ose-cluster-api-rhel9
 payload_name: cluster-capi-controllers
 owners:
 - aos-cloud@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-authentication-operator.yml
+++ b/images/ose-cluster-authentication-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-authentication-rhel9-operator
 payload_name: cluster-authentication-operator
 owners:
 - aos-apiserver@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-autoscaler-operator.yml
+++ b/images/ose-cluster-autoscaler-operator.yml
@@ -29,3 +29,7 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-baremetal-operator-rhel9
 payload_name: cluster-baremetal-operator
 owners:
 - metal-platform@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-bootstrap.yml
+++ b/images/ose-cluster-bootstrap.yml
@@ -26,3 +26,7 @@ name: openshift/ose-cluster-bootstrap-rhel9
 payload_name: cluster-bootstrap
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-capi-operator.yml
+++ b/images/ose-cluster-capi-operator.yml
@@ -33,3 +33,7 @@ name: openshift/ose-cluster-capi-rhel9-operator
 payload_name: cluster-capi-operator
 owners:
 - aos-cloud@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -36,3 +36,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-config-api.yml
+++ b/images/ose-cluster-config-api.yml
@@ -30,3 +30,7 @@ payload_name: cluster-config-api
 owners:
 - jspeed@redhat.com
 - deads@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-config-operator.yml
+++ b/images/ose-cluster-config-operator.yml
@@ -29,3 +29,7 @@ payload_name: cluster-config-operator
 owners:
 - aos-master@redhat.com
 - tnozicka@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-control-plane-machine-set-operator.yml
+++ b/images/ose-cluster-control-plane-machine-set-operator.yml
@@ -38,3 +38,7 @@ name: openshift/ose-cluster-control-plane-machine-set-rhel9-operator
 payload_name: cluster-control-plane-machine-set-operator
 owners:
 - aos-cloud-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-csi-snapshot-controller-operator.yml
+++ b/images/ose-cluster-csi-snapshot-controller-operator.yml
@@ -32,3 +32,7 @@ name: openshift/ose-cluster-csi-snapshot-controller-rhel9-operator
 payload_name: cluster-csi-snapshot-controller-operator
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-dns-operator.yml
+++ b/images/ose-cluster-dns-operator.yml
@@ -26,3 +26,7 @@ name: openshift/ose-cluster-dns-rhel9-operator
 payload_name: cluster-dns-operator
 owners:
 - aos-network-edge@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-image-registry-operator.yml
+++ b/images/ose-cluster-image-registry-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-image-registry-rhel9-operator
 payload_name: cluster-image-registry-operator
 owners:
 - openshift-image-registry@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-ingress-operator.yml
+++ b/images/ose-cluster-ingress-operator.yml
@@ -26,3 +26,7 @@ name: openshift/ose-cluster-ingress-rhel9-operator
 payload_name: cluster-ingress-operator
 owners:
 - aos-network-edge@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-kube-apiserver-operator.yml
+++ b/images/ose-cluster-kube-apiserver-operator.yml
@@ -31,3 +31,7 @@ name: openshift/ose-cluster-kube-apiserver-rhel9-operator
 payload_name: cluster-kube-apiserver-operator
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-kube-controller-manager-operator.yml
+++ b/images/ose-cluster-kube-controller-manager-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-kube-controller-manager-rhel9-operator
 payload_name: cluster-kube-controller-manager-operator
 owners:
 - aos-cloud@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-kube-scheduler-rhel9-operator
 payload_name: cluster-kube-scheduler-operator
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-kube-storage-version-migrator-operator.yml
+++ b/images/ose-cluster-kube-storage-version-migrator-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-cluster-kube-storage-version-migrator-rhel9-operator
 payload_name: cluster-kube-storage-version-migrator-operator
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-machine-approver.yml
+++ b/images/ose-cluster-machine-approver.yml
@@ -33,3 +33,7 @@ name: openshift/ose-cluster-machine-approver-rhel9
 payload_name: cluster-machine-approver
 owners:
 - aos-apiserver@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-olm-operator.yml
+++ b/images/ose-cluster-olm-operator.yml
@@ -28,3 +28,7 @@ payload_name: cluster-olm-operator
 owners:
 - angoldst@redhat.com
 - aos-odin@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-openshift-apiserver-operator.yml
+++ b/images/ose-cluster-openshift-apiserver-operator.yml
@@ -26,3 +26,7 @@ name: openshift/ose-cluster-openshift-apiserver-rhel9-operator
 payload_name: cluster-openshift-apiserver-operator
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-openshift-controller-manager-operator.yml
+++ b/images/ose-cluster-openshift-controller-manager-operator.yml
@@ -26,3 +26,7 @@ name: openshift/ose-cluster-openshift-controller-manager-rhel9-operator
 payload_name: cluster-openshift-controller-manager-operator
 owners:
 - openshift-build-api@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-samples-operator.yml
+++ b/images/ose-cluster-samples-operator.yml
@@ -28,3 +28,7 @@ name: openshift/ose-cluster-samples-rhel9-operator
 payload_name: cluster-samples-operator
 owners:
 - openshift-build-api@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -31,3 +31,7 @@ name: openshift/ose-cluster-update-keys-rhel9
 payload_name: cluster-update-keys
 owners:
 - aos-team-art@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-csi-external-resizer.yml
+++ b/images/ose-csi-external-resizer.yml
@@ -37,3 +37,7 @@ payload_name: csi-external-resizer
 name_in_bundle: csi-external-resizer
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-csi-external-snapshotter.yml
+++ b/images/ose-csi-external-snapshotter.yml
@@ -36,3 +36,7 @@ payload_name: csi-external-snapshotter
 name_in_bundle: csi-external-snapshotter
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-csi-snapshot-controller.yml
+++ b/images/ose-csi-snapshot-controller.yml
@@ -33,3 +33,7 @@ name: openshift/ose-csi-snapshot-controller-rhel9
 payload_name: csi-snapshot-controller
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -38,3 +38,7 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -41,3 +41,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -36,3 +36,7 @@ name: openshift/ose-gcp-pd-csi-driver-operator-rhel9
 payload_name: gcp-pd-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -40,3 +40,7 @@ name: openshift/ose-gcp-pd-csi-driver-rhel9
 payload_name: gcp-pd-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -38,3 +38,7 @@ name: openshift/ose-ibm-cloud-controller-manager-rhel9
 payload_name: ibm-cloud-controller-manager
 owners:
 - aos-cloud@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-ibm-vpc-block-csi-driver-operator.yml
+++ b/images/ose-ibm-vpc-block-csi-driver-operator.yml
@@ -34,3 +34,7 @@ name: openshift/ose-ibm-vpc-block-csi-driver-rhel9-operator
 payload_name: ibm-vpc-block-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -39,3 +39,7 @@ name: openshift/ose-ibm-vpc-block-csi-driver-rhel9
 payload_name: ibm-vpc-block-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -39,3 +39,7 @@ payload_name: ibmcloud-cluster-api-controllers
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -35,3 +35,7 @@ name: openshift/ose-ibmcloud-machine-controllers-rhel9
 payload_name: ibmcloud-machine-controllers
 owners:
 - aos-cloud@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -33,3 +33,6 @@ name: openshift/ose-image-customization-controller-rhel9
 payload_name: machine-image-customization-controller
 owners:
 - metal-platform@redhat.com
+okd:
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/ose-insights-operator.yml
+++ b/images/ose-insights-operator.yml
@@ -26,3 +26,7 @@ name: openshift/ose-insights-rhel9-operator
 payload_name: insights-operator
 owners:
 - ccoleman@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-insights-runtime-exporter.yml
+++ b/images/ose-insights-runtime-exporter.yml
@@ -27,3 +27,7 @@ payload_name: insights-runtime-exporter
 name: openshift/insights-runtime-exporter-rhel9
 owners:
 - jmesnil@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -38,3 +38,7 @@ konflux:
     x86_64: linux-d160-c4xlarge/amd64
     aarch64: linux-d160-c4xlarge/arm64
   build_attempts: 3
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-installer.yml
+++ b/images/ose-installer.yml
@@ -50,3 +50,7 @@ konflux:
     x86_64: linux-d160-c4xlarge/amd64
     aarch64: linux-d160-c4xlarge/arm64
   build_attempts: 3
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-kube-metrics-server.yml
+++ b/images/ose-kube-metrics-server.yml
@@ -35,3 +35,7 @@ name: openshift/kube-metrics-server-rhel9
 payload_name: kube-metrics-server
 owners:
 - team-monitoring-incluster@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-kube-storage-version-migrator.yml
+++ b/images/ose-kube-storage-version-migrator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-kube-storage-version-migrator-rhel9
 payload_name: kube-storage-version-migrator
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-kube-vip.yml
+++ b/images/ose-kube-vip.yml
@@ -31,3 +31,7 @@ name: openshift/ose-kube-vip-rhel9
 payload_name: kube-vip
 owners:
 - mko@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-kubevirt-cloud-controller-manager.yml
+++ b/images/ose-kubevirt-cloud-controller-manager.yml
@@ -32,3 +32,7 @@ payload_name: kubevirt-cloud-controller-manager
 owners:
 - dvossel@redhat.com
 - nargaman@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-kubevirt-csi-driver-rhel8.yml
+++ b/images/ose-kubevirt-csi-driver-rhel8.yml
@@ -36,3 +36,7 @@ owners:
 - rgolan@redhat.com
 - nargaman@redhat.com
 - dvossel@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -35,3 +35,7 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -38,3 +38,7 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -38,3 +38,7 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -39,3 +39,7 @@ owners:
 - aos-cloud@redhat.com
 konflux:
   tagging_mode: enabled
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-machine-api-provider-openstack.yml
+++ b/images/ose-machine-api-provider-openstack.yml
@@ -31,3 +31,7 @@ owners:
 - osasinfra-dev@redhat.com
 konflux:
   tagging_mode: enabled
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-machine-config-operator.yml
+++ b/images/ose-machine-config-operator.yml
@@ -43,3 +43,6 @@ owners:
 - jkyros@redhat.com
 - skumari@redhat.com
 - zzlotnik@redhat.com
+okd:
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/ose-multus-admission-controller.yml
+++ b/images/ose-multus-admission-controller.yml
@@ -31,3 +31,7 @@ name: openshift/ose-multus-admission-controller-rhel9
 payload_name: multus-admission-controller
 owners:
 - multus-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -30,3 +30,7 @@ name: openshift/ose-multus-route-override-cni-rhel9
 payload_name: multus-route-override-cni
 owners:
 - multus-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -31,3 +31,7 @@ name: openshift/ose-multus-whereabouts-ipam-cni-rhel9
 payload_name: multus-whereabouts-ipam-cni
 owners:
 - multus-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -35,3 +35,7 @@ name: openshift/ose-must-gather-rhel9
 payload_name: must-gather
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -29,3 +29,7 @@ name: openshift/ose-network-interface-bond-cni-rhel9
 payload_name: network-interface-bond-cni
 owners:
 - carlosg@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-network-metrics-daemon.yml
+++ b/images/ose-network-metrics-daemon.yml
@@ -28,3 +28,7 @@ payload_name: network-metrics-daemon
 owners:
 - fpaoline@redhat.com
 - sscheink@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -40,3 +40,7 @@ konflux:
       rpms:
       - gcc-plugin-annobin
       - llvm-filesystem
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-nutanix-cloud-controller-manager.yml
+++ b/images/ose-nutanix-cloud-controller-manager.yml
@@ -39,3 +39,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-nutanix-machine-controllers.yml
+++ b/images/ose-nutanix-machine-controllers.yml
@@ -38,3 +38,7 @@ owners:
 - mfedosin@redhat.com
 - dmoiseev@redhat.com
 - ademicev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-oauth-apiserver.yml
+++ b/images/ose-oauth-apiserver.yml
@@ -27,3 +27,7 @@ name: openshift/ose-oauth-apiserver-rhel9
 payload_name: oauth-apiserver
 owners:
 - aos-apiserver@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-olm-catalogd.yml
+++ b/images/ose-olm-catalogd.yml
@@ -30,3 +30,7 @@ name: openshift/ose-olm-catalogd-rhel9
 payload_name: olm-catalogd
 owners:
 - aos-odin@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-olm-operator-controller.yml
+++ b/images/ose-olm-operator-controller.yml
@@ -36,3 +36,7 @@ name: openshift/ose-olm-operator-controller-rhel9
 payload_name: olm-operator-controller
 owners:
 - aos-odin@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-openshift-apiserver.yml
+++ b/images/ose-openshift-apiserver.yml
@@ -31,3 +31,7 @@ name: openshift/ose-openshift-apiserver-rhel9
 payload_name: openshift-apiserver
 owners:
 - aos-master@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-openshift-controller-manager.yml
+++ b/images/ose-openshift-controller-manager.yml
@@ -27,3 +27,7 @@ name: openshift/ose-openshift-controller-manager-rhel9
 payload_name: openshift-controller-manager
 owners:
 - openshift-build-api@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-openstack-cinder-csi-driver-operator.yml
+++ b/images/ose-openstack-cinder-csi-driver-operator.yml
@@ -33,3 +33,7 @@ payload_name: openstack-cinder-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
 - osasinfra-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-openstack-cinder-csi-driver.yml
+++ b/images/ose-openstack-cinder-csi-driver.yml
@@ -32,3 +32,7 @@ payload_name: openstack-cinder-csi-driver
 owners:
 - aos-storage-staff@redhat.com
 - osasinfra-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-openstack-cloud-controller-manager.yml
+++ b/images/ose-openstack-cloud-controller-manager.yml
@@ -37,3 +37,7 @@ owners:
 - dmoiseev@redhat.com
 - mbooth@redhat.com
 - osasinfra-dev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-operator-framework-tools.yml
+++ b/images/ose-operator-framework-tools.yml
@@ -31,3 +31,7 @@ owners:
 - jlanford@redhat.com
 - krizza@redhat.com
 - jkeister@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -36,3 +36,7 @@ payload_name: powervs-block-csi-driver-operator
 owners:
 - mchellam@redhat.com
 - mkumatag@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -44,3 +44,7 @@ konflux:
     lockfile:
       rpms:
       - keyutils
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-powervs-cloud-controller-manager.yml
+++ b/images/ose-powervs-cloud-controller-manager.yml
@@ -32,3 +32,7 @@ payload_name: powervs-cloud-controller-manager
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-powervs-machine-controllers.yml
+++ b/images/ose-powervs-machine-controllers.yml
@@ -31,3 +31,7 @@ payload_name: powervs-machine-controllers
 owners:
 - mkumatag@redhat.com
 - kabhat@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-route-controller-manager.yml
+++ b/images/ose-route-controller-manager.yml
@@ -32,3 +32,7 @@ payload_name: route-controller-manager
 owners:
 - jchaloup@redhat.com
 - fkrepins@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-service-ca-operator.yml
+++ b/images/ose-service-ca-operator.yml
@@ -27,3 +27,7 @@ name: openshift/ose-service-ca-rhel9-operator
 payload_name: service-ca-operator
 owners:
 - aos-apiserver@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-vmware-vsphere-csi-driver-operator.yml
+++ b/images/ose-vmware-vsphere-csi-driver-operator.yml
@@ -35,3 +35,7 @@ name: openshift/ose-vsphere-csi-driver-rhel9-operator
 payload_name: vsphere-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -39,3 +39,7 @@ name: openshift/ose-vsphere-csi-driver-rhel9
 payload_name: vsphere-csi-driver
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -39,3 +39,7 @@ from:
   builder:
   - stream: rhel-9-golang
   member: openshift-enterprise-base-rhel9
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -39,3 +39,7 @@ owners:
 - jspeed@redhat.com
 - elmiko@redhat.com
 - dmoiseev@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/ovn-kubernetes-microshift.yml
+++ b/images/ovn-kubernetes-microshift.yml
@@ -39,3 +39,7 @@ name: openshift/ose-ovn-kubernetes-microshift-rhel9
 payload_name: ovn-kubernetes-microshift
 owners:
 - aos-networking-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -44,3 +44,6 @@ konflux:
     lockfile:
       rpms:
       - openshift-prometheus-promu
+okd:
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/prometheus-config-reloader.yml
+++ b/images/prometheus-config-reloader.yml
@@ -40,3 +40,7 @@ name: openshift/ose-prometheus-config-reloader-rhel9
 payload_name: prometheus-config-reloader
 owners:
 - team-monitoring@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/prometheus-operator-admission-webhook.yml
+++ b/images/prometheus-operator-admission-webhook.yml
@@ -35,3 +35,7 @@ name: openshift/ose-prometheus-operator-admission-webhook-rhel9
 payload_name: prometheus-operator-admission-webhook
 owners:
 - team-monitoring@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/prometheus-operator.yml
+++ b/images/prometheus-operator.yml
@@ -41,3 +41,7 @@ name: openshift/ose-prometheus-rhel9-operator
 payload_name: prometheus-operator
 owners:
 - team-monitoring@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/telemeter.yml
+++ b/images/telemeter.yml
@@ -35,3 +35,7 @@ name: openshift/ose-telemeter-rhel9
 payload_name: telemeter
 owners:
 - team-monitoring@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/vmware-vsphere-syncer.yml
+++ b/images/vmware-vsphere-syncer.yml
@@ -35,3 +35,7 @@ name: openshift/ose-vsphere-csi-driver-syncer-rhel9
 payload_name: vsphere-csi-driver-syncer
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/volume-data-source-validator.yml
+++ b/images/volume-data-source-validator.yml
@@ -35,3 +35,7 @@ payload_name: volume-data-source-validator
 owners:
 - rbednar@redhat.com
 - jsafrane@redhat.com
+okd:
+  content:
+    source:
+      modifications: []

--- a/images/vsphere-problem-detector.yml
+++ b/images/vsphere-problem-detector.yml
@@ -34,3 +34,7 @@ name: openshift/ose-vsphere-problem-detector-rhel9
 payload_name: vsphere-problem-detector
 owners:
 - aos-storage-staff@redhat.com
+okd:
+  content:
+    source:
+      modifications: []


### PR DESCRIPTION
Add okd: overrides to 169 payload images that were previously missing them, enabling ART to build these images directly via Konflux instead of mirroring from CI.

- 8 images: repo swap (embargoed → non-embargoed)
- 161 images: no modifications needed (empty modifications [])

Tracks: [ART-23275](https://redhat.atlassian.net/browse/ART-23275)