### PR TITLE
mta-agent-skills, mta-agentic-controller: add pip binary config to work around repo-level pip detection

### DIFF
--- a/images/mta-agent-skills.yml
+++ b/images/mta-agent-skills.yml
@@ -1,0 +1,41 @@
+base_image_release:
+  force: true
+# TODO: ART auto-detects requirements.txt from the repo and runs pip prefetch
+# for every component sourcing from this repo, even ones that don't install
+# Python packages. Mirroring the binary config from mta-agent-base makes the
+# prefetch succeed (tree-sitter-php==0.24.1 has no sdist, only wheels).
+# Remove once ART's pip detection scope is clarified / scoped per image.
+cachito:
+  packages:
+    pip:
+      - path: "."
+        requirements_files:
+        - requirements.txt
+        binary:
+          packages: ":all:"
+          arch: "x86_64,aarch64"
+          py_version: 311
+content:
+  source:
+    dockerfile: catalog/Containerfile
+    git:
+      branch:
+        target: main
+      url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
+      web: https://github.com/migtools/mta-agentic-controller
+jira:
+  project: MTA
+  component: Analysis
+distgit:
+  component: mta-agent-skills-container
+delivery:
+  delivery_repo_names:
+  - mta/mta-agent-skills-rhel9
+enabled_repos:
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
+name: mta/mta-agent-skills-rhel9
+owners:
+- mta-devs@redhat.com
+dependents:
+  - mta-operator

--- a/images/mta-agentic-controller.yml
+++ b/images/mta-agentic-controller.yml
@@ -1,0 +1,50 @@
+cachito:
+  packages:
+    gomod:
+      - path: .
+      - path: api/
+    # TODO: ART auto-detects requirements.txt from the repo and runs pip prefetch
+    # for every component sourcing from this repo, even ones that don't install
+    # Python packages. Mirroring the binary config from mta-agent-base makes the
+    # prefetch succeed (tree-sitter-php==0.24.1 has no sdist, only wheels).
+    # Remove once ART's pip detection scope is clarified / scoped per image.
+    pip:
+      - path: "."
+        requirements_files:
+        - requirements.txt
+        binary:
+          packages: ":all:"
+          arch: "x86_64,aarch64"
+          py_version: 311
+content:
+  source:
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: main
+      url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
+      web: https://github.com/migtools/mta-agentic-controller
+    modifications:
+      - action: replace
+        match: "RUN go mod download"
+        replacement: "# go mod download removed - deps pre-fetched by cachi2"
+jira:
+  project: MTA
+  component: Analysis
+distgit:
+  component: mta-agentic-controller-container
+delivery:
+  delivery_repo_names:
+  - mta/mta-agentic-controller-rhel9
+enabled_repos:
+- rhel-98-appstream-rpms
+- rhel-98-baseos-rpms
+from:
+  builder:
+    - stream: rhel-9-golang
+  member: base-rhel9
+name: mta/mta-agentic-controller-rhel9
+owners:
+- mta-devs@redhat.com
+dependents:
+  - mta-operator


### PR DESCRIPTION
## Summary

- Adds `mta-agent-skills.yml` (new image entry for the skills bundle, `FROM scratch`)
- Adds pip binary package config to both `mta-agent-skills.yml` and `mta-agentic-controller.yml`

## Context

ART's pip detection appears to operate at the repo level rather than per image: both `mta-agent-skills` and `mta-agentic-controller` source from `openshift-priv/migtools-mta-agentic-controller` which contains a `requirements.txt`, causing hermeto to run pip prefetch for these images even though neither installs Python packages.

Without a `binary:` configuration, hermeto tries to resolve source distributions (sdists). `tree-sitter-php==0.24.1` (a transitive dep via graphifyy) has no sdist — only wheels — so hermeto fails with `PackageRejected: No distributions found`.

Mirroring the `binary: packages: ":all:"` config from `mta-agent-base` makes the prefetch succeed by resolving wheels instead.

## TODO

Remove the pip section from `mta-agent-skills` and `mta-agentic-controller` once ART's pip detection scope is clarified / scoped per image.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)