### PR TITLE
Fix EC.0 kernel basis event

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -3,7 +3,7 @@ releases:
     assembly:
       type: preview
       basis:
-        time: "2026-09-01T16:02:54+00:00"
+        brew_event: 68679380
         reference_releases:
           x86_64: 5.1.0-0.nightly-2026-09-01-192803
       group:


### PR DESCRIPTION
## Summary

- replace the generated basis time with Brew event `68679380`
- align the inherited kernel with `kernel-5.14.0-687.42.1.el9_8` contained in the required EC.0 RHCOS payload
- retain the selected `5.1.0-0.nightly-2026-09-01-192803` reference release

## Validation

- `git diff --check`
- parsed the EC.0 basis with `yq`
- verified Brew event `68679380` resolves `kernel-5.14.0-687.42.1.el9_8` before `.43.1` entered the candidate tag