### PR TITLE
ART-21345: Configure installer OVE UI build-time integration test

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -14,6 +14,8 @@ arches:
 konflux:
   arches:
   - x86_64
+  integration_test_scenarios:
+  - abi-qe-prow-compact
   network_mode: open
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   privileged_nested: true


### PR DESCRIPTION
## Summary
- configure abi-qe-prow-compact as a build-time integration test scenario for installer-ove-ui-4.22
- keep the scenario definition and resolver configuration managed in Konflux

## Validation
- confirmed the scenario exists in art-installer-agent-tenant
- confirmed it belongs to application installer-ove-ui-4-22

## Dependency
Requires openshift-eng/art-tools#3112 to consume konflux.integration_test_scenarios and gate builds on the configured result.