### PR TITLE
5.1 ec.0: remove advisories

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -7,10 +7,10 @@ releases:
         # reference_releases:
         #   x86_64: 5.1.0-0.nightly-2026-09-01-192803
       group:
-        advisories:
-          rpm: 172443
-          rhcos: 172444
-          microshift: 172445
+        # advisories:
+        #   rpm: 172443
+        #   rhcos: 172444
+        #   microshift: 172445
         release_jira: ART-0
         shipment:
           advisories:


### PR DESCRIPTION
Cannot change advisory 172443: Erratum 172443: Incorrect parameters: Invalid product version OSE-5.1-RHEL-9