### PR TITLE
Allow prepare-release-konflux for EC.0

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -25,11 +25,6 @@ releases:
             tag: rhaos-4.23-rhel-9-candidate
             condition: greater_equal
       rhcos:
-        dependencies:
-          rpms:
-            - el9: kernel-5.14.0-687.42.1.el9_8
-              why: Pin RHCOS kernel dependency to match actual RHCOS build
-              non_gc_tag: rhaos-4.23-rhel-9-candidate
         rhel-coreos:
           images:
             x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:834aa080cb798a6de4b2f826619ec575d0e53116c39bc7142d94cc50757d8ca1


### PR DESCRIPTION
The EC.0 prepare-release-konflux job fails in Elliott build sweeping because the assembly contains an RHCOS-specific RPM dependency.

Failure observed in prepare-release-konflux #1234:
`Assembly ec.0 is not appliable for build sweep because it contains RHCOS specific dependencies for a custom release.`

`art-tools/elliott/elliottlib/cli/find_builds_cli.py` intentionally rejects `rhcos.dependencies.rpms` when an assembly has a basis event. Remove the EC.0 kernel dependency pin while retaining the assembly-level `check_external_packages` kernel rule with `greater_equal`; this allows the fixed public RHCOS payload kernel to pass consistency checks without making prepare-release inapplicable.

Validation:
- YAML parsing and EC.0 assertions passed
- Doozer `config:read-group --build-system=konflux` passed
- `git diff --check` passed
- repository commit hooks passed