### PR TITLE
mta-agent-base: fix multi-stage Containerfile parent-image declarations

### DIFF
--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -36,6 +36,13 @@ content:
         match: 'ENV PATH="/root/.cargo/bin:${PATH}"'
         replacement: "# cargo from rpm is already on PATH"
       - action: replace
+        # FROM ${GOOSE_IMAGE} is ARG-based; doozer cannot resolve ARGs statically
+        # and counts it as an external FROM, breaking the parent-image count check.
+        # Replacing it with the concrete stage name lets doozer recognise it as an
+        # internal stage reference.
+        match: 'FROM ${GOOSE_IMAGE} AS goose'
+        replacement: 'FROM goose-dist AS goose'
+      - action: replace
         match: 'RUN cargo build --release -p goose-cli --bin goose \'
         # --ignore-rust-version bypasses the MSRV gate (goose declares rust-version = "1.94.1"
         # but RHEL 9.8 tops out at 1.92.0 via rust-toolset). The build will still fail if goose
@@ -61,7 +68,8 @@ enabled_repos:
 - rhel-98-codeready-builder-rpms
 from:
   builder:
-    - stream: rhel-9-golang
+    - stream: rhel-9-golang  # goose-builder stage
+    - stream: rhel-9-golang  # builder (harness) stage
   member: base-rhel9
 name: mta/mta-agent-base-rhel9
 owners:

--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -50,7 +50,9 @@ content:
         # rm -f .cargo/config.toml removes any .cargo/config.toml from the goose source that
         # would conflict with cachi2's offline vendor settings (cachi2 injects its own config
         # via CARGO_HOME rather than the source tree).
-        replacement: 'RUN rm -f .cargo/config.toml && cargo build --release --ignore-rust-version -p goose-cli --bin goose \'
+        # --features native-tls re-enables the TLS implementation that cachi2/hermeto strips
+        # when it injects --no-default-features into the cargo build environment.
+        replacement: 'RUN rm -f .cargo/config.toml && cargo build --release --ignore-rust-version --features native-tls -p goose-cli --bin goose \'
     pkg_managers:
     - gomod
     - cargo


### PR DESCRIPTION
## Summary

Fixes the doozer rebase failure introduced when the `agent-base` Containerfile was restructured into a 5-stage multi-stage build (goose-builder → goose-dist → goose → builder → runtime) by PR #12617.

## Root cause

Doozer counts FROM directives to validate against the declared `from:` parent images. The new Containerfile has 5 FROM lines, but `from:` declared only 2 parents. Doozer reported **"expected 2 parent images, but found 5 (0 are stage references)"** because:

1. `FROM ${GOOSE_IMAGE} AS goose` — ARG-based FROM; doozer cannot resolve ARGs statically so it counted this as an external parent instead of recognising it as an internal stage reference.
2. Only 1 `rhel-9-golang` builder was declared, but there are now 2 external `golang:1.26` stages (`goose-builder` and `builder`).

## Fix

- Add a `modifications` entry to replace `FROM ${GOOSE_IMAGE} AS goose` with `FROM goose-dist AS goose` so doozer sees a concrete internal stage reference.
- Add a second `rhel-9-golang` builder in `from:` to cover both `goose-builder` and `builder`.

After the modification, doozer sees 3 external FROMs (goose-builder, builder, runtime) + 1 scratch + 1 internal, matching the declared 2 builders + 1 member.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)