### PR TITLE
Rename RH OCP 4.17 repository key

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -119,7 +119,7 @@ repos:
     reposync:
       enabled: false
 
-  rhel-9-server-ose-rpms:
+  rhocp-4.17-rhel9-rpms:
     conf:
       extra_options:
         # Required to enable RPMs with higher NVRs to show up as installable options in the presence of modules from another repo.

--- a/images/assisted-installer-controller.yaml
+++ b/images/assisted-installer-controller.yaml
@@ -22,7 +22,7 @@ dependents:
 enabled_repos:
   - rhel-9-baseos-rpms
   - rhel-9-appstream-rpms
-  - rhel-9-server-ose-rpms
+  - rhocp-4.17-rhel9-rpms
 from:
   builder:
     - stream: rhel-9-golang

--- a/images/assisted-service-9.yaml
+++ b/images/assisted-service-9.yaml
@@ -23,7 +23,7 @@ enabled_repos:
   - rhel-9-baseos-rpms
   - rhel-9-appstream-rpms
   - rhel-9-codeready-builder-rpms
-  - rhel-9-server-ose-rpms
+  - rhocp-4.17-rhel9-rpms
 from:
   builder:
     - stream: rhel-9-golang


### PR DESCRIPTION
Summary:
- Rename the repository key to rhocp-4.17-rhel9-rpms.
- Update assisted-service-9 and assisted-installer-controller references.

Validation:
- YAML parsing passed.
- Repository reference consistency check passed.
- No stale rhel-9-server-ose-rpms references remain.