### PR TITLE
Upgrade golang builder to v1.26 for MTC CVE fix

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -23,7 +23,7 @@ ose-must-gather:
 rhel-8-golang:
   aliases:
     - rhel-8-golang-{GO_LATEST}
-  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.25-rhel8
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel8
 
 rhel-8-builder:
   image: registry.redhat.io/ubi8/ubi:latest


### PR DESCRIPTION
## Summary
Upgrade rhel-8-golang builder image from v1.25 to v1.26 to support mig-controller CVE fix.

## Changes
- Updated `streams.yml`: `golang-builder-v1.25-rhel8` → `golang-builder-v1.26-rhel8`

## Related
- **CVE**: [MIG-1987](https://redhat.atlassian.net/browse/MIG-1987) (CVE-2026-56858) - Go html/template XSS
- **Jira**: https://redhat.atlassian.net/browse/MIG-1987
- **mig-controller PRs**:
  - master: https://github.com/migtools/mig-controller/pull/1470
  - release-1.8: https://github.com/migtools/mig-controller/pull/1471

## Context
Rayford requested this change on the mig-controller PR thread to ensure the OpenShift/Konflux build system uses the correct Go 1.26 builder image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)