### PR TITLE
Remove rhel-8-golang stream from ose-network-interface-bond-cni

### DIFF
--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -23,7 +23,6 @@ from:
   builder:
   # Binaries must be compiled for the RHCOS version of RHEL
   - stream: rhel-9-golang
-  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-network-interface-bond-cni-rhel9
 payload_name: network-interface-bond-cni


### PR DESCRIPTION
follows https://github.com/openshift/bond-cni/pull/113