### PR TITLE
NO-JIRA: Configure canonical parent images for MTA 8.1

### DIFF
--- a/images/base-rhel9.yml
+++ b/images/base-rhel9.yml
@@ -1,6 +1,8 @@
 base_only: true
 content:
   source:
+    ci_alignment:
+      upstream_image: registry.redhat.io/ubi9/ubi:9.8
     git:
       branch:
         target: openshift-base-rhel9

--- a/streams.yml
+++ b/streams.yml
@@ -2,7 +2,8 @@
 rhel-9-golang:
   aliases:
     - rhel-9-golang-{GO_LATEST}
-  image: registry.redhat.io/ubi9/go-toolset:1.25
+  image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.25-rhel9
+  upstream_image: registry.redhat.io/openshift/golang-builder:golang-builder-v1.25-rhel9
 
 rhel-9-nodejs-18:
   image: registry.redhat.io/ubi9/nodejs-18:latest


### PR DESCRIPTION
## Summary

- replace the MTA 8.1 Go toolset stream with the floating OpenShift Go 1.25 builder
- use the same builder pullspec as the canonical upstream reconciliation image
- map base-rhel9 reconciliation directly to the configured UBI 9.8 parent

## Why

This prevents layered reconciliation from synthesizing the inaccessible registry.ci.openshift.org/ocp/4.12:base-rhel9 pullspec and keeps upstream Golang parents aligned with the builder used by MTA builds.

## Validation

- full validate-ocp-build-data validation passed for streams.yml and images/base-rhel9.yml
- focused doozer upstream-resolution tests passed: 5 tests
- verified both registry.redhat.io pullspecs resolve
- verified the floating builder currently reports Go 1.25.14