### PR TITLE
mta-agent-skills, mta-agentic-controller: add pip binary config to work around repo-level pip detection

### DIFF
--- a/images/mta-agent-skills.yml
+++ b/images/mta-agent-skills.yml
@@ -1,5 +1,20 @@
 base_image_release:
   force: true
+# TODO: ART auto-detects requirements.txt from the repo and runs pip prefetch
+# for every component sourcing from this repo, even ones that don't install
+# Python packages. Mirroring the binary config from mta-agent-base makes the
+# prefetch succeed (tree-sitter-php==0.24.1 has no sdist, only wheels).
+# Remove once ART's pip detection scope is clarified / scoped per image.
+cachito:
+  packages:
+    pip:
+      - path: "."
+        requirements_files:
+        - requirements.txt
+        binary:
+          packages: ":all:"
+          arch: "x86_64,aarch64"
+          py_version: 311
 content:
   source:
     dockerfile: catalog/Containerfile

--- a/images/mta-agentic-controller.yml
+++ b/images/mta-agentic-controller.yml
@@ -3,6 +3,19 @@ cachito:
     gomod:
       - path: .
       - path: api/
+    # TODO: ART auto-detects requirements.txt from the repo and runs pip prefetch
+    # for every component sourcing from this repo, even ones that don't install
+    # Python packages. Mirroring the binary config from mta-agent-base makes the
+    # prefetch succeed (tree-sitter-php==0.24.1 has no sdist, only wheels).
+    # Remove once ART's pip detection scope is clarified / scoped per image.
+    pip:
+      - path: "."
+        requirements_files:
+        - requirements.txt
+        binary:
+          packages: ":all:"
+          arch: "x86_64,aarch64"
+          py_version: 311
 content:
   source:
     dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

- Adds `mta-agent-skills.yml` (new image entry for the skills bundle, `FROM scratch`)
- Adds pip binary package config to both `mta-agent-skills.yml` and `mta-agentic-controller.yml`

## Context

ART's pip detection appears to operate at the repo level rather than per image: both `mta-agent-skills` and `mta-agentic-controller` source from `openshift-priv/migtools-mta-agentic-controller` which contains a `requirements.txt`, causing hermeto to run pip prefetch for these images even though neither installs Python packages.

Without a `binary:` configuration, hermeto tries to resolve source distributions (sdists). `tree-sitter-php==0.24.1` (a transitive dep via graphifyy) has no sdist — only wheels — so hermeto fails with `PackageRejected: No distributions found`.

Mirroring the `binary: packages: ":all:"` config from `mta-agent-base` makes the prefetch succeed by resolving wheels instead.

## TODO

Remove the pip section from `mta-agent-skills` and `mta-agentic-controller` once ART's pip detection scope is clarified / scoped per image.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)