### PR TITLE
ART-23309: Use default builder/base images for okd

### DIFF
--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -29,8 +29,3 @@ name: openshift/egress-router-cni-rhel9
 payload_name: egress-router-cni
 owners:
 - aos-networking-staff@redhat.com
-okd:
-  from:
-    builder:
-    - stream: rhel-9-golang
-    stream: centos_stream9

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -205,4 +205,4 @@ okd:
     source:
       dockerfile: Dockerfile.okd
   from:
-    stream: openshift-enterprise-base-rhel9
+    member: openshift-enterprise-base-rhel9

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -205,4 +205,4 @@ okd:
     source:
       dockerfile: Dockerfile.okd
   from:
-    stream: centos_stream9
+    stream: openshift-enterprise-base-rhel9

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -75,7 +75,3 @@ okd:
     branch: rhaos-5.0-rhel-9
   enabled_repos:
   - rhel-9-codeready-builder-rpms
-  from:
-    builder:
-    - stream: rhel-9-golang
-    stream: centos_stream9

--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -38,9 +38,3 @@ owners:
 - fpan@redhat.com
 - tohayash@redhat.com
 - dcbw@redhat.com
-okd:
-  from:
-    builder:
-    - stream: rhel-9-golang
-    - stream: rhel-9-golang
-    stream: centos_stream9


### PR DESCRIPTION
Use default base images - `centos 10` - instead of `centos 9`

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED