### PR TITLE
mta-agent-base: remove pip prefetch; graphify dependency dropped upstream

### DIFF
--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -5,14 +5,6 @@ cachito:
     gomod:
       - path: harness/
       - path: api/
-    pip:
-      - path: "."
-        requirements_files:
-        - requirements.txt
-        binary:
-          packages: ":all:"
-          arch: "x86_64,aarch64"
-          py_version: 311
     cargo:
       - path: images/agent-base/goose-src/
 content:
@@ -54,7 +46,6 @@ content:
         replacement: '&& rm -f .cargo/config.toml && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
-    - pip
     - cargo
 jira:
   project: MTA

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -36,14 +36,14 @@ content:
         match: 'ENV PATH="/root/.cargo/bin:${PATH}"'
         replacement: "# cargo from rpm is already on PATH"
       - action: replace
-        match: '&& cargo build --release -p goose-cli --bin goose \'
+        match: 'RUN cargo build --release -p goose-cli --bin goose \'
         # --ignore-rust-version bypasses the MSRV gate (goose declares rust-version = "1.94.1"
         # but RHEL 9.8 tops out at 1.92.0 via rust-toolset). The build will still fail if goose
         # actually uses a language feature introduced after 1.92.0, which surfaces a clear error.
-        # rm -f .cargo/config.toml removes any config shipped by the goose source tarball that
+        # rm -f .cargo/config.toml removes any .cargo/config.toml from the goose source that
         # would conflict with cachi2's offline vendor settings (cachi2 injects its own config
         # via CARGO_HOME rather than the source tree).
-        replacement: '&& rm -f .cargo/config.toml && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
+        replacement: 'RUN rm -f .cargo/config.toml && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - cargo


### PR DESCRIPTION
## Summary

Removes pip prefetch configuration from `mta-agent-base.yml`.

## Reason

`konveyor/agentic-controller` removed graphify as unused (konveyor/agentic-controller#212, now synced to migtools/mta-agentic-controller#13). With no Python packages installed in `agent-base` at build time, the pip prefetch section serves no purpose.

Removing pip also fixes the root cause of the `prefetch-dependencies` failures that were hitting `mta-agent-skills` and `mta-agentic-controller`: pip was being detected at the repo level and hermeto was failing on `tree-sitter-php==0.24.1` (no sdist, only wheels) for images that never install Python packages. The correct fix is to stop prefetching pip entirely rather than adding binary workarounds per image.

This PR supersedes #12688.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)