### PR TITLE
[5.0] networking-console-plugin: use Dockerfile for ART builds

### DIFF
--- a/images/networking-console-plugin.yml
+++ b/images/networking-console-plugin.yml
@@ -1,6 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.art
+    dockerfile: Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
The upstream Dockerfile and Dockerfile.art are now identical for this component. Point ART at the regular Dockerfile, which is already used by OKD alignment, so the build configuration no longer selects the duplicate ART-specific filename.\n\nThis is a one-line configuration change in images/networking-console-plugin.yml.