### PR TITLE
ART-23398: define Konflux RHCOS assembly

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -738,3 +738,32 @@ releases:
                   # - libgcrypt
                   # - "openssl*"
                   # - "*libc*"
+  art23398:
+    assembly:
+      type: stream
+      basis:
+        assembly: stream
+      group:
+        rhcos:
+          payload_tags!:
+            - name: rhel-coreos
+              rhcos_index_tag: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:5.0-9.8-node-image
+              rhel_build_id_index: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:5.0-9.8-node-image
+              rhel_version: "9.8"
+              meta_type: commitmeta
+              primary: true
+            - name: rhel-coreos-extensions
+              rhcos_index_tag: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:5.0-9.8-node-image-extensions
+              rhel_build_id_index: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:5.0-9.8-node-image
+              rhel_version: "9.8"
+              meta_type: meta
+            - name: rhel-coreos-10
+              rhcos_index_tag: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:5.0-10.2-node-image
+              rhel_build_id_index: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:5.0-10.2-node-image
+              rhel_version: "10.2"
+              meta_type: commitmeta
+            - name: rhel-coreos-10-extensions
+              rhcos_index_tag: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:5.0-10.2-node-image-extensions
+              rhel_build_id_index: quay.io/redhat-user-workloads/ocp-art-tenant/art-images:5.0-10.2-node-image
+              rhel_version: "10.2"
+              meta_type: meta


### PR DESCRIPTION
## What does this PR do?

Defines the `konflux-rhcos` stream assembly on openshift-5.0. It inherits the stream configuration and overrides RHCOS payload and build-ID indexes to use the Konflux art-images floating tags.

Jira: [ART-23398](https://redhat.atlassian.net/browse/ART-23398)

## Validation

- `doozer --data-path=. --group=openshift-5.0 --assembly=konflux-rhcos --build-system=konflux config:read-group rhcos --yaml`
- `git diff --check`
- Verified floating tags against the ART tooling worktree.