### PR TITLE
[openshift-4.20] NO-JIRA: Add 1.25 golang extra builders

### DIFF
--- a/images/ci-openshift-golang-builder-extra.rhel8.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel8.yml
@@ -1,0 +1,64 @@
+content:
+  # set_build_variables to false, as setting git commit env vars break certain
+  # workloads. Set env vars in the Dockerfile, and use modifications if they
+  # should be variable
+  set_build_variables: false
+  source:
+    dockerfile: ci_images/rhel-8/ci-openshift-golang-builder/Dockerfile
+    git:
+      branch:
+        target: openshift-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: true
+      mirror_manifest_list: true
+      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+      upstream_image_mirror:
+      - registry.ci.openshift.org/ocp-priv/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+    modifications:
+    - action: replace
+      match: "ENV CI_RPM_SVC=base-MAJOR-MINOR-rhelX.ocp.svc"
+      replacement: "ENV CI_RPM_SVC=base-{MAJOR}-{MINOR}-rhel8.ocp.svc"
+
+from:
+  stream: rhel-8-golang-{GO_EXTRA}
+labels:
+  io.k8s.description: golang {GO_EXTRA} builder image for Red Hat CI
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+  component: ci-openshift-golang-builder-extra-container
+  name: ci-openshift-golang-builder-extra
+
+# Repos enabled in the builder image will be ultimately be injected as repos
+# in the builder image. This means that engineers who download the image and
+# run it connected to the VPN will be able to access the content. This is
+# desirable since it allows Dockerfile builds requiring RPMs to work as long
+# as the host is connected to the VPN.
+enabled_repos:
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-server-ose-rpms
+- rhel-8-fast-datapath-rpms
+
+name: openshift/ci-openshift-golang-builder-extra-rhel8
+for_payload: false
+for_release: false
+owners:
+- aos-team-art@redhat.com
+maintainer:
+  component: Release
+
+# The from: stanza is exactly what we want to use. So ignore anything in
+# the Dockerfile.
+canonical_builders_from_upstream: false
+
+scan_sources:
+  exempt_rpms:
+  - '*'
+konflux:
+  network_mode: open
+okd:
+  mode: disabled

--- a/images/ci-openshift-golang-builder-extra.rhel9.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel9.yml
@@ -1,0 +1,64 @@
+content:
+  # set_build_variables to false, as setting git commit env vars break certain
+  # workloads. Set env vars in the Dockerfile, and use modifications if they
+  # should be variable
+  set_build_variables: false
+  source:
+    dockerfile: ci_images/rhel-9/ci-openshift-golang-builder/Dockerfile
+    git:
+      branch:
+        target: openshift-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/ocp-build-data.git
+      web: https://github.com/openshift-eng/ocp-build-data
+    ci_alignment:
+      streams_prs:
+        enabled: false
+      mirror: true
+      mirror_manifest_list: true
+      upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+      upstream_image_mirror:
+      - registry.ci.openshift.org/ocp-priv/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
+    modifications:
+    - action: replace
+      match: "ENV CI_RPM_SVC=base-MAJOR-MINOR-rhelX.ocp.svc"
+      replacement: "ENV CI_RPM_SVC=base-{MAJOR}-{MINOR}-rhel9.ocp.svc"
+
+from:
+  stream: rhel-9-golang-{GO_EXTRA}
+labels:
+  io.k8s.description: golang {GO_EXTRA} builder image for Red Hat CI
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
+  component: ci-openshift-golang-builder-extra-container
+
+# Repos enabled in the builder image will be ultimately be injected as repos
+# in the builder image. This means that engineers who download the image and
+# run it connected to the VPN will be able to access the content. This is
+# desirable since it allows Dockerfile builds requiring RPMs to work as long
+# as the host is connected to the VPN.
+enabled_repos:
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-codeready-builder-rpms
+- rhel-9-server-ose-rpms
+- rhel-9-fast-datapath-rpms
+
+name: openshift/ci-openshift-golang-builder-extra-rhel9
+for_payload: false
+for_release: false
+owners:
+- aos-team-art@redhat.com
+maintainer:
+  component: Release
+
+# The from: stanza is exactly what we want to use. So ignore anything in
+# the Dockerfile.
+canonical_builders_from_upstream: false
+
+scan_sources:
+  exempt_rpms:
+  - '*'
+konflux:
+  network_mode: open
+okd:
+  mode: disabled


### PR DESCRIPTION
## Summary

The `openshift-4.20` Go 1.25 streams reference extra builder images through https://github.com/openshift-eng/ocp-build-data/pull/12620 , but the corresponding image definitions were missing. This prevents the builder image `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.20` from being built and published, which is required for jobs/image build in [openshift/ibm-powervs-block-csi-driver](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ibm-powervs-block-csi-driver/146/pull-ci-openshift-ibm-powervs-block-csi-driver-release-4.20-images/2097212662449442816#1:build-log.txt%3A23) to mitigate CVEs. 

The changes are based on https://github.com/openshift-eng/ocp-build-data/pull/9661.

Note: This was an attempt to mitigate the issue using chai-bot, please let me know if there are any supporting changes that may be required in this PR. 

## Changes

- Add `images/ci-openshift-golang-builder-extra.rhel8.yml`.
- Add `images/ci-openshift-golang-builder-extra.rhel9.yml`.
- Keep the change limited to the Go 1.25 extra builder image definition.

Credits: @redhat-chai-bot 