### PR TITLE
ART-23149: mta-agent-base doozer FROM stage-ref fix

### DIFF
--- a/images/mta-agent-base.yml
+++ b/images/mta-agent-base.yml
@@ -17,6 +17,11 @@ content:
       web: https://github.com/migtools/mta-agentic-controller
     modifications:
       - action: replace
+        match: 'FROM ${GOOSE_IMAGE} AS goose'
+        # Doozer rebaser counts ${GOOSE_IMAGE} as an external parent (not a stage ref),
+        # causing "expected 4 parent images, but found 5". ARG default is goose-dist.
+        replacement: 'FROM goose-dist AS goose'
+      - action: replace
         match: "RUN go mod download"
         replacement: "# go mod download removed - deps pre-fetched by cachi2"
       - action: replace


### PR DESCRIPTION
## Summary
- Add ocp-build-data modification to replace `FROM ${GOOSE_IMAGE} AS goose` with `FROM goose-dist AS goose` at rebase time
- Fixes mass rebuild #16646 rebase failure: doozer counted 5 external parents (ARG expansion is not a stage reference)

## Test plan
- [ ] Jenkins layered-products with `IMAGE_LIST=mta-agent-base` on fork branch
- [ ] Rebase succeeds; PLR completes prefetch + build