### PR TITLE
Update canonical_builders_from_upstream comment to document alternati…

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -256,6 +256,8 @@ check_golang_versions: "x.y"
 # canonical_builders_from_upstream can be overridden by every single image
 # If set to False, it will use the default art config
 # If set to True, it will honor the image's config
+# Note: If upstream uses a different RHEL version (e.g., el9 vs el10), you must add a
+# corresponding alternative_upstream config with a "when: el{version}" clause to handle the divergence
 canonical_builders_from_upstream: true
 
 # This is a toggle to allow streams prs to not yet be opened. This can be useful when golang


### PR DESCRIPTION
…ve_upstream requirement

Add documentation note that when upstream uses a different RHEL version than ART (e.g., el9 vs el10), a corresponding alternative_upstream config with a matching "when: el{version}" clause must be added to handle the divergence. This aligns with the validation enforced by doozer.

cherrypick of https://github.com/openshift-eng/ocp-build-data/pull/8826