### PR TITLE
[OKD] Enable ART/Konflux builds for CoreOS images (stream-coreos, stream-coreos-extensions)

### DIFF
--- a/images/rhcos-node-extensions.yml
+++ b/images/rhcos-node-extensions.yml
@@ -43,4 +43,22 @@ canonical_builders_from_upstream: false
 konflux:
   network_mode: open
 okd:
-  mode: disabled
+  mode: enabled
+  from:
+    builder:
+      - member: rhcos-node-image
+      - member: openshift-enterprise-base-rhel9
+    member: openshift-enterprise-base-rhel9
+  enabled_repos: []
+  content:
+    source:
+      modifications:
+      - action: replace
+        match: "ARG STREAM_CLASS"
+        replacement: "ARG STREAM_CLASS=centos-10"
+      - action: replace
+        match: "RUN --mount=type=secret,id=yumrepos,target=/os/secret.repo extensions/build.sh"
+        replacement: |
+          RUN rm -f /os/c10s.repo && touch /os/empty.repo && \
+              sed -e 's/--repo="${repo_list}"//' extensions/build.sh | bash
+  payload_name: stream-coreos-extensions

--- a/images/rhcos-node-image.yml
+++ b/images/rhcos-node-image.yml
@@ -55,4 +55,39 @@ canonical_builders_from_upstream: false
 konflux:
   network_mode: open
 okd:
-  mode: disabled
+  mode: enabled
+  from:
+    stream: scos_coreos
+  enabled_repos: []
+  content:
+    source:
+      modifications:
+      - action: replace
+        match: "ARG OPENSHIFT_VERSION=overridden"
+        replacement: "ARG OPENSHIFT_VERSION=5.0"
+      - action: replace
+        match: "ARG STREAM_CLASS"
+        replacement: "ARG STREAM_CLASS=centos-10"
+      - action: replace
+        match: "ARG IMAGE_NAME"
+        replacement: "ARG IMAGE_NAME=openshift/scos-node-image"
+      - action: replace
+        match: "ARG IMAGE_CPE"
+        replacement: "ARG IMAGE_CPE=cpe:/a:redhat:openshift:5.0::el10"
+      - action: replace
+        match: "ARG TARGETARCH"
+        replacement: "ARG TARGETARCH=amd64"
+      - action: replace
+        match: "LABEL name=${IMAGE_NAME}"
+        replacement: ""
+      - action: replace
+        match: "LABEL architecture=${TARGETARCH}"
+        replacement: ""
+      - action: replace
+        match: 'RUN --mount=type=bind,target=/run/src --mount=type=secret,id=yumrepos,target=/run/src/secret.repo /run/src/build-node-image.sh'
+        replacement: |
+          RUN --mount=type=bind,target=/run/src --mount=type=secret,id=yumrepos,target=/run/src/secret.repo \
+              sed -e 's/dnf --repo="${YUM_REPO_NAMES}"/dnf/' \
+                  -e '/cat \/run\/src\/\*\.repo >> \/etc\/yum\.repos\.d\/git\.repo/a sed -i "s/enabled=1/enabled=0/g" /etc/yum.repos.d/git.repo' \
+                  /run/src/build-node-image.sh | bash
+  payload_name: stream-coreos

--- a/streams.yml
+++ b/streams.yml
@@ -123,5 +123,9 @@ rhel_coreos10:
   image: registry.ci.openshift.org/coreos/rhel-coreos-base:10.2
   skip_nvr_check: true
 
+scos_coreos:
+  image: registry.ci.openshift.org/coreos/stream-coreos-base:10
+  skip_nvr_check: true
+
 scratch:
   image: scratch


### PR DESCRIPTION
## Summary

Currently `stream-coreos` and `stream-coreos-extensions` are the only two OKD images that come from CI — they are mirrored from the CI imagestream (`scos-5.0`) into the ART imagestream (`scos-5.0-art`) via the `mirror_coreos_imagestreams()` method in `pyartcd/pipelines/okd.py`.

This PR enables ART to build these images directly via Konflux, eliminating the CI dependency for the nightly stream.

## Changes

### `streams.yml`
- Add `scos_coreos` stream pointing to `registry.ci.openshift.org/coreos/stream-coreos-base:10` (CentOS Stream CoreOS base, analogous to `rhel_coreos` / `rhel_coreos10`)

### `images/rhcos-node-image.yml`
- Change `okd: mode: disabled` → enabled with overrides:
  - `from: stream: scos_coreos` (CentOS Stream CoreOS base instead of RHEL)
  - `STREAM_CLASS=centos-10` (matching the CI `__okd-scos` config)
  - Containerfile modifications adapted from the RHEL build
  - `payload_name: stream-coreos` (for imagestream tagging)

### `images/rhcos-node-extensions.yml`
- Change `okd: mode: disabled` → enabled with overrides:
  - `STREAM_CLASS=centos-10`
  - Build script modifications matching the CI OKD build
  - `payload_name: stream-coreos-extensions`

## Art-tools dependency

The `update_imagestreams()` method in `pyartcd/pipelines/okd.py` currently skips images that are not `for_payload` or `base_only`. Since these CoreOS images have `for_payload: false`, a corresponding change is needed in art-tools to:

1. Update `update_imagestreams()` to also tag images that have `okd.payload_name` set (even if not `for_payload`), OR
2. Remove/disable the `mirror_coreos_imagestreams()` method once ART builds these directly

## Context

- The CI stream (`5.0.0-0.okd-scos`) builds these images via Prow and promotes to both `scos-5.0` AND `scos-5.0-art`
- The ART nightly stream (`5.0.0-0.okd-scos-nightly`) currently relies on `mirror_coreos_imagestreams()` to copy CI tags into `scos-5.0-art`
- This change makes ART build CoreOS images independently, removing the last CI dependency from the nightly stream

cc @openshift-eng/art