### PR TITLE
Pin EC.0 ose-tools operand build

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -61,6 +61,11 @@ releases:
       members:
         rpms: []
         images:
+          - distgit_key: ose-tools
+            why: Pin the public tools build referenced by the EC.0 AWS EFS CSI operator bundle.
+            metadata:
+              is:
+                nvr: ose-tools-container-v4.23.0-202608180204.p2.g4b0a124.assembly.stream.el9
           - distgit_key: ose-aws-efs-csi-driver-operator
             why: Use the public operator build referenced by the EC.0 bundle metadata instead of the embargoed latest build.
             metadata:


### PR DESCRIPTION
The AWS EFS CSI operator bundle for EC.0 embeds the public ose-tools build `ose-tools-container-v4.23.0-202608180204.p2.g4b0a124.assembly.stream.el9`, while release discovery selects the later `202608200941` build. This causes prepare-release-konflux Verify_attached_operators to reject the bundle. Pin the embedded public operand build in EC.0 so the bundle and release contents are consistent.

Validated by prepare-release-konflux #1240: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release-konflux/1240/