### PR TITLE
ART-21345: Configure custom integration test Snapshot

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -16,6 +16,8 @@ konflux:
   - x86_64
   integration_test_scenarios:
   - abi-qe-prow-compact
+  integration_test_snapshot_annotations:
+    pac.test.appstudio.openshift.io/branch: release-4.22
   network_mode: open
   image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-agent-installer-iso
   privileged_nested: true


### PR DESCRIPTION
## Summary

Configure the ART-created Snapshot used by the build-time custom integration test with the target PaC branch:

- `pac.test.appstudio.openshift.io/branch: release-4.22`

The IntegrationTestScenario itself was configured by #12786.

## Dependency and rollout

- Depends on openshift-eng/art-tools#3112.
- Change `abi-qe-prow-compact` to the `disabled` context before the updated art-tools version becomes active; ART-tools will explicitly trigger it.

## Testing

- Parsed `group.yml` successfully.
- The matching art-tools schema and orchestration tests pass.