### PR TITLE
Remove per-image jira overrides from MCE 5.0 images

### DIFF
--- a/images/addon-manager.yml
+++ b/images/addon-manager.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/addon-manager-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-addon-manager-container

--- a/images/azure-service-operator.yml
+++ b/images/azure-service-operator.yml
@@ -38,6 +38,3 @@ from:
 name: multicluster-engine/azure-service-operator-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-azure-service-operator-container

--- a/images/backplane-must-gather.yml
+++ b/images/backplane-must-gather.yml
@@ -24,6 +24,3 @@ from:
 name: multicluster-engine/must-gather-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-backplane-must-gather-container

--- a/images/backplane-operator.yml
+++ b/images/backplane-operator.yml
@@ -32,6 +32,3 @@ update-csv:
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-backplane-operator-container

--- a/images/capoa-bootstrap.yml
+++ b/images/capoa-bootstrap.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/capoa-bootstrap-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-capoa-bootstrap-container

--- a/images/capoa-control-plane.yml
+++ b/images/capoa-control-plane.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/capoa-control-plane-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-capoa-control-plane-container

--- a/images/cloudevents-conductor.yml
+++ b/images/cloudevents-conductor.yml
@@ -24,6 +24,3 @@ from:
 name: multicluster-engine/cloudevents-conductor-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cloudevents-conductor-container

--- a/images/cluster-api-provider-agent.yml
+++ b/images/cluster-api-provider-agent.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/cluster-api-provider-agent-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cluster-api-provider-agent-container

--- a/images/cluster-api-provider-aws.yml
+++ b/images/cluster-api-provider-aws.yml
@@ -31,6 +31,3 @@ from:
 name: multicluster-engine/cluster-api-provider-aws-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cluster-api-provider-aws-container

--- a/images/cluster-api-provider-azure.yml
+++ b/images/cluster-api-provider-azure.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/cluster-api-provider-azure-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cluster-api-provider-azure-container

--- a/images/cluster-api-provider-kubevirt.yml
+++ b/images/cluster-api-provider-kubevirt.yml
@@ -31,6 +31,3 @@ from:
 name: multicluster-engine/cluster-api-provider-kubevirt-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cluster-api-provider-kubevirt-container

--- a/images/cluster-api-webhook-config.yml
+++ b/images/cluster-api-webhook-config.yml
@@ -30,6 +30,3 @@ from:
 name: multicluster-engine/mce-capi-webhook-config-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cluster-api-webhook-config-container

--- a/images/cluster-curator-controller.yml
+++ b/images/cluster-curator-controller.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/cluster-curator-controller-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cluster-curator-controller-container

--- a/images/cluster-image-set-controller.yml
+++ b/images/cluster-image-set-controller.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/cluster-image-set-controller-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cluster-image-set-controller-container

--- a/images/cluster-permission.yml
+++ b/images/cluster-permission.yml
@@ -24,6 +24,3 @@ from:
 name: multicluster-engine/cluster-permission-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cluster-permission-container

--- a/images/cluster-proxy.yml
+++ b/images/cluster-proxy.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/cluster-proxy-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-cluster-proxy-container

--- a/images/clusterclaims-controller.yml
+++ b/images/clusterclaims-controller.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/clusterclaims-controller-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-clusterclaims-controller-container

--- a/images/clusterlifecycle-state-metrics.yml
+++ b/images/clusterlifecycle-state-metrics.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/clusterlifecycle-state-metrics-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-clusterlifecycle-state-metrics-container

--- a/images/console-mce.yml
+++ b/images/console-mce.yml
@@ -29,6 +29,3 @@ from:
 name: multicluster-engine/console-mce-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-console-mce-container

--- a/images/discovery-operator.yml
+++ b/images/discovery-operator.yml
@@ -24,6 +24,3 @@ from:
 name: multicluster-engine/discovery-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-discovery-operator-container

--- a/images/hive.yml
+++ b/images/hive.yml
@@ -34,9 +34,6 @@ from:
 name: multicluster-engine/hive-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-hive-container
 konflux:
   vm_override:
     aarch64: linux-mxlarge/arm64

--- a/images/hypershift-addon-operator.yml
+++ b/images/hypershift-addon-operator.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/hypershift-addon-rhel9-operator
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-hypershift-addon-operator-container

--- a/images/hypershift-cli.yml
+++ b/images/hypershift-cli.yml
@@ -22,6 +22,3 @@ from:
 name: multicluster-engine/hypershift-cli-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-hypershift-cli-container

--- a/images/hypershift-release.yml
+++ b/images/hypershift-release.yml
@@ -25,6 +25,3 @@ from:
 name: multicluster-engine/hypershift-rhel9-operator
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-hypershift-release-container

--- a/images/image-based-install-operator.yml
+++ b/images/image-based-install-operator.yml
@@ -29,6 +29,3 @@ from:
 name: multicluster-engine/image-based-install-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-image-based-install-operator-container

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -24,6 +24,3 @@ from:
 name: multicluster-engine/kube-rbac-proxy-mce-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-kube-rbac-proxy-container

--- a/images/maestro.yml
+++ b/images/maestro.yml
@@ -24,6 +24,3 @@ from:
 name: multicluster-engine/maestro-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-maestro-container

--- a/images/managed-serviceaccount.yml
+++ b/images/managed-serviceaccount.yml
@@ -24,6 +24,3 @@ from:
 name: multicluster-engine/managed-serviceaccount-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-managed-serviceaccount-container

--- a/images/managedcluster-import-controller-addon.yml
+++ b/images/managedcluster-import-controller-addon.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/managedcluster-import-controller-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-managedcluster-import-controller-container

--- a/images/multicloud-manager.yml
+++ b/images/multicloud-manager.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/multicloud-manager-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-multicloud-manager-container

--- a/images/placement.yml
+++ b/images/placement.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/placement-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-placement-container

--- a/images/provider-credential-controller.yml
+++ b/images/provider-credential-controller.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/provider-credential-controller-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-provider-credential-controller-container

--- a/images/registration-operator.yml
+++ b/images/registration-operator.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/registration-operator-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-registration-operator-container

--- a/images/registration.yml
+++ b/images/registration.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/registration-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-registration-container

--- a/images/work.yml
+++ b/images/work.yml
@@ -21,6 +21,3 @@ from:
 name: multicluster-engine/work-rhel9
 owners:
 - acm-cicd@redhat.com
-jira:
-  project: ACM
-  component: mce-work-container


### PR DESCRIPTION
## Summary
- Removes the per-image `jira:` blocks from all 35 MCE 5.0 payload images
- Those `jira.component` values were copies of `distgit.component` (e.g. `mce-backplane-operator-container`) and are not valid ACM Jira components
- Image metadata overrides `product.yml`, so these blocks would keep ART from using the generated mappings

`base-rhel9.yml` is unchanged (no `jira` section). Same approach as ACM in https://github.com/openshift-eng/ocp-build-data/pull/12690

Depends on https://github.com/openshift-eng/ocp-build-data/pull/12692 so `product.yml` on `main` has the MCE distgit → Jira mappings (including `issue_project: ACM`).

## Test plan
- [x] Confirmed every removed `jira.component` matched `distgit.component`
- [x] No `jira:` keys remain under `images/` except the skipped base image
- [ ] Merge after #12692 so doozer/elliott resolve MCE bugs via `product.yml`


Made with [Cursor](https://cursor.com)