### PR TITLE
Pin public CSI operator builds for EC.0

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -61,6 +61,21 @@ releases:
       members:
         rpms: []
         images:
+          - distgit_key: ose-aws-efs-csi-driver-operator
+            why: Use the public operator build referenced by the EC.0 bundle metadata instead of the embargoed latest build.
+            metadata:
+              is:
+                nvr: ose-aws-efs-csi-driver-operator-container-v4.23.0-202608180204.p2.g9ce1841.assembly.stream.el9
+          - distgit_key: ose-secrets-store-csi-driver-operator
+            why: Use the public operator build referenced by the EC.0 bundle metadata instead of the embargoed latest build.
+            metadata:
+              is:
+                nvr: ose-secrets-store-csi-driver-operator-container-v4.23.0-202608180204.p2.g4f4745c.assembly.stream.el9
+          - distgit_key: ose-smb-csi-driver-operator
+            why: Use the public operator build referenced by the EC.0 bundle metadata instead of the embargoed latest build.
+            metadata:
+              is:
+                nvr: ose-smb-csi-driver-operator-container-v4.23.0-202608180204.p2.g9ce1841.assembly.stream.el9
           - distgit_key: ose-openstack-cinder-csi-driver-operator
             why: Query from assembly basis event failed to replicate referenced nightly content exactly. Pinning to replicate.
             metadata:


### PR DESCRIPTION
The EC.0 prepare-release job fails because the latest CSI operator builds are Konflux p3 (embargoed). Bundle rebase safely substitutes the public p2 builds, but verify_attached_operators rejects the mismatch.

Pin AWS EFS, Secrets Store CSI, and SMB CSI operators to the public p2 NVRs used by the bundles. This avoids shipping embargoed p3 content and keeps bundle operands consistent.

Validation: forced public bundle rebuild is running in Jenkins job #33842.