### PR TITLE
OCPBUGS-48831: [rhcos] Restore ISO sync for checksum promotion

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -105,6 +105,14 @@ rhcos:
   exempt_rpms: # skip check these rpms as they will aligned with rhel base image in rhcos
   - libreswan
   allow_missing_brew_rpms: false
+  sync:
+  - aliyun
+  - aws
+  - azure
+  - gcp
+  - iso
+  - metal
+  - vmware
 
 check_external_packages:
   - name: cri-o


### PR DESCRIPTION
## Summary
- Adds `iso` to the `rhcos.sync` list in `group.yml`
- Restores ISO artifact syncing so ART downloads `.iso` files to the mirror directory and appends their checksums to `sha256sum.txt`

## Test plan
- [ ] Verify `group.yml` passes ART validation
- [ ] Confirm ISO artifacts are synced and checksums appear in `sha256sum.txt` after promotion


Made with [Cursor](https://cursor.com)