### PR TITLE
bump GO_EXTRA to 1.26

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -26,7 +26,7 @@ vars:
   #               - rhel-9-golang-{GO_LATEST}
   #               image: openshift/golang-builder:v1.21.3-202401221732.el9.g00c615b
   GO_LATEST: "1.26"
-  GO_EXTRA: "1.25"
+  GO_EXTRA: "1.26"
 
 compliance:
   rpm_shim:

--- a/images/ci-openshift-build-root-extra.rhel8.yml
+++ b/images/ci-openshift-build-root-extra.rhel8.yml
@@ -1,3 +1,5 @@
+# No extra builders at this time
+mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-build-root-extra.rhel9.yml
+++ b/images/ci-openshift-build-root-extra.rhel9.yml
@@ -1,3 +1,5 @@
+# No extra builders at this time
+mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-golang-builder-extra.rhel8.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel8.yml
@@ -1,3 +1,5 @@
+# No extra builders at this time
+mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/images/ci-openshift-golang-builder-extra.rhel9.yml
+++ b/images/ci-openshift-golang-builder-extra.rhel9.yml
@@ -1,3 +1,5 @@
+# No extra builders at this time
+mode: disabled
 content:
   # set_build_variables to false, as setting git commit env vars break certain
   # workloads. Set env vars in the Dockerfile, and use modifications if they

--- a/streams.yml
+++ b/streams.yml
@@ -35,16 +35,6 @@ rhel-8-golang:
   # upstream_image informs reconciliation PRs which upstream image to use for CI when this stream is referenced.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_LATEST}-openshift-{MAJOR}.{MINOR}
 
-rhel-9-golang-1.25:
-  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.12-202608271548.p2.gedd1cdd.assembly.stream.el9
-  mirror: true
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-9-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
-
-rhel-8-golang-1.25:
-  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.11-202608271541.p2.gedd1cdd.assembly.stream.el8
-  mirror: true
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-{GO_EXTRA}-openshift-{MAJOR}.{MINOR}
-
 partner-rhel-8-golang-1.26:
   image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.26.7-202608270918.p2.gedd1cdd.assembly.stream.el8
   mirror: true
@@ -60,22 +50,6 @@ partner-rhel-9-golang-1.26:
   upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.26-openshift-{MAJOR}.{MINOR}
   upstream_image_mirror:
     - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.26-openshift-{MAJOR}.{MINOR}
-
-partner-rhel-8-golang-1.25:
-  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.11-202608271541.p2.gedd1cdd.assembly.stream.el8
-  mirror: true
-  mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-8-golang-1.25-openshift-{MAJOR}.{MINOR}
-  upstream_image_mirror:
-    - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-8-golang-1.25-openshift-{MAJOR}.{MINOR}
-
-partner-rhel-9-golang-1.25:
-  image: registry.redhat.io/openshift/golang-builder:openshift-golang-builder-container-v1.25.12-202608271548.p2.gedd1cdd.assembly.stream.el9
-  mirror: true
-  mirror_manifest_list: true
-  upstream_image: quay.io/openshift-release-dev/golang-builder--partner-share:rhel-9-golang-1.25-openshift-{MAJOR}.{MINOR}
-  upstream_image_mirror:
-    - quay.io/openshift-release-dev/golang-builder--ibm-share:rhel-9-golang-1.25-openshift-{MAJOR}.{MINOR}
 
 rhel9:
   # built on top of rhel9-8-els/rhel-minimal


### PR DESCRIPTION
```
go: golang.org/x/tools/cmd/goimports@latest: golang.org/x/tools@v0.50.0 requires go >= 1.26.0 (running go 1.25.11; GOTOOLCHAIN=local)"
```

1.25 is not used at all in 5.0