### PR TITLE
ART-23336: build OKD haproxy28/haproxy32 from source for CentOS Stream 10

### DIFF
--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -41,9 +41,9 @@ okd:
                 yum install -y --setopt=install_weak_deps=0 $INSTALL_PKGS && \
                 rpm -V $INSTALL_PKGS && \
                 yum clean all && \
-                mkdir -p /var/lib/haproxy/router/{certs,cacerts,allowlists} && \
-                mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log,mtls} && \
-                touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+                mkdir -p /var/lib/haproxy/router/{{certs,cacerts,allowlists}} && \
+                mkdir -p /var/lib/haproxy/{{conf/.tmp,run,bin,log,mtls}} && \
+                touch /var/lib/haproxy/conf/{{{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}}.map,haproxy.config}} && \
                 setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
                 chown -R :0 /var/lib/haproxy && \
                 chmod -R g+w /var/lib/haproxy && \
@@ -52,16 +52,16 @@ okd:
             RUN HAPROXY_VERSION=3.2.6 && \
                 BUILD_PKGS="gcc make pcre2-devel openssl-devel systemd-devel" && \
                 yum install -y --setopt=install_weak_deps=0 socat rsyslog procps-ng util-linux $BUILD_PKGS && \
-                curl -fsSL "https://www.haproxy.org/download/${HAPROXY_VERSION%.*}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o /tmp/haproxy.tar.gz && \
+                curl -fsSL "https://www.haproxy.org/download/${{HAPROXY_VERSION%.*}}/src/haproxy-${{HAPROXY_VERSION}}.tar.gz" -o /tmp/haproxy.tar.gz && \
                 mkdir -p /usr/src/haproxy && tar -xzf /tmp/haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 && \
                 make -C /usr/src/haproxy -j"$(nproc)" TARGET=linux-glibc USE_OPENSSL=1 USE_PCRE2=1 USE_SYSTEMD=1 && \
                 make -C /usr/src/haproxy install-bin PREFIX=/usr && \
                 rm -rf /usr/src/haproxy /tmp/haproxy.tar.gz && \
                 yum remove -y $BUILD_PKGS && \
                 yum clean all; \
-                mkdir -p /var/lib/haproxy/router/{certs,cacerts,allowlists} && \
-                mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log,mtls} && \
-                touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+                mkdir -p /var/lib/haproxy/router/{{certs,cacerts,allowlists}} && \
+                mkdir -p /var/lib/haproxy/{{conf/.tmp,run,bin,log,mtls}} && \
+                touch /var/lib/haproxy/conf/{{{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}}.map,haproxy.config}} && \
                 setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
                 chown -R :0 /var/lib/haproxy && \
                 chmod -R g+w /var/lib/haproxy && \

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -35,4 +35,4 @@ okd:
   distgit:
     branch: rhaos-5.0-rhel-9
   enabled_repos:
-  - rhel-9-server-ose-rpms
+  - rhel-10-server-ose-rpms

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -32,39 +32,7 @@ payload_name: haproxy-router
 owners:
 - aos-network-edge@redhat.com
 okd:
-  content:
-    source:
-      modifications:
-        - action: replace
-          match: |
-            RUN INSTALL_PKGS="socat haproxy32 rsyslog procps-ng util-linux" && \
-                yum install -y --setopt=install_weak_deps=0 $INSTALL_PKGS && \
-                rpm -V $INSTALL_PKGS && \
-                yum clean all && \
-                mkdir -p /var/lib/haproxy/router/{{certs,cacerts,allowlists}} && \
-                mkdir -p /var/lib/haproxy/{{conf/.tmp,run,bin,log,mtls}} && \
-                touch /var/lib/haproxy/conf/{{{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}}.map,haproxy.config}} && \
-                setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
-                chown -R :0 /var/lib/haproxy && \
-                chmod -R g+w /var/lib/haproxy && \
-                sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
-          replacement: |
-            RUN HAPROXY_VERSION=3.2.6 && \
-                BUILD_PKGS="gcc make pcre2-devel openssl-devel systemd-devel" && \
-                yum install -y --setopt=install_weak_deps=0 socat rsyslog procps-ng util-linux $BUILD_PKGS && \
-                curl -fsSL "https://www.haproxy.org/download/${{HAPROXY_VERSION%.*}}/src/haproxy-${{HAPROXY_VERSION}}.tar.gz" -o /tmp/haproxy.tar.gz && \
-                mkdir -p /usr/src/haproxy && tar -xzf /tmp/haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 && \
-                make -C /usr/src/haproxy -j"$(nproc)" TARGET=linux-glibc USE_OPENSSL=1 USE_PCRE2=1 USE_SYSTEMD=1 && \
-                make -C /usr/src/haproxy install-bin PREFIX=/usr && \
-                rm -rf /usr/src/haproxy /tmp/haproxy.tar.gz && \
-                yum remove -y $BUILD_PKGS && \
-                yum clean all; \
-                mkdir -p /var/lib/haproxy/router/{{certs,cacerts,allowlists}} && \
-                mkdir -p /var/lib/haproxy/{{conf/.tmp,run,bin,log,mtls}} && \
-                touch /var/lib/haproxy/conf/{{{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}}.map,haproxy.config}} && \
-                setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
-                chown -R :0 /var/lib/haproxy && \
-                chmod -R g+w /var/lib/haproxy && \
-                sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
   distgit:
     branch: rhaos-5.0-rhel-9
+  enabled_repos:
+  - rhel-9-server-ose-rpms

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -68,5 +68,3 @@ okd:
                 sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
   distgit:
     branch: rhaos-5.0-rhel-9
-  enabled_repos:
-  - rhel-10-server-ose-rpms

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -32,6 +32,40 @@ payload_name: haproxy-router
 owners:
 - aos-network-edge@redhat.com
 okd:
+  content:
+    source:
+      modifications:
+        - action: replace
+          match: |
+            RUN INSTALL_PKGS="socat haproxy32 rsyslog procps-ng util-linux" && \
+                yum install -y --setopt=install_weak_deps=0 $INSTALL_PKGS && \
+                rpm -V $INSTALL_PKGS && \
+                yum clean all && \
+                mkdir -p /var/lib/haproxy/router/{certs,cacerts,allowlists} && \
+                mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log,mtls} && \
+                touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+                setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+                chown -R :0 /var/lib/haproxy && \
+                chmod -R g+w /var/lib/haproxy && \
+                sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
+          replacement: |
+            RUN HAPROXY_VERSION=3.2.6 && \
+                BUILD_PKGS="gcc make pcre2-devel openssl-devel systemd-devel" && \
+                yum install -y --setopt=install_weak_deps=0 socat rsyslog procps-ng util-linux $BUILD_PKGS && \
+                curl -fsSL "https://www.haproxy.org/download/${HAPROXY_VERSION%.*}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o /tmp/haproxy.tar.gz && \
+                mkdir -p /usr/src/haproxy && tar -xzf /tmp/haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 && \
+                make -C /usr/src/haproxy -j"$(nproc)" TARGET=linux-glibc USE_OPENSSL=1 USE_PCRE2=1 USE_SYSTEMD=1 && \
+                make -C /usr/src/haproxy install-bin PREFIX=/usr && \
+                rm -rf /usr/src/haproxy /tmp/haproxy.tar.gz && \
+                yum remove -y $BUILD_PKGS && \
+                yum clean all; \
+                mkdir -p /var/lib/haproxy/router/{certs,cacerts,allowlists} && \
+                mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log,mtls} && \
+                touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+                setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+                chown -R :0 /var/lib/haproxy && \
+                chmod -R g+w /var/lib/haproxy && \
+                sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
   distgit:
     branch: rhaos-5.0-rhel-9
   enabled_repos:

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -31,7 +31,3 @@ owners:
 okd:
   distgit:
     branch: rhaos-5.0-rhel-9
-  from:
-    builder:
-    - stream: rhel-9-golang
-    stream: centos_stream9

--- a/images/ose-haproxy-router-haproxy28.yml
+++ b/images/ose-haproxy-router-haproxy28.yml
@@ -25,6 +25,30 @@ payload_name: haproxy-router-haproxy28
 owners:
 - aos-network-edge-staff@redhat.com
 okd:
+  content:
+    source:
+      modifications:
+        - action: replace
+          match: |
+            RUN INSTALL_PKGS="socat haproxy28" && \
+                yum install -y --setopt=install_weak_deps=0 $INSTALL_PKGS && \
+                rpm -V $INSTALL_PKGS && \
+                yum clean all && \
+                setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+                sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
+          replacement: |
+            RUN HAPROXY_VERSION=2.8.15 && \
+                BUILD_PKGS="gcc make pcre2-devel openssl-devel systemd-devel" && \
+                yum install -y --setopt=install_weak_deps=0 socat $BUILD_PKGS && \
+                curl -fsSL "https://www.haproxy.org/download/${HAPROXY_VERSION%.*}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o /tmp/haproxy.tar.gz && \
+                mkdir -p /usr/src/haproxy && tar -xzf /tmp/haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 && \
+                make -C /usr/src/haproxy -j"$(nproc)" TARGET=linux-glibc USE_OPENSSL=1 USE_PCRE2=1 USE_SYSTEMD=1 && \
+                make -C /usr/src/haproxy install-bin PREFIX=/usr && \
+                rm -rf /usr/src/haproxy /tmp/haproxy.tar.gz && \
+                yum remove -y $BUILD_PKGS && \
+                yum clean all; \
+                setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+                sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
   distgit:
     branch: rhaos-5.0-rhel-9
   enabled_repos:

--- a/images/ose-haproxy-router-haproxy28.yml
+++ b/images/ose-haproxy-router-haproxy28.yml
@@ -40,7 +40,7 @@ okd:
             RUN HAPROXY_VERSION=2.8.15 && \
                 BUILD_PKGS="gcc make pcre2-devel openssl-devel systemd-devel" && \
                 yum install -y --setopt=install_weak_deps=0 socat $BUILD_PKGS && \
-                curl -fsSL "https://www.haproxy.org/download/${HAPROXY_VERSION%.*}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o /tmp/haproxy.tar.gz && \
+                curl -fsSL "https://www.haproxy.org/download/${{HAPROXY_VERSION%.*}}/src/haproxy-${{HAPROXY_VERSION}}.tar.gz" -o /tmp/haproxy.tar.gz && \
                 mkdir -p /usr/src/haproxy && tar -xzf /tmp/haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 && \
                 make -C /usr/src/haproxy -j"$(nproc)" TARGET=linux-glibc USE_OPENSSL=1 USE_PCRE2=1 USE_SYSTEMD=1 && \
                 make -C /usr/src/haproxy install-bin PREFIX=/usr && \

--- a/images/ose-haproxy-router-haproxy28.yml
+++ b/images/ose-haproxy-router-haproxy28.yml
@@ -27,7 +27,5 @@ owners:
 okd:
   distgit:
     branch: rhaos-5.0-rhel-9
-  from:
-    stream: centos_stream9
   enabled_repos:
-  - rhel-9-server-ose-rpms
+  - rhel-10-server-ose-rpms

--- a/images/ose-haproxy-router-haproxy28.yml
+++ b/images/ose-haproxy-router-haproxy28.yml
@@ -51,5 +51,3 @@ okd:
                 sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
   distgit:
     branch: rhaos-5.0-rhel-9
-  enabled_repos:
-  - rhel-10-server-ose-rpms

--- a/images/ose-haproxy-router-haproxy32.yml
+++ b/images/ose-haproxy-router-haproxy32.yml
@@ -31,7 +31,5 @@ konflux:
 okd:
   distgit:
     branch: rhaos-5.0-rhel-9
-  from:
-    stream: centos_stream9
   enabled_repos:
-  - rhel-9-server-ose-rpms
+  - rhel-10-server-ose-rpms

--- a/images/ose-haproxy-router-haproxy32.yml
+++ b/images/ose-haproxy-router-haproxy32.yml
@@ -44,7 +44,7 @@ okd:
             RUN HAPROXY_VERSION=3.2.6 && \
                 BUILD_PKGS="gcc make pcre2-devel openssl-devel systemd-devel" && \
                 yum install -y --setopt=install_weak_deps=0 socat $BUILD_PKGS && \
-                curl -fsSL "https://www.haproxy.org/download/${HAPROXY_VERSION%.*}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o /tmp/haproxy.tar.gz && \
+                curl -fsSL "https://www.haproxy.org/download/${{HAPROXY_VERSION%.*}}/src/haproxy-${{HAPROXY_VERSION}}.tar.gz" -o /tmp/haproxy.tar.gz && \
                 mkdir -p /usr/src/haproxy && tar -xzf /tmp/haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 && \
                 make -C /usr/src/haproxy -j"$(nproc)" TARGET=linux-glibc USE_OPENSSL=1 USE_PCRE2=1 USE_SYSTEMD=1 && \
                 make -C /usr/src/haproxy install-bin PREFIX=/usr && \

--- a/images/ose-haproxy-router-haproxy32.yml
+++ b/images/ose-haproxy-router-haproxy32.yml
@@ -55,5 +55,3 @@ okd:
                 sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
   distgit:
     branch: rhaos-5.0-rhel-9
-  enabled_repos:
-  - rhel-10-server-ose-rpms

--- a/images/ose-haproxy-router-haproxy32.yml
+++ b/images/ose-haproxy-router-haproxy32.yml
@@ -29,6 +29,30 @@ konflux:
     lockfile:
       backend: rpm-lockfile-prototype
 okd:
+  content:
+    source:
+      modifications:
+        - action: replace
+          match: |
+            RUN INSTALL_PKGS="socat haproxy32" && \
+                yum install -y --setopt=install_weak_deps=0 $INSTALL_PKGS && \
+                rpm -V $INSTALL_PKGS && \
+                yum clean all && \
+                setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+                sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
+          replacement: |
+            RUN HAPROXY_VERSION=3.2.6 && \
+                BUILD_PKGS="gcc make pcre2-devel openssl-devel systemd-devel" && \
+                yum install -y --setopt=install_weak_deps=0 socat $BUILD_PKGS && \
+                curl -fsSL "https://www.haproxy.org/download/${HAPROXY_VERSION%.*}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o /tmp/haproxy.tar.gz && \
+                mkdir -p /usr/src/haproxy && tar -xzf /tmp/haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 && \
+                make -C /usr/src/haproxy -j"$(nproc)" TARGET=linux-glibc USE_OPENSSL=1 USE_PCRE2=1 USE_SYSTEMD=1 && \
+                make -C /usr/src/haproxy install-bin PREFIX=/usr && \
+                rm -rf /usr/src/haproxy /tmp/haproxy.tar.gz && \
+                yum remove -y $BUILD_PKGS && \
+                yum clean all; \
+                setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+                sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/crypto-policies/back-ends/opensslcnf.config
   distgit:
     branch: rhaos-5.0-rhel-9
   enabled_repos:


### PR DESCRIPTION
## Summary
- OKD 5.0 images build against CentOS Stream 10 (`okd.branch: rhaos-{MAJOR}.{MINOR}-rhel-10` in group.yml), but the `haproxy28`/`haproxy32` RPM packages are only available in the RHEL 9 embargoed repo and aren't packaged for CentOS Stream 10.
- Remove the `okd.from` override on `images/ose-haproxy-router-base.yml` that pinned OKD's base/builder images to `centos_stream9`/`rhel-9-golang`, so it now uses the group's default CentOS Stream 10 base and builder images.
- Add `okd.content.source.modifications` to `images/ose-haproxy-router-haproxy28.yml` and `images/ose-haproxy-router-haproxy32.yml` to compile HAProxy from source instead of installing it via RPM.
- Drop the no-longer-needed `enabled_repos` override for OKD.

Jira: [ART-23336](https://redhat.atlassian.net/browse/ART-23336)

🤖 Generated with [Claude Code](https://claude.com/claude-code)