### PR TITLE
OKD-432: remove okd override from egress router

### DIFF
--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -29,8 +29,3 @@ name: openshift/egress-router-cni-rhel9
 payload_name: egress-router-cni
 owners:
 - aos-networking-staff@redhat.com
-okd:
-  from:
-    builder:
-    - stream: rhel-9-golang
-    stream: centos_stream9


### PR DESCRIPTION
Remove the OKD from override from egress-router-cni so builds inherit the enterprise base image with required packages like util-linux.

[Slack thread for context](https://redhat-internal.slack.com/archives/C08HS7DBZU4/p1788475276102359?thread_ts=1788474390.040259&cid=C08HS7DBZU4)