### PR TITLE
ART-19530: [5.1] Set build repo for RHCOS images

### DIFF
--- a/images/rhcos-node-extensions-rhel10.yml
+++ b/images/rhcos-node-extensions-rhel10.yml
@@ -42,5 +42,6 @@ owners:
 canonical_builders_from_upstream: false
 konflux:
   network_mode: open
+  image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-rhcos-images
 okd:
   mode: disabled

--- a/images/rhcos-node-extensions.yml
+++ b/images/rhcos-node-extensions.yml
@@ -42,5 +42,6 @@ owners:
 canonical_builders_from_upstream: false
 konflux:
   network_mode: open
+  image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-rhcos-images
 okd:
   mode: disabled

--- a/images/rhcos-node-image-rhel10.yml
+++ b/images/rhcos-node-image-rhel10.yml
@@ -54,5 +54,6 @@ owners:
 canonical_builders_from_upstream: false
 konflux:
   network_mode: open
+  image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-rhcos-images
 okd:
   mode: disabled

--- a/images/rhcos-node-image.yml
+++ b/images/rhcos-node-image.yml
@@ -54,5 +54,6 @@ owners:
 canonical_builders_from_upstream: false
 konflux:
   network_mode: open
+  image_repo: quay.io/redhat-user-workloads/ocp-art-tenant/art-rhcos-images
 okd:
   mode: disabled


### PR DESCRIPTION
Port of #12716 to openshift-5.1.

This sets the Konflux image repository for the RHCOS node image and extensions definitions.