### PR TITLE
ART-23149 [mta-8.3]: mta-agent-base hermetic goose-from-source (submodule)

### DIFF
--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -14,6 +14,7 @@ content:
       branch:
         target: main
       url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
+      url_pull: https://github.com/lgarciaaco/mta-agentic-controller.git
       web: https://github.com/migtools/mta-agentic-controller
     modifications:
       - action: replace
@@ -35,6 +36,10 @@ content:
       - action: replace
         match: 'ENV PATH="/root/.cargo/bin:${PATH}"'
         replacement: "# cargo from rpm is already on PATH"
+      - action: replace
+        match: 'COPY images/agent-base/goose-src/ .'
+        replacement: |-
+          RUN tar -xzf /cachi2/output/deps/generic/goose-v1.45.0.tar.gz --strip-components=1
       - action: replace
         match: 'RUN cargo build --release -p goose-cli --bin goose \'
         # --ignore-rust-version bypasses the MSRV gate (goose declares rust-version = "1.94.1"
@@ -62,6 +67,8 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
+    - image: scratch
+    - stream: rhel-9-golang
   member: base-rhel9
 name: mta/mta-agent-base-rhel9
 owners:
@@ -86,3 +93,8 @@ konflux:
         - libxcb-devel
         - openssl-devel
         - perl
+    artifact_lockfile:
+      enabled: true
+      resources:
+        - url: https://github.com/aaif-goose/goose/archive/refs/tags/v1.45.0.tar.gz
+          filename: goose-v1.45.0.tar.gz

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -37,10 +37,6 @@ content:
         match: 'ENV PATH="/root/.cargo/bin:${PATH}"'
         replacement: "# cargo from rpm is already on PATH"
       - action: replace
-        match: 'COPY images/agent-base/goose-src/ .'
-        replacement: |-
-          RUN tar -xzf /cachi2/output/deps/generic/goose-v1.45.0.tar.gz --strip-components=1
-      - action: replace
         match: 'RUN cargo build --release -p goose-cli --bin goose \'
         # --ignore-rust-version bypasses the MSRV gate (goose declares rust-version = "1.94.1"
         # but RHEL 9.8 tops out at 1.92.0 via rust-toolset). The build will still fail if goose
@@ -93,8 +89,3 @@ konflux:
         - libxcb-devel
         - openssl-devel
         - perl
-    artifact_lockfile:
-      enabled: true
-      resources:
-        - url: https://github.com/aaif-goose/goose/archive/refs/tags/v1.45.0.tar.gz
-          filename: goose-v1.45.0.tar.gz

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -50,7 +50,9 @@ content:
         # instead of CMake, avoiding nasm on x86_64. --features list re-enables what MTA
         # needs: TLS, AWS Bedrock, telemetry/tracing — but NOT nostr/system-keyring/update
         # which are irrelevant in containers and would add unnecessary build complexity.
-        replacement: 'RUN export AWS_LC_SYS_CMAKE_BUILDER=0 && cargo build --release --no-default-features --features aws-providers,telemetry,otel,rustls-tls --ignore-rust-version -p goose-cli --bin goose \'
+        # portable-default = rustls-tls + aws-providers + telemetry + otel + tui;
+        # drops code-mode (v8/deno) and local-inference (llama.cpp).
+        replacement: 'RUN export AWS_LC_SYS_CMAKE_BUILDER=0 && cargo build --release --no-default-features --features portable-default --ignore-rust-version -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - cargo

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -14,7 +14,6 @@ content:
       branch:
         target: main
       url: git@github.com:openshift-priv/migtools-mta-agentic-controller.git
-      url_pull: https://github.com/lgarciaaco/mta-agentic-controller.git
       web: https://github.com/migtools/mta-agentic-controller
     modifications:
       - action: replace

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -41,13 +41,12 @@ content:
         # --ignore-rust-version bypasses the MSRV gate (goose declares rust-version = "1.94.1"
         # but RHEL 9.8 tops out at 1.92.0 via rust-toolset). The build will still fail if goose
         # actually uses a language feature introduced after 1.92.0, which surfaces a clear error.
-        # rm -f .cargo/config.toml removes any .cargo/config.toml from the goose source that
-        # would conflict with cachi2's offline vendor settings (cachi2 injects its own config
-        # via CARGO_HOME rather than the source tree).
+        # NOTE: do NOT rm .cargo/config.toml — cachi2 overwrites it during prefetch to set
+        # up the offline registry. Removing it would break hermetic cargo builds.
         # AWS_LC_SYS_NO_ASM=1 disables nasm/GAS assembly in the aws-lc-sys build
         # (pulled in by jsonwebtoken v11 → aws-lc-rs → aws-lc-sys unconditionally).
         # Without this, the build fails on both x86_64 (missing nasm) and aarch64.
-        replacement: 'RUN export AWS_LC_SYS_NO_ASM=1 && rm -f .cargo/config.toml && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
+        replacement: 'RUN export AWS_LC_SYS_NO_ASM=1 && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - cargo

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -44,7 +44,10 @@ content:
         # rm -f .cargo/config.toml removes any .cargo/config.toml from the goose source that
         # would conflict with cachi2's offline vendor settings (cachi2 injects its own config
         # via CARGO_HOME rather than the source tree).
-        replacement: 'RUN rm -f .cargo/config.toml && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
+        # AWS_LC_SYS_NO_ASM=1 disables nasm/GAS assembly in the aws-lc-sys build
+        # (pulled in by jsonwebtoken v11 → aws-lc-rs → aws-lc-sys unconditionally).
+        # Without this, the build fails on both x86_64 (missing nasm) and aarch64.
+        replacement: 'RUN export AWS_LC_SYS_NO_ASM=1 && rm -f .cargo/config.toml && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - cargo

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -43,10 +43,13 @@ content:
         # actually uses a language feature introduced after 1.92.0, which surfaces a clear error.
         # NOTE: do NOT rm .cargo/config.toml — cachi2 overwrites it during prefetch to set
         # up the offline registry. Removing it would break hermetic cargo builds.
-        # AWS_LC_SYS_NO_ASM=1 disables nasm/GAS assembly in the aws-lc-sys build
-        # (pulled in by jsonwebtoken v11 → aws-lc-rs → aws-lc-sys unconditionally).
-        # Without this, the build fails on both x86_64 (missing nasm) and aarch64.
-        replacement: 'RUN export AWS_LC_SYS_NO_ASM=1 && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
+        # AWS_LC_SYS_CMAKE_BUILDER=0 forces aws-lc-sys to use the cc crate builder
+        # instead of CMake. The build environment sets CMAKE=cmake3, which triggers
+        # CMake mode in aws-lc-sys 0.44.0; CMake mode requires nasm on x86_64 and
+        # panics if AWS_LC_SYS_NO_ASM=1 is set for release builds.
+        # The cc builder compiles the AWS-LC C library directly with gcc/g++ —
+        # no nasm required, works on both x86_64 and aarch64, no release restriction.
+        replacement: 'RUN export AWS_LC_SYS_CMAKE_BUILDER=0 && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - cargo

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -43,13 +43,12 @@ content:
         # actually uses a language feature introduced after 1.92.0, which surfaces a clear error.
         # NOTE: do NOT rm .cargo/config.toml — cachi2 overwrites it during prefetch to set
         # up the offline registry. Removing it would break hermetic cargo builds.
-        # AWS_LC_SYS_CMAKE_BUILDER=0 forces aws-lc-sys to use the cc crate builder
-        # instead of CMake. The build environment sets CMAKE=cmake3, which triggers
-        # CMake mode in aws-lc-sys 0.44.0; CMake mode requires nasm on x86_64 and
-        # panics if AWS_LC_SYS_NO_ASM=1 is set for release builds.
-        # The cc builder compiles the AWS-LC C library directly with gcc/g++ —
-        # no nasm required, works on both x86_64 and aarch64, no release restriction.
-        replacement: 'RUN export AWS_LC_SYS_CMAKE_BUILDER=0 && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
+        # --no-default-features drops the code-mode feature, which pulls in pctx_executor →
+        # deno_core → v8-goose. The v8-goose build script downloads V8 native binaries at
+        # compile time, which is blocked in hermetic Konflux builds. code-mode is not needed
+        # for MTA's use of goose. AWS_LC_SYS_CMAKE_BUILDER=0 uses the cc builder (gcc/g++)
+        # instead of CMake, avoiding nasm on x86_64.
+        replacement: 'RUN export AWS_LC_SYS_CMAKE_BUILDER=0 && cargo build --release --no-default-features --ignore-rust-version -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - cargo

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -63,7 +63,7 @@ enabled_repos:
 from:
   builder:
     - stream: rhel-9-golang
-    - image: scratch
+    - stream: rhel9
     - stream: rhel-9-golang
   member: base-rhel9
 name: mta/mta-agent-base-rhel9

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -47,8 +47,10 @@ content:
         # deno_core → v8-goose. The v8-goose build script downloads V8 native binaries at
         # compile time, which is blocked in hermetic Konflux builds. code-mode is not needed
         # for MTA's use of goose. AWS_LC_SYS_CMAKE_BUILDER=0 uses the cc builder (gcc/g++)
-        # instead of CMake, avoiding nasm on x86_64.
-        replacement: 'RUN export AWS_LC_SYS_CMAKE_BUILDER=0 && cargo build --release --no-default-features --ignore-rust-version -p goose-cli --bin goose \'
+        # instead of CMake, avoiding nasm on x86_64. --features list re-enables what MTA
+        # needs: TLS, AWS Bedrock, telemetry/tracing — but NOT nostr/system-keyring/update
+        # which are irrelevant in containers and would add unnecessary build complexity.
+        replacement: 'RUN export AWS_LC_SYS_CMAKE_BUILDER=0 && cargo build --release --no-default-features --features aws-providers,telemetry,otel,rustls-tls --ignore-rust-version -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - cargo


### PR DESCRIPTION
## Summary

Enable hermetic Konflux builds for `mta-agent-base` after PR #11 added goose-from-source compilation. Goose source uses the standard MTA submodule pattern (`images/agent-base/goose-src` → `aaif-goose/goose`), not vendored inline files.

## Problem

**Before:** Rebase failed (FROM count mismatch from `FROM ${GOOSE_IMAGE}`). Subsequent build issues: aws-lc-sys, v8-goose via `code-mode`, cargo offline registry.

**After:** Source repo keeps submodule + `FROM goose-dist AS goose`. ocp-build-data declares 4 parents, RHEL rust-toolset modifications, and `portable-default` cargo flags.

## Changes

- `from:`: two `rhel-9-golang`, `rhel9` (goose-dist), `base-rhel9`
- `cachito.packages.cargo`: `images/agent-base/goose-src/` (submodule content from git-clone)
- `cachito.packages.gomod`: `harness/`, `api/`
- Doozer modifications: Debian→RHEL, `AWS_LC_SYS_CMAKE_BUILDER=0`, `--no-default-features --features portable-default`
- `url_pull`: fork until [migtools/mta-agentic-controller#14](https://github.com/migtools/mta-agentic-controller/pull/14) merges

## Test plan

- [x] Build validated with compile flags: Jenkins [#16478](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Flayered-products/16478/), PLR `gcxgv`
- [ ] Re-test with submodule-based fork (main @ adc48a5)
- [ ] Remove `url_pull` after upstream merge

Related: [ART-23149](https://redhat.atlassian.net/browse/ART-23149)