### PR TITLE
ART-23344: pin pkg_managers to stop spurious pip prefetch

### DIFF
--- a/images/mta-agent-skills.yml
+++ b/images/mta-agent-skills.yml
@@ -2,6 +2,7 @@ base_image_release:
   force: true
 content:
   source:
+    pkg_managers: []
     dockerfile: catalog/Containerfile
     git:
       branch:

--- a/images/mta-agent-skills.yml
+++ b/images/mta-agent-skills.yml
@@ -22,9 +22,6 @@ enabled_repos:
 - rhel-98-baseos-rpms
 konflux:
   no_shell: true
-  cachi2:
-    lockfile:
-      enabled: false
 name: mta/mta-agent-skills-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-agent-skills.yml
+++ b/images/mta-agent-skills.yml
@@ -20,6 +20,11 @@ delivery:
 enabled_repos:
 - rhel-98-appstream-rpms
 - rhel-98-baseos-rpms
+konflux:
+  no_shell: true
+  cachi2:
+    lockfile:
+      enabled: false
 name: mta/mta-agent-skills-rhel9
 owners:
 - mta-devs@redhat.com

--- a/images/mta-agentic-controller.yml
+++ b/images/mta-agentic-controller.yml
@@ -5,6 +5,8 @@ cachito:
       - path: api/
 content:
   source:
+    pkg_managers:
+    - gomod
     dockerfile: Dockerfile
     git:
       branch:


### PR DESCRIPTION
## Summary
Pin `content.source.pkg_managers` on MTA agentic-controller images so Hermeto does not auto-detect pip from the shared repo-root `requirements.txt`.

## Problem
**Before:** With group cachi2 enabled and no `pkg_managers`, Doozer auto-detects `go.mod` and `requirements.txt` at repo root. Prefetch pulls pip deps including `tree-sitter-php==0.24.1`, which is wheel-only (no sdist). Hermeto fails with `No distributions found`. This breaks `mta-agent-skills` (FROM scratch, no Python) and `mta-agentic-controller` (gomod only).

**After:** `mta-agent-skills` uses `pkg_managers: []` (RPM lockfile only). `mta-agentic-controller` uses `pkg_managers: [gomod]` matching its cachito config. Pip prefetch is skipped for both.

Related: [ART-23344](https://redhat.atlassian.net/browse/ART-23344), [ART-23345](https://redhat.atlassian.net/browse/ART-23345)

## Test plan
- [ ] layered-products `IMAGE_LIST=mta-agent-skills,mta-agentic-controller` with fork DOOZER_DATA_GITREF
- [ ] prefetch-dependencies passes for both images