### PR TITLE
Remove rhl8 base from ose-network-interface-bond-cni

### DIFF
--- a/images/ose-network-interface-bond-cni.yml
+++ b/images/ose-network-interface-bond-cni.yml
@@ -23,7 +23,6 @@ from:
   builder:
   # Binaries must be compiled for the RHCOS version of RHEL
   - stream: rhel-9-golang
-  - stream: rhel-8-golang
   member: openshift-enterprise-base-rhel9
 name: openshift/ose-network-interface-bond-cni-rhel9
 payload_name: network-interface-bond-cni


### PR DESCRIPTION
Upstream Removed rhel8 build stage from Dockerfile.openshift
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED