### PR TITLE
ART-22836 [openshift-4.18]: restore gotest2junit in ci-build-root

### DIFF
--- a/ci_transforms/rhel-8/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-8/ci-build-root/Dockerfile
@@ -49,6 +49,14 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 RUN GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
     GOFLAGS='' go install gotest.tools/gotestsum@v1.12.2 && \
     GOFLAGS='' go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.15 && \
+    git clone --filter=blob:none --sparse --depth=1 https://github.com/openshift/release.git /tmp/openshift-release && \
+    cd /tmp/openshift-release && \
+    git fetch --depth=1 origin cb964bf35961bc626e0839c3908ef754d8ff7caf && \
+    git checkout cb964bf35961bc626e0839c3908ef754d8ff7caf && \
+    git sparse-checkout set tools/gotest2junit && \
+    printf 'module github.com/openshift/release\n\ngo 1.21\n' > go.mod && \
+    GOFLAGS='' GOTOOLCHAIN=local go install ./tools/gotest2junit && \
+    cd / && rm -rf /tmp/openshift-release && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \
     mkdir $GOPATH/bin && \

--- a/ci_transforms/rhel-9/ci-build-root/Dockerfile
+++ b/ci_transforms/rhel-9/ci-build-root/Dockerfile
@@ -48,6 +48,14 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
 RUN GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.24.0 && \
     GOFLAGS='' go install gotest.tools/gotestsum@v1.12.2 && \
     GOFLAGS='' go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.15 && \
+    git clone --filter=blob:none --sparse --depth=1 https://github.com/openshift/release.git /tmp/openshift-release && \
+    cd /tmp/openshift-release && \
+    git fetch --depth=1 origin cb964bf35961bc626e0839c3908ef754d8ff7caf && \
+    git checkout cb964bf35961bc626e0839c3908ef754d8ff7caf && \
+    git sparse-checkout set tools/gotest2junit && \
+    printf 'module github.com/openshift/release\n\ngo 1.21\n' > go.mod && \
+    GOFLAGS='' GOTOOLCHAIN=local go install ./tools/gotest2junit && \
+    cd / && rm -rf /tmp/openshift-release && \
     mv $GOPATH/bin/* /usr/bin/ && \
     rm -rf $GOPATH/* $GOPATH/.cache && \
     mkdir $GOPATH/bin && \


### PR DESCRIPTION
## Summary
- Restore `gotest2junit` in RHEL 8/9 `ci-build-root` Dockerfiles for openshift-4.18
- Build from pinned openshift/release commit via sparse checkout (same approach as openshift-4.16)

## Test plan
- [ ] Jenkins sync-ci-images with DATA_GITREF=fix/gotest2junit-ci-build-root-4.18
- [ ] Verify `which gotest2junit` in rebuilt golang build_root images

Related: [ART-22836](https://redhat.atlassian.net/browse/ART-22836)