### PR TITLE
Bump OVE UI ISO embedded OCP release to 4.22.13

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -24,9 +24,9 @@ konflux:
     memory: "8Gi"
   build_args:
   - "RELEASE_FLAG=--release-image-url"
-  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.22.11-x86_64"
+  - "RELEASE_VALUE=quay.io/openshift-release-dev/ocp-release:4.22.13-x86_64"
   - "MAJOR_MINOR_VERSION=4.22"
-  - "PATCH_VERSION=11"
+  - "PATCH_VERSION=13"
   - "ARCH=x86_64"
 
 assemblies:


### PR DESCRIPTION
## Summary
- Update `konflux.build_args` in `group.yml` to embed OCP **4.22.13** in the OVE agent installer ISO build
  - Changes `RELEASE_VALUE` to `quay.io/openshift-release-dev/ocp-release:4.22.13-x86_64` and `PATCH_VERSION` to `13`

## Context
Prepares the `installer-ove-ui-4.22` branch for a new `art-agent-installer-iso` Konflux/Jenkins build.

Follow-up to #12489 (4.22.11 bump). `streams.yml` already points at the quay-proxy `agent-preinstall-image-builder` pullspec; no change needed there.

## Test plan
- [ ] Merge PR
- [ ] Trigger layered-products build with `GROUP=installer-ove-ui-4.22`, `ASSEMBLY=stream`, `IMAGE_LIST=art-agent-installer-iso`, and this branch as `DOOZER_DATA_GITREF`
- [ ] Confirm build embeds OCP 4.22.13 in the ISO