### PR TITLE
ART-23407, ART-23408: pin goimports@v0.49.0

### DIFF
--- a/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-8/ci-openshift-build-root/Dockerfile
@@ -50,7 +50,7 @@ RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOFLAGS='' && export GO111MODULE=on && \
     export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/cover@latest && \
-    go install golang.org/x/tools/cmd/goimports@latest && \
+    go install golang.org/x/tools/cmd/goimports@v0.49.0 && \
     go install github.com/tools/godep@latest && \
     go install golang.org/x/lint/golint@latest && \
     go install gotest.tools/gotestsum@latest && \

--- a/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
+++ b/ci_images/rhel-9/ci-openshift-build-root/Dockerfile
@@ -50,7 +50,7 @@ RUN export GOPROXY="https://ocp-artifacts.engineering.redhat.com/goproxy/" && \
     export GOFLAGS='' && export GO111MODULE=on && \
     export SSL_CERT_FILE=`test -f /tmp/tls-ca-bundle.pem && echo /tmp/tls-ca-bundle.pem || echo /tmp/Current-IT-Root-CAs.pem` && cat $SSL_CERT_FILE && \
     go install golang.org/x/tools/cmd/cover@latest && \
-    go install golang.org/x/tools/cmd/goimports@latest && \
+    go install golang.org/x/tools/cmd/goimports@v0.49.0 && \
     go install github.com/tools/godep@latest && \
     go install golang.org/x/lint/golint@latest && \
     go install gotest.tools/gotestsum@latest && \


### PR DESCRIPTION
```
go: golang.org/x/tools/cmd/goimports@latest: golang.org/x/tools@v0.50.0 requires go >= 1.26.0 (running go 1.25.14; GOTOOLCHAIN=local)"
```

https://go.googlesource.com/tools/+/refs/tags/v0.49.0/go.mod#3