### PR TITLE
Revert EC.0 kernel member pin

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -46,12 +46,7 @@ releases:
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6849aaff77599f4c2e79f8df2a2c4b4849da5c1fd825410d2307e9dc0ec66cfa
             ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d748fe8212c9fc0c653d8ab855ddac793da78791e2e0f1a91b9484dae6bb28f3
       members:
-        rpms:
-          - distgit_key: kernel
-            why: Pin the EC.0 kernel to match the fixed RHCOS payload
-            metadata:
-              is:
-                el9: kernel-5.14.0-687.42.1.el9_8
+        rpms: []
         images: []
       permits:
         - code: CONFLICTING_INHERITED_DEPENDENCY


### PR DESCRIPTION
Revert #12697. The 5.1 group models kernel as an external package, not an RPM distgit, so `assembly.members.rpms` cannot reference `kernel`.