### PR TITLE
chore: fix prometheus-operator Dockerfile paths

### DIFF
--- a/images/obo-prometheus-operator-admission-webhook.yml
+++ b/images/obo-prometheus-operator-admission-webhook.yml
@@ -4,7 +4,7 @@ cachito:
       - path: .
 content:
   source:
-    dockerfile: cmd/admission-webhook/Dockerfile.art
+    dockerfile: Dockerfile.admission-webhook
     git:
       branch:
         target: release-coo-1.5

--- a/images/obo-prometheus-operator-config-reloader.yml
+++ b/images/obo-prometheus-operator-config-reloader.yml
@@ -4,7 +4,7 @@ cachito:
       - path: .
 content:
   source:
-    dockerfile: cmd/prometheus-config-reloader/Dockerfile.art
+    dockerfile: Dockerfile.prometheus-config-reloader
     git:
       branch:
         target: release-coo-1.5

--- a/images/obo-prometheus-operator.yml
+++ b/images/obo-prometheus-operator.yml
@@ -4,7 +4,7 @@ cachito:
       - path: .
 content:
   source:
-    dockerfile: Dockerfile.art
+    dockerfile: Dockerfile.operator
     git:
       branch:
         target: release-coo-1.5


### PR DESCRIPTION
prometheus operator does not follow the standard Dockerfile naming patters, since one repo supplies 3 Dockerfiles.