### PR TITLE
Add oc-mirror product team MR approvers

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -23,7 +23,7 @@ assemblies:
   enabled: true
 
 mr_approvers:
-  product team:
+  product_team:
     - dorzel
     - aguidi
 

--- a/group.yml
+++ b/group.yml
@@ -22,6 +22,11 @@ konflux:
 assemblies:
   enabled: true
 
+mr_approvers:
+  product team:
+    - dorzel
+    - aguidi
+
 public_upstreams:
 - private: "https://github.com/openshift-priv"
   public: "https://github.com/openshift"


### PR DESCRIPTION
Adds the product team MR approval group for oc-mirror-2.0.

Approvers:
- dorzel
- aguidi